### PR TITLE
Set codeowners to set default reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sarahse @elkebab @Eiriknil


### PR DESCRIPTION
https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#about-code-owners

"Code owners are automatically requested for review when someone opens a pull request(...)"