### PR TITLE
use same translation keys as tabs

### DIFF
--- a/src/translations/en/formikValues.json
+++ b/src/translations/en/formikValues.json
@@ -1,9 +1,9 @@
 {
   "entityDescription": {
-    "contributors": "Contributors",
-    "mainTitle": "Title",
-    "peerReview": "Peer review",
-    "publicationContext": "Publisher",
+    "contributors": "$t(publication:contributors.authors)",
+    "mainTitle": "$t(common:title)",
+    "peerReview": "$t(publication:references.peer_reviewed)",
+    "publicationContext": "$t(common:publisher)",
     "publicationSubtype": "Publication subtype",
     "publicationType": "Publication type"
   }

--- a/src/translations/nb/formikValues.json
+++ b/src/translations/nb/formikValues.json
@@ -1,9 +1,9 @@
 {
   "entityDescription": {
-    "contributors": "Forfattere",
-    "mainTitle": "Tittel",
-    "peerReview": "Fagfellevurdert",
-    "publicationContext": "Utgiver",
+    "contributors": "$t(publication:contributors.authors)",
+    "mainTitle": "$t(common:title)",
+    "peerReview": "$t(publication:references.peer_reviewed)",
+    "publicationContext": "$t(common:publisher)",
     "publicationSubtype": "Publikasjonssubtype",
     "publicationType": "Publikasjonstype"
   }


### PR DESCRIPTION
både publicationType og publicationSubtype heter bare `type`, så jeg oversetter de manuelt, slik at brukeren forstår (mer om) hvilken type det er