### PR TITLE
add Type field to objects in publication model temporarily

### DIFF
--- a/src/pages/publication/FilesAndLicensePanel.tsx
+++ b/src/pages/publication/FilesAndLicensePanel.tsx
@@ -95,7 +95,7 @@ const FilesAndLicensePanel: React.FC<FilesAndLicensePanelProps> = ({ goToNextTab
               <>
                 <StyledUploadedFiles>
                   <Heading>{t('files_and_license.files')}</Heading>
-                  {fileSet.map((file, index) => (
+                  {fileSet.map((file: any, index: number) => (
                     <FileCard
                       key={file.id}
                       file={file}

--- a/src/pages/publication/PublicationForm.tsx
+++ b/src/pages/publication/PublicationForm.tsx
@@ -93,6 +93,7 @@ const PublicationForm: FC<PublicationFormProps> = ({
     if (updatedPublication.error) {
       dispatch(setNotification(updatedPublication.error, NotificationVariant.Error));
     } else {
+      setInitialValues(deepmerge(emptyPublication, updatedPublication));
       dispatch(setNotification(t('feedback:success.update_publication')));
     }
   };

--- a/src/pages/publication/submission_tab/submission_files_licenses.tsx
+++ b/src/pages/publication/submission_tab/submission_files_licenses.tsx
@@ -10,7 +10,7 @@ const SubmissionFilesAndLicenses: React.FC = () => {
 
   return (
     <>
-      {values.fileSet.map((file) => (
+      {values.fileSet.map((file: any) => (
         <React.Fragment key={file.id}>
           <hr />
           <LabelContentRow label={t('files_and_license.title')}>{file.name}</LabelContentRow>

--- a/src/types/publication.types.ts
+++ b/src/types/publication.types.ts
@@ -1,5 +1,5 @@
 import { Contributor } from './contributor.types';
-import { File } from './file.types';
+// import { File } from './file.types';
 import { LanguageValues } from './language.types';
 import { Project } from './project.types';
 import { PublicationType, JournalArticleType, ReportType, DegreeType, BookType } from './publicationFieldNames';
@@ -25,6 +25,7 @@ export interface PublicationMetadata {
 }
 
 export interface Publisher {
+  type?: string; //TODO: remove this when backend has fixed Reference
   title: string;
   printIssn: string;
   onlineIssn: string;
@@ -73,7 +74,7 @@ export interface Publication {
   readonly owner: string;
   readonly status: PublicationStatus;
   entityDescription: PublicationEntityDescription;
-  fileSet: File[];
+  fileSet: any; //TODO: map fileSet correctly according to datamodel
 }
 
 interface PublicationEntityDescription {
@@ -98,13 +99,16 @@ interface PublicationEntityDescription {
   specialization: string;
   textBook: boolean;
   reference: {
+    type: string; //TODO: remove this when backend has fixed Reference
     doi: string;
     publicationInstance: {
+      type: string; //TODO: remove this when backend has fixed Reference
       volume: string;
       issue: string;
       articleNumber: string;
       peerReviewed: boolean;
       pages: {
+        type: string; //TODO: remove this when backend has fixed Reference
         begin: string;
         end: string;
       };
@@ -139,18 +143,28 @@ const emptyPublicationEntityDescription: PublicationEntityDescription = {
   specialization: '',
   textBook: false,
   reference: {
+    type: 'Reference', //TODO: remove this when backend has fixed Reference
     doi: '',
     publicationInstance: {
+      type: 'PublicationInstance', //TODO: remove this when backend has fixed Reference
       volume: '',
       issue: '',
       articleNumber: '',
       peerReviewed: false,
       pages: {
+        type: 'Pages', //TODO: remove this when backend has fixed Reference
         begin: '',
         end: '',
       },
     },
-    publicationContext: null,
+    publicationContext: {
+      type: 'PublicationContext', //TODO: remove this when backend has fixed Reference
+      title: '',
+      level: null,
+      onlineIssn: '',
+      openAccess: false,
+      printIssn: '',
+    },
   },
 };
 
@@ -174,6 +188,19 @@ export const emptyPublication: FormikPublication = {
   owner: '',
   status: PublicationStatus.DRAFT,
   entityDescription: emptyPublicationEntityDescription,
-  fileSet: [],
+  fileSet: {
+    type: 'FileSet',
+    files: [
+      {
+        type: 'File',
+        identifier: '',
+        name: '',
+        license: {
+          type: 'License',
+          identifier: '',
+        },
+      },
+    ],
+  },
   shouldCreateDoi: false,
 };

--- a/src/utils/formik-helpers.ts
+++ b/src/utils/formik-helpers.ts
@@ -1,7 +1,7 @@
 import { FormikErrors, FormikTouched, getIn } from 'formik';
 import {
   FileFieldNames,
-  SpecificFileFieldNames,
+  // SpecificFileFieldNames,
   SpecificContributorFieldNames,
   ContributorFieldNames,
 } from '../types/publicationFieldNames';
@@ -48,15 +48,16 @@ export const getAllFileFields = (fileSet: File[]) => {
   if (fileSet.length === 0) {
     fieldNames.push(FileFieldNames.FILE_SET);
   } else {
-    fileSet.forEach((file, index) => {
-      const baseFieldName = `${FileFieldNames.FILE_SET}[${index}]`;
-      fieldNames.push(`${baseFieldName}.${SpecificFileFieldNames.ADMINISTRATIVE_AGREEMENT}`);
-      if (!file.administrativeAgreement) {
-        fieldNames.push(`${baseFieldName}.${SpecificFileFieldNames.PUBLISHER_AUTHORITY}`);
-        fieldNames.push(`${baseFieldName}.${SpecificFileFieldNames.EMBARGO_DATE}`);
-        fieldNames.push(`${baseFieldName}.${SpecificFileFieldNames.LICENSE}`);
-      }
-    });
+    //TODO: fix this when files is mapped correctly to datamodel
+    // fileSet.forEach((file, index) => {
+    //   const baseFieldName = `${FileFieldNames.FILE_SET}[${index}]`;
+    //   fieldNames.push(`${baseFieldName}.${SpecificFileFieldNames.ADMINISTRATIVE_AGREEMENT}`);
+    //   if (!file.administrativeAgreement) {
+    //     fieldNames.push(`${baseFieldName}.${SpecificFileFieldNames.PUBLISHER_AUTHORITY}`);
+    //     fieldNames.push(`${baseFieldName}.${SpecificFileFieldNames.EMBARGO_DATE}`);
+    //     fieldNames.push(`${baseFieldName}.${SpecificFileFieldNames.LICENSE}`);
+    //   }
+    // });
   }
   return fieldNames;
 };


### PR DESCRIPTION
Det er egentlig kun en linje som skal legges til for å få populert formik etter PUT (i PublicationForm), men siden backend ikke er helt ferdig enda, så må vi legge på `type` for å få lov til å PUT'e. 

Filer er ikke mappet riktig, og det mangler mapping for `publicationContext` og `projects`, men tar dette i separate PRer, så det er derfor noe som er foreløpig kommentert ut