### PR TITLE
check only required field names when navigating to submission tab

### DIFF
--- a/src/pages/publication/SubmissionPanel.tsx
+++ b/src/pages/publication/SubmissionPanel.tsx
@@ -12,14 +12,13 @@ import SubmissionJournalPublication from './submission_tab/submission_journal';
 import SubmissionDescription from './submission_tab/submission_description';
 import SubmissionFilesAndLicenses from './submission_tab/submission_files_licenses';
 import SubmissionContributors from './submission_tab/submission_contributors';
-import { PublicationType, ReferenceFieldNames, DescriptionFieldNames } from '../../types/publicationFieldNames';
+import { PublicationType, requiredFieldNames } from '../../types/publicationFieldNames';
 import Heading from '../../components/Heading';
 import SubHeading from '../../components/SubHeading';
 import Card from '../../components/Card';
 import { useHistory } from 'react-router';
 import LabelContentRow from '../../components/LabelContentRow';
 import ErrorSummary from './submission_tab/ErrorSummary';
-import { getAllFileFields, getAllContributorFields } from '../../utils/formik-helpers';
 import { DOI_PREFIX } from '../../utils/constants';
 import Progress from '../../components/Progress';
 import { publishPublication } from '../../api/publicationApi';
@@ -64,13 +63,7 @@ const SubmissionPanel: FC<SubmissionPanelProps> = ({ isSaving, savePublication }
   }, [values]);
 
   useEffect(() => {
-    const fieldNames = [
-      ...Object.values(DescriptionFieldNames),
-      ...Object.values(ReferenceFieldNames),
-      ...getAllContributorFields(valuesRef.current.entityDescription.contributors),
-      ...getAllFileFields(valuesRef.current.fileSet.files),
-    ];
-    fieldNames.forEach((fieldName) => setFieldTouched(fieldName));
+    requiredFieldNames.forEach((fieldName) => setFieldTouched(fieldName));
   }, [setFieldTouched]);
 
   const onClickPublish = async () => {

--- a/src/types/publicationFieldNames.ts
+++ b/src/types/publicationFieldNames.ts
@@ -89,3 +89,11 @@ export enum SpecificContributorFieldNames {
   ROLE = 'role', // TODO
   SEQUENCE = 'sequence',
 }
+
+export const requiredFieldNames = [
+  DescriptionFieldNames.TITLE,
+  ReferenceFieldNames.PUBLICATION_CONTEXT,
+  ReferenceFieldNames.PUBLICATION_TYPE,
+  ContributorFieldNames.CONTRIBUTORS,
+  FileFieldNames.FILES,
+];


### PR DESCRIPTION
Siden denne sjekken kun avgjør om faneoverskriftene skal ha rødfarge eller ikke, så tenker jeg at det holder å sjekke på kun de feltene som er required. og ikke loope igjennom alle felt.