### PR TITLE
Handle undefined messages

### DIFF
--- a/src/pages/worklist/DoiRequestAccordion.tsx
+++ b/src/pages/worklist/DoiRequestAccordion.tsx
@@ -102,7 +102,7 @@ export const DoiRequestAccordion = ({ identifier }: DoiRequestAccordionProps) =>
       </AccordionSummary>
       <AccordionDetails>
         <StyledMessages>
-          <MessageList messages={registration?.doiRequest.messages} />
+          {registration?.doiRequest.messages && <MessageList messages={registration?.doiRequest.messages} />}
           <MessageForm
             confirmAction={async (message) => {
               onClickSendMessage(message);

--- a/src/types/registration.types.ts
+++ b/src/types/registration.types.ts
@@ -74,7 +74,7 @@ interface DoiRequest {
   createdDate: string;
   modifiedDate: string;
   status: DoiRequestStatus;
-  messages: DoiRequestMessage[];
+  messages?: DoiRequestMessage[];
 }
 
 export interface RegistrationPublisher {


### PR DESCRIPTION
Fikser bug hvor man ikke kunne åpne Mine Meldinger om man har en DoiRequest uten noen meldinger.
Dukket opp  pga  /publication/{identifier} og /doi-request ikke returnerer det samme. F.eks. identifier: c2dc2e63-0331-493a-840d-6cd2e3a86baa gir dette:
/publication  -> doiRequest.messages: undefined
 /doi-request -> doiRequest.messages: []

Har nevnt dette til @axthosarouris , og at vi foretrekker `[]` i sånne tilfeller