### PR TITLE
Allow copying from page header

### DIFF
--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import TextTruncate from 'react-text-truncate';
 import styled from 'styled-components';
-import { Button, Typography, TypographyProps } from '@material-ui/core';
+import { Button, Tooltip, Typography, TypographyProps } from '@material-ui/core';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
@@ -15,17 +15,15 @@ const StyledHeader = styled.div`
   word-wrap: break-word;
 `;
 
-const StyledTypography = styled(Typography)`
-  border-bottom: 3px solid;
-  padding-bottom: 0.5rem;
-  cursor: pointer;
-`;
-
 const StyledButton = styled(Button)`
   background-color: ${({ theme }) => theme.palette.section.light};
   color: ${({ theme }) => theme.palette.section.megaDark};
-  padding: 0.2rem;
-  min-width: 0;
+`;
+
+const StyledTruncatableHeading = styled.div`
+  border-bottom: 3px solid;
+  display: flex;
+  align-items: center;
 `;
 
 export interface PageHeaderProps extends TypographyProps {
@@ -37,6 +35,7 @@ export const PageHeader = ({ backPath, children, ...props }: PageHeaderProps) =>
   const { t } = useTranslation('common');
   const history = useHistory();
   const [showFullText, setShowFullText] = useState(false);
+  const [canBeTruncated, setCanBeTruncated] = useState(false);
 
   const toggleFullText = () => setShowFullText(!showFullText);
 
@@ -55,18 +54,23 @@ export const PageHeader = ({ backPath, children, ...props }: PageHeaderProps) =>
       <Button data-testid="navigate-back-button" startIcon={<ArrowBackIcon />} variant="text" onClick={onBackClick}>
         {t('back')}
       </Button>
-      <StyledTypography variant="h1" onClick={toggleFullText} {...props}>
-        <TextTruncate
-          line={showFullText ? false : 2}
-          truncateText="..."
-          text={children}
-          textTruncateChild={
+      <StyledTruncatableHeading>
+        <Typography variant="h1" {...props}>
+          <TextTruncate
+            line={showFullText ? false : 2}
+            truncateText="..."
+            text={children}
+            onTruncated={() => setCanBeTruncated(true)}
+          />
+        </Typography>
+        {canBeTruncated && (
+          <Tooltip title={showFullText ? 'Minimer tittel' : 'Vis hele tittel'}>
             <StyledButton variant="contained" onClick={toggleFullText}>
               {showFullText ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
             </StyledButton>
-          }
-        />
-      </StyledTypography>
+          </Tooltip>
+        )}
+      </StyledTruncatableHeading>
     </StyledHeader>
   );
 };


### PR DESCRIPTION
Ble litt revet med med Truncate-stuff når jeg fiksa bug for opplisting av contributors tidligere i dag, og er ganske lei av at det ikke er mulig å merke og kopiere deler av PageHeader uten at den kjører sitt eget løp med å minmere/utvide i stedet for å merke teksten. Jeg foreslår noe sånn som dette i stedet

TODO:
1. i18n og a11y for utvid/minimer-knapp
2. Sørg for at tittelen (`<TextTruncate>`) vet hvor mye plass den har på forhånd. Atm kan første render gi 3 linjer med `line={2}` siden den ikke vet at utvid-knappen kan ta noe plass
![bilde](https://user-images.githubusercontent.com/6313468/111320390-342c3d00-8667-11eb-9ea8-8b0fe0de8da9.png)
