### PR TITLE
Np 1613  bugfix wrong navigation

### DIFF
--- a/src/pages/publication/PublicationForm.tsx
+++ b/src/pages/publication/PublicationForm.tsx
@@ -118,12 +118,12 @@ const PublicationForm: FC<PublicationFormProps> = ({ identifier, closeForm }) =>
           initialValues={publication ? deepmerge(emptyPublication, publication) : emptyPublication}
           validate={validateForm}
           onSubmit={(values: Publication) => savePublication(values)}>
-          {({ dirty, values, isValid }: FormikProps<Publication>) => (
+          {({ dirty, values }: FormikProps<Publication>) => (
             <>
               <RouteLeavingGuard
                 modalDescription={t('modal_unsaved_changes_description')}
                 modalHeading={t('modal_unsaved_changes_heading')}
-                shouldBlockNavigation={dirty || !isValid}
+                shouldBlockNavigation={dirty}
               />
               <Form>
                 <PublicationFormTabs tabNumber={tabNumber} handleTabChange={handleTabChange} />


### PR DESCRIPTION
RouteLeavingGuard caused this bug. And it's not right that the user should be interrupted if a publication is not valid (since it is permitted to save changes with missing fields)