### PR TITLE
Np 1607 validate tabs

### DIFF
--- a/src/pages/publication/PublicationForm.tsx
+++ b/src/pages/publication/PublicationForm.tsx
@@ -96,12 +96,12 @@ const PublicationForm: FC<PublicationFormProps> = ({ identifier, closeForm }) =>
 
   const validateForm = (values: Publication) => {
     const {
-      reference: { publicationInstance, publicationContext },
+      reference: { publicationContext },
     } = values.entityDescription;
     try {
       validateYupSchema<Publication>(values, publicationValidationSchema, true, {
-        publicationInstanceType: publicationInstance.type,
         publicationContextType: publicationContext.type,
+        publicationStatus: publication?.status,
       });
     } catch (err) {
       return yupToFormErrors(err);

--- a/src/pages/publication/PublicationFormContent.tsx
+++ b/src/pages/publication/PublicationFormContent.tsx
@@ -69,7 +69,7 @@ export const PublicationFormContent: FC<PublicationFormContentProps> = ({
       )}
       {tabNumber === PublicationTab.Submission && (
         <StyledPanel>
-          <SubmissionPanel isSaving={isSaving} savePublication={savePublication} setTouchedFields={setTouchedFields} />
+          <SubmissionPanel isSaving={isSaving} savePublication={savePublication} />
         </StyledPanel>
       )}
     </>

--- a/src/pages/publication/SubmissionPanel.tsx
+++ b/src/pages/publication/SubmissionPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, FC, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { FormikProps, useFormikContext } from 'formik';
+import { FormikProps, useFormikContext, setNestedObjectValues } from 'formik';
 import { Publication, DoiRequestStatus } from '../../types/publication.types';
 import { Button, Typography } from '@material-ui/core';
 import styled from 'styled-components';
@@ -22,14 +22,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { setNotification } from '../../redux/actions/notificationActions';
 import { NotificationVariant } from '../../types/notification.types';
 import ButtonWithProgress from '../../components/ButtonWithProgress';
-import {
-  touchedFilesTabFields,
-  touchedContributorTabFields,
-  touchedDescriptionTabFields,
-  touchedReferenceTabFields,
-  mergeTouchedFields,
-} from '../../utils/formik-helpers';
-import { PanelProps } from './PublicationFormContent';
 import { RootStore } from '../../redux/reducers/rootReducer';
 import { NAVIGATE_TO_PUBLIC_PUBLICATION_DURATION } from '../../utils/constants';
 
@@ -46,34 +38,28 @@ const StyledButtonWithProgress = styled(ButtonWithProgress)`
   margin-right: 0.5rem;
 `;
 
-interface SubmissionPanelProps extends PanelProps {
+interface SubmissionPanelProps {
   isSaving: boolean;
   savePublication: (values: Publication) => void;
 }
 
-const SubmissionPanel: FC<SubmissionPanelProps> = ({ isSaving, savePublication, setTouchedFields }) => {
+const SubmissionPanel: FC<SubmissionPanelProps> = ({ isSaving, savePublication }) => {
   const user = useSelector((store: RootStore) => store.user);
   const { t } = useTranslation('publication');
-  const { values, isValid, dirty }: FormikProps<Publication> = useFormikContext();
+  const { values, isValid, dirty, errors, setTouched }: FormikProps<Publication> = useFormikContext();
   const [isPublishing, setIsPublishing] = useState(false);
   const history = useHistory();
   const dispatch = useDispatch();
   const {
     doiRequest,
-    entityDescription: { contributors, reference },
-    fileSet: { files },
+    entityDescription: { reference },
   } = values;
   const publicationContextType = reference.publicationContext.type;
 
   useEffect(() => {
-    const touchedForm = mergeTouchedFields([
-      touchedDescriptionTabFields,
-      touchedReferenceTabFields(publicationContextType),
-      touchedContributorTabFields(contributors),
-      touchedFilesTabFields(files),
-    ]);
-    setTouchedFields(touchedForm);
-  }, [setTouchedFields, contributors, files, publicationContextType]);
+    // Set all fields with error to touched to ensure tabs with error are showing error state
+    setTouched(setNestedObjectValues(errors, true));
+  }, [setTouched, errors]);
 
   const onClickPublish = async () => {
     setIsPublishing(true);

--- a/src/utils/validation/publication/fileValidation.ts
+++ b/src/utils/validation/publication/fileValidation.ts
@@ -1,5 +1,6 @@
 import * as Yup from 'yup';
 import { ErrorMessage } from '../errorMessage';
+import { PublicationStatus } from '../../../types/publication.types';
 
 export const fileValidationSchema = Yup.object().shape({
   administrativeAgreement: Yup.boolean(),
@@ -7,7 +8,16 @@ export const fileValidationSchema = Yup.object().shape({
     .nullable()
     .when('administrativeAgreement', {
       is: false,
-      then: Yup.date().nullable().min(new Date(), ErrorMessage.MUST_BE_FUTURE).typeError(ErrorMessage.INVALID_FORMAT),
+      then: Yup.date()
+        .nullable()
+        .when('$publicationStatus', {
+          is: PublicationStatus.PUBLISHED,
+          then: Yup.date().nullable().typeError(ErrorMessage.INVALID_FORMAT),
+          otherwise: Yup.date()
+            .nullable()
+            .min(new Date(), ErrorMessage.MUST_BE_FUTURE)
+            .typeError(ErrorMessage.INVALID_FORMAT),
+        }),
     }),
   publisherAuthority: Yup.boolean()
     .nullable()


### PR DESCRIPTION
Feltene ble ikke satt riktig til touched om man hadde en link som gikk direkte til Summary tab (fra DoiRequest, feks).
Oppdaterte også validering, slik at `embargoDate` ikke gir feilmelding for at den må være i fremtiden hvis publikasjonene allerede er publisert