### PR TITLE
NP-2227 Avoid firefox to show error if user refreshes page while a request is loading

### DIFF
--- a/src/api/apiRequest.ts
+++ b/src/api/apiRequest.ts
@@ -43,6 +43,8 @@ export const apiRequest = async <T>(axiosRequestConfig: AxiosRequestConfig): Pro
       return { error: false };
     }
   } catch (error) {
-    return Axios.isCancel(error) ? null : { error: true };
+    // eslint-disable-next-line eqeqeq
+    const requestWasCancelled = Axios.isCancel(error) || error == 'Error: Request aborted';
+    return requestWasCancelled ? null : { error: true };
   }
 };


### PR DESCRIPTION
I firefox får man error snackbar om man refresher siden mens det pågår en request. Virker veldig rart, men det er visst browserspesifikt, og ser ut til å virke helt fint i både Chrome og Edge.

Fiksen er veldig hacky også, så tror kanskje vi bare skal droppe denne