### PR TITLE
NP-2145 Allow saving type without peer review field after setting it to true

### DIFF
--- a/src/pages/registration/ReferencesPanel.tsx
+++ b/src/pages/registration/ReferencesPanel.tsx
@@ -21,6 +21,7 @@ import SelectTypeField from './references_tab/components/SelectTypeField';
 import DegreeTypeForm from './references_tab/DegreeTypeForm';
 import JournalTypeForm from './references_tab/JournalTypeForm';
 import ReportTypeForm from './references_tab/ReportTypeForm';
+import { isJournalTypeWithPeerReview } from '../../utils/registration-helpers';
 
 const ReferencesPanel = () => {
   const { values, setTouched, setFieldValue, touched } = useFormikContext<Registration>();
@@ -58,11 +59,11 @@ const ReferencesPanel = () => {
   };
 
   const onChangeSubType = (newInstanceType: string) => {
-    setFieldValue(
-      instanceTypeBaseFieldName,
-      { ...values.entityDescription.reference.publicationInstance, type: newInstanceType },
-      false
-    );
+    const newValues = isJournalTypeWithPeerReview(newInstanceType)
+      ? { ...values.entityDescription.reference.publicationInstance, type: newInstanceType }
+      : { ...values.entityDescription.reference.publicationInstance, type: newInstanceType, peerReviewed: undefined };
+
+    setFieldValue(instanceTypeBaseFieldName, newValues, false);
   };
 
   return (

--- a/src/utils/registration-helpers.ts
+++ b/src/utils/registration-helpers.ts
@@ -1,5 +1,5 @@
 import { Registration } from '../types/registration.types';
-import { PublicationType } from '../types/publicationFieldNames';
+import { JournalType, PublicationType } from '../types/publicationFieldNames';
 import { User } from '../types/user.types';
 
 export const isJournal = (registration: Registration): boolean =>
@@ -18,3 +18,6 @@ export const userIsRegistrationOwner = (user: User | null, registration?: Regist
 
 export const userIsRegistrationCurator = (user: User | null, registration?: Registration) =>
   !!user && !!registration && user.isCurator && user.customerId === registration.publisher.id;
+
+export const isJournalTypeWithPeerReview = (type: string) =>
+  type === JournalType.ARTICLE || type === JournalType.SHORT_COMMUNICATION;


### PR DESCRIPTION
Bug hvor man ikke kunne lagre type som ikke har `peerReviewed` om den tidligere var satt til true for en annen type