### PR TITLE
Update publishing to SAR with generated labels and webhook triggered…

### DIFF
--- a/buildspec_publish_sar.yml
+++ b/buildspec_publish_sar.yml
@@ -24,14 +24,22 @@ phases:
       - env
       - npm install
       - pip3 install aws-sam-cli
+      - apt install -q -y jq
+
   build:
     commands:
       - npm run build
   post_build:
     commands:
-      - sam package --template-file ./templates/sar_application_template.yml --s3-bucket $S3_BUCKET --output-template-file sampackaged.yaml
-      - sam publish --template sampackaged.yaml
-
+      - sam package --template-file ./templates/sar_application_template.yml --s3-bucket $S3_BUCKET --output-template-file sampackaged_raw.yaml
+      # Setting a timestamp for the build in labels
+      - BUILD_TIMESTAMP=$(date -Iseconds)
+      # Getting latest version tag from git
+      - APPLICATION_VERSION=$(curl -s  https://api.github.com/repos/BIBSYSDEV/$GIT_REPO/releases/latest | jq -r '.tag_name')
+      # Updating metadata.labels in template
+      - envsubst '${CODEBUILD_RESOLVED_SOURCE_VERSION},${GIT_REPO},${BUILD_TIMESTAMP}' < sampackaged_raw.yaml > sampackaged.yaml
+      # publishing to SAR
+      - sam publish  --semantic-version $APPLICATION_VERSION  --template sampackaged.yaml
 artifacts:
   files:
     - '**/*'

--- a/templates/pipeline_publish_sar_template.yml
+++ b/templates/pipeline_publish_sar_template.yml
@@ -66,7 +66,7 @@ Resources:
                 OAuthToken: !Ref GitHubOAuthToken
                 Repo: !Ref GitHubRepo
                 Branch: !Ref GitHubBranch
-                PollForSourceChanges: true
+                PollForSourceChanges: false
               OutputArtifacts:
                 - Name: SourceArtifact
               RunOrder: 1
@@ -81,8 +81,9 @@ Resources:
               Configuration:
                 ProjectName: !GetAtt CodeBuildProject.Arn
                 EnvironmentVariables: !Sub
-                  - '[{"name":"S3_BUCKET","value":"${PublishArtifactStoreBucket}","type":"PLAINTEXT"}]'
+                  - '[{"name":"S3_BUCKET","value":"${PublishArtifactStoreBucket}","type":"PLAINTEXT"}, {"name":"GIT_REPO","value":"${GitRepo}","type":"PLAINTEXT"}]'
                   - PublishArtifactStoreBucket: !Ref PublishArtifactStoreBucket
+                    GitRepo: !Ref GitHubRepo
               InputArtifacts:
                 - Name: SourceArtifact
               OutputArtifacts:
@@ -208,3 +209,17 @@ Resources:
             Principal:
               Service:
                 - serverlessrepo.amazonaws.com
+
+  PublishVersionPipelineWebhook:
+    Type: AWS::CodePipeline::Webhook
+    Properties:
+      Authentication: GITHUB_HMAC
+      AuthenticationConfiguration:
+        SecretToken: !Ref GitHubOAuthToken
+      Filters:
+        - JsonPath: "$.action"
+          MatchEquals: released
+      TargetPipeline: !Ref PublishFrontendPipeline
+      TargetAction: GitHubSourceMaster
+      TargetPipelineVersion: !GetAtt PublishFrontendPipeline.Version
+      RegisterWithThirdParty: true

--- a/templates/sar_application_template.yml
+++ b/templates/sar_application_template.yml
@@ -11,9 +11,10 @@ Metadata:
     Name: NVA-Frontend
     Description: Frontend for NVA
     Author: Unit
-    SemanticVersion: 1.1.4
     SpdxLicenseId: MIT
     LicenseUrl: ../LICENSE
+    Labels: ['${CODEBUILD_RESOLVED_SOURCE_VERSION}', '${GIT_REPO}', '@${BUILD_TIMESTAMP}']
+    # SemanticVersion: is set via SAM command line
 
 Parameters:
   AmazonCognitoDomain:


### PR DESCRIPTION
… from git release.  
Template changes affect publishing to SAR only. Building and publising to SAR is now triggered from github relase command via a webhook. Labeles for SAR is genererated on the fly with info from github event, via jq and envsubst. 

Ignore warnings from validator regarding 'Found an embedded parameter "${.....}" outside of an "Fn::Sub" at Metadata/AWS::ServerlessRepo::Application/Labels/..' - this ill be replaced by envsubst during build 