### PR TITLE
NP-1078 Show progress when logging in

### DIFF
--- a/src/layout/header/Login.tsx
+++ b/src/layout/header/Login.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
@@ -11,6 +11,7 @@ import { USE_MOCK_DATA } from '../../utils/constants';
 import { logoutSuccess } from '../../redux/actions/authActions';
 import { setUser } from '../../redux/actions/userActions';
 import { mockUser } from '../../utils/testfiles/mock_feide_user';
+import ButtonWithProgress from '../../components/ButtonWithProgress';
 
 const StyledLoginComponent = styled.div`
   grid-area: auth;
@@ -18,15 +19,28 @@ const StyledLoginComponent = styled.div`
   align-items: center;
 `;
 
+const redirectedToFeideKey = 'redirectedToFeide';
+
 const Login: FC = () => {
   const user = useSelector((state: RootStore) => state.user);
   const dispatch = useDispatch();
   const { t } = useTranslation('authorization');
 
+  // Use localStorage to track if user comes from a sign in or sign out process (FEIDE)
+  const redirectedToFeide = !!localStorage.getItem(redirectedToFeideKey);
+
+  useEffect(() => {
+    // Clear possible redirect state in localStorage on mount
+    if (redirectedToFeide) {
+      localStorage.removeItem(redirectedToFeideKey);
+    }
+  }, [redirectedToFeide]);
+
   const handleLogin = () => {
     if (USE_MOCK_DATA) {
       dispatch(setUser(mockUser));
     } else {
+      localStorage.setItem(redirectedToFeideKey, 'true');
       Auth.federatedSignIn();
     }
   };
@@ -35,6 +49,7 @@ const Login: FC = () => {
     if (USE_MOCK_DATA) {
       dispatch(logoutSuccess());
     } else {
+      localStorage.setItem(redirectedToFeideKey, 'true');
       Auth.signOut();
     }
   };
@@ -43,6 +58,8 @@ const Login: FC = () => {
     <StyledLoginComponent>
       {user ? (
         <Menu menuButtonLabel={user.name} handleLogout={handleLogout} />
+      ) : redirectedToFeide ? (
+        <ButtonWithProgress isLoading>{t('common:loading')}</ButtonWithProgress>
       ) : (
         <Button color="primary" variant="contained" onClick={handleLogin} data-testid="menu-login-button">
           {t('login')}


### PR DESCRIPTION
Når vi laster siden første gang kan vi ikke vite om brukeren er på sitt første besøk, eller om hen kommer fra feide, så legger en state for dette i localstorage, slik at vi slipper at innloggingsknappen oppe til høyre plutselig bytter fra "Logg inn" til "Mitt Navn" når man egentlig er logget inn hele tiden