### PR TITLE
NP-903 Fix bug where modal text was incomplete

### DIFF
--- a/src/pages/publication/contributors_tab/components/AffiliationsCell.tsx
+++ b/src/pages/publication/contributors_tab/components/AffiliationsCell.tsx
@@ -101,10 +101,7 @@ const AffiliationsCell: FC<AffiliationsCellProps> = ({ affiliations, baseFieldNa
       <ConfirmDialog
         open={!!affiliationToRemove}
         title={t('contributors.confirm_remove_affiliation_title')}
-        text={t('contributors.confirm_remove_affiliation_text', {
-          affiliationName: Object.values(affiliationToRemove?.labels ?? {})[0],
-          contributorName: contributorName,
-        })}
+        text={t('contributors.confirm_remove_affiliation_text')}
         onAccept={() => {
           setFieldValue(
             `${baseFieldName}.${SpecificContributorFieldNames.AFFILIATIONS}`,

--- a/src/translations/en/publication.json
+++ b/src/translations/en/publication.json
@@ -11,7 +11,7 @@
     "add_other_contributor": "Add more contributors",
     "author_already_added": "Chosen author is already added",
     "authors": "Authors",
-    "confirm_remove_affiliation_text": "Are you sure you want to remove the affiliation to {{affiliationName}} for {{contributorName}}?",
+    "confirm_remove_affiliation_text": "Are you sure you want to remove this affiliation?",
     "confirm_remove_affiliation_title": "Remove affiliation?",
     "confirm_remove_contributor_text": "Are you sure you want to remove {{contributorName}} from list of contributors?",
     "confirm_remove_contributor_title": "Remove contributor?",

--- a/src/translations/nb/publication.json
+++ b/src/translations/nb/publication.json
@@ -11,7 +11,7 @@
     "add_other_contributor": "Legg til flere",
     "author_already_added": "Valgt forfatter er allerede lagt til",
     "authors": "Forfattere",
-    "confirm_remove_affiliation_text": "Er du sikker på at du ønsker å fjerne tilknytningen til {{affiliationName}} for {{contributorName}}?",
+    "confirm_remove_affiliation_text": "Er du sikker på at du ønsker å fjerne denne tilknytningen?",
     "confirm_remove_affiliation_title": "Fjerne tilknytning?",
     "confirm_remove_contributor_text": "Er du sikker på at du ønsker å fjerne {{contributorName}} fra listen over bidragsytere?",
     "confirm_remove_contributor_title": "Fjerne bidragsyter?",


### PR DESCRIPTION
Vi har ikke labels på affiliations som kommer forhåndsutfylt basert på authority, så forekler bare meldingen heller enn å trikse til med å gjøre enda ett kall per affiliation for en filleting