### PR TITLE
NP-2396 Add accessible title to error icon

### DIFF
--- a/src/components/LinkTab.tsx
+++ b/src/components/LinkTab.tsx
@@ -1,7 +1,8 @@
-import React, { FC } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { Tab, TabProps } from '@material-ui/core';
 import ErrorIcon from '@material-ui/icons/Error';
+import { useTranslation } from 'react-i18next';
 
 const StyledTab = styled(Tab)`
   margin: auto;
@@ -16,8 +17,12 @@ interface LinkTabProps extends TabProps {
   error?: boolean;
 }
 
-const LinkTab: FC<LinkTabProps> = ({ error, ...rest }) => (
-  <StyledTab disableRipple icon={error ? <StyledErrorIcon data-testid="error-tab" /> : undefined} {...rest} />
-);
-
-export default LinkTab;
+export const LinkTab = ({ error, ...rest }: LinkTabProps) => {
+  const { t } = useTranslation('registration');
+  return (
+    <StyledTab
+      icon={error ? <StyledErrorIcon data-testid="error-tab" titleAccess={t('validation_errors')} /> : undefined}
+      {...rest}
+    />
+  );
+};

--- a/src/components/LinkTab.tsx
+++ b/src/components/LinkTab.tsx
@@ -4,10 +4,6 @@ import { Tab, TabProps } from '@material-ui/core';
 import ErrorIcon from '@material-ui/icons/Error';
 import { useTranslation } from 'react-i18next';
 
-const StyledTab = styled(Tab)`
-  margin: auto;
-`;
-
 const StyledErrorIcon = styled(ErrorIcon)`
   margin-left: 0.3rem;
   color: ${({ theme }) => theme.palette.error.main};
@@ -19,10 +15,12 @@ interface LinkTabProps extends TabProps {
 
 export const LinkTab = ({ error, ...rest }: LinkTabProps) => {
   const { t } = useTranslation('registration');
+
   return (
-    <StyledTab
-      icon={error ? <StyledErrorIcon data-testid="error-tab" titleAccess={t('validation_errors')} /> : undefined}
+    <Tab
       {...rest}
+      tabIndex="0" // Allow navigating to tab with both arrows and Tab
+      icon={error ? <StyledErrorIcon data-testid="error-tab" titleAccess={t('validation_errors')} /> : undefined}
     />
   );
 };

--- a/src/pages/registration/RegistrationFormTabs.tsx
+++ b/src/pages/registration/RegistrationFormTabs.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { Tabs, Typography } from '@material-ui/core';
 
-import LinkTab from '../../components/LinkTab';
 import { Registration, RegistrationTab } from '../../types/registration.types';
 import {
   mergeTouchedFields,
@@ -17,6 +16,7 @@ import {
 } from '../../utils/formik-helpers';
 import { ErrorList } from './ErrorList';
 import { RequiredDescription } from '../../components/RequiredDescription';
+import { LinkTab } from '../../components/LinkTab';
 
 const StyledTabs = styled(Tabs)`
   @media (min-width: ${({ theme }) => theme.breakpoints.values.sm + 'px'}) {

--- a/src/pages/registration/RegistrationFormTabs.tsx
+++ b/src/pages/registration/RegistrationFormTabs.tsx
@@ -21,7 +21,7 @@ import { LinkTab } from '../../components/LinkTab';
 const StyledTabs = styled(Tabs)`
   @media (min-width: ${({ theme }) => theme.breakpoints.values.sm + 'px'}) {
     .MuiTabs-flexContainer {
-      justify-content: center;
+      justify-content: space-around;
     }
   }
 `;
@@ -89,11 +89,11 @@ export const RegistrationFormTabs = ({ setTabNumber, tabNumber }: RegistrationFo
     <>
       <StyledTabs
         onChange={(_, value) => setTabNumber(value)}
-        scrollButtons="auto"
+        variant="scrollable"
+        scrollButtons="on"
         textColor="primary"
         indicatorColor="secondary"
-        value={tabNumber}
-        variant="scrollable">
+        value={tabNumber}>
         <LinkTab
           data-testid="nav-tabpanel-description"
           label={t('heading.description')}

--- a/src/pages/registration/RegistrationFormTabs.tsx
+++ b/src/pages/registration/RegistrationFormTabs.tsx
@@ -90,7 +90,7 @@ export const RegistrationFormTabs = ({ setTabNumber, tabNumber }: RegistrationFo
       <StyledTabs
         onChange={(_, value) => setTabNumber(value)}
         variant="scrollable"
-        scrollButtons="on"
+        scrollButtons="auto"
         textColor="primary"
         indicatorColor="secondary"
         value={tabNumber}>


### PR DESCRIPTION
Syns Tabs var mye bedre enn Stepper på mobil i tillegg til at det ser litt ryddigere ut generelt, så tror vi kan fortsette med Tabs litt til. 

Kode for Stepper:
```
<Stepper activeStep={tabNumber} nonLinear alternativeLabel>
        <Step>
          <StepButton title={t('heading.description')} onClick={() => setTabNumber(RegistrationTab.Description)}>
            <StepLabel error={tabErrors[RegistrationTab.Description].length > 0}>{t('heading.description')}</StepLabel>
          </StepButton>
        </Step>
        <Step>
          <StepButton title={t('heading.resource_type')} onClick={() => setTabNumber(RegistrationTab.ResourceType)}>
            <StepLabel error={tabErrors[RegistrationTab.ResourceType].length > 0}>
              {t('heading.resource_type')}
            </StepLabel>
          </StepButton>
        </Step>
        <Step>
          <StepButton title={t('heading.contributors')} onClick={() => setTabNumber(RegistrationTab.Contributors)}>
            <StepLabel error={tabErrors[RegistrationTab.Contributors].length > 0}>
              {t('heading.contributors')}
            </StepLabel>
          </StepButton>
        </Step>
        <Step>
          <StepButton
            title={t('heading.files_and_license')}
            onClick={() => setTabNumber(RegistrationTab.FilesAndLicenses)}>
            <StepLabel error={tabErrors[RegistrationTab.FilesAndLicenses].length > 0}>
              {t('heading.files_and_license')}
            </StepLabel>
          </StepButton>
        </Step>
      </Stepper>
```