### PR TITLE
Np 2395 description labels

### DIFF
--- a/src/pages/registration/DescriptionPanel.tsx
+++ b/src/pages/registration/DescriptionPanel.tsx
@@ -34,6 +34,7 @@ const DescriptionPanel = () => {
           {({ field, meta: { touched, error } }: FieldProps<string>) => (
             <TextField
               {...field}
+              id={field.name}
               required
               data-testid="registration-title-field"
               inputProps={{ 'data-testid': 'registration-title-input' }}
@@ -49,6 +50,7 @@ const DescriptionPanel = () => {
           {({ field }: FieldProps<string>) => (
             <TextField
               {...field}
+              id={field.name}
               data-testid="registration-abstract-field"
               inputProps={{ 'data-testid': 'registration-abstract-input' }}
               variant="filled"
@@ -63,6 +65,7 @@ const DescriptionPanel = () => {
           {({ field }: FieldProps<string>) => (
             <TextField
               {...field}
+              id={field.name}
               data-testid="registration-description-field"
               inputProps={{ 'data-testid': 'registration-description-input' }}
               label={t('description.description_of_content')}
@@ -79,6 +82,7 @@ const DescriptionPanel = () => {
           {({ field }: FieldProps) => (
             <Autocomplete
               {...field}
+              id={field.name}
               freeSolo
               multiple
               options={[]}
@@ -113,6 +117,7 @@ const DescriptionPanel = () => {
             {({ field }: FieldProps<string>) => (
               <TextField
                 {...field}
+                id={field.name}
                 data-testid="registration-language-field"
                 fullWidth
                 label={t('description.primary_language')}

--- a/src/pages/registration/DescriptionPanel.tsx
+++ b/src/pages/registration/DescriptionPanel.tsx
@@ -9,7 +9,7 @@ import lightTheme from '../../themes/lightTheme';
 import { registrationLanguages } from '../../types/language.types';
 import { DescriptionFieldNames } from '../../types/publicationFieldNames';
 import { Registration } from '../../types/registration.types';
-import DatePickerField from './description_tab/DatePickerField';
+import { DatePickerField } from './description_tab/DatePickerField';
 import { ProjectsField } from './description_tab/projects_field';
 
 const DateAndLanguageWrapper = styled.div`

--- a/src/pages/registration/description_tab/DatePickerField.tsx
+++ b/src/pages/registration/description_tab/DatePickerField.tsx
@@ -66,7 +66,14 @@ const DatePickerField = () => {
     <MuiPickersUtilsProvider utils={DateFnsUtils} locale={getDateFnsLocale(i18n.language)}>
       <MuiThemeProvider theme={lightTheme}>
         <KeyboardDatePicker
+          id="date-picker"
           {...datePickerTranslationProps}
+          DialogProps={{ 'aria-labelledby': 'date-picker-label', 'aria-label': t('description.date_published') }}
+          KeyboardButtonProps={{
+            'aria-labelledby': 'date-picker-label',
+          }}
+          leftArrowButtonProps={{ 'aria-label': t('common:previous') }}
+          rightArrowButtonProps={{ 'aria-label': t('common:next') }}
           data-testid="date-published-field"
           inputVariant="filled"
           label={t('description.date_published')}

--- a/src/pages/registration/description_tab/DatePickerField.tsx
+++ b/src/pages/registration/description_tab/DatePickerField.tsx
@@ -17,7 +17,7 @@ const StyledFormControlLabel = styled(FormControlLabel)`
   height: 100%; /* Ensure this element is as high as the DatePicker for centering */
 `;
 
-const DatePickerField = () => {
+export const DatePickerField = () => {
   const { t, i18n } = useTranslation('registration');
   const { setFieldValue, values, errors, touched, setFieldTouched } = useFormikContext<Registration>();
   const { year, month, day } = values.entityDescription.date;
@@ -97,5 +97,3 @@ const DatePickerField = () => {
     </MuiPickersUtilsProvider>
   );
 };
-
-export default DatePickerField;

--- a/src/pages/registration/description_tab/projects_field/ProjectsField.tsx
+++ b/src/pages/registration/description_tab/projects_field/ProjectsField.tsx
@@ -29,6 +29,7 @@ export const ProjectsField = () => {
       {({ field, form: { setFieldValue } }: FieldProps<ResearchProject[]>) => (
         <Autocomplete
           {...autocompleteTranslationProps}
+          id={field.name}
           options={projects}
           getOptionLabel={(option) => getProjectTitle(option)}
           onInputChange={(_, newInputValue, reason) => {


### PR DESCRIPTION
MUI trenger visst `id` for å kunne koble id til felt opp mot `id` til label.
Date-picker manglet litt mer i tillegg.

Firefox hevder Autocomplete for prosjekt og nøkkelord fortsatt mangler label, men ser riktig ut i DOMen for meg, så lar det ligge... 
![bilde](https://user-images.githubusercontent.com/6313468/111957473-58b36980-8aec-11eb-8ceb-8116322f7c13.png)
