### PR TITLE
NP-3120 Avoid redundant POST when user already has feide id

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -126,13 +126,13 @@ export const App = () => {
             // Add cristinId to Authority's orgunitids
             const authorityWithOrgId = await addQualifierIdForAuthority(
               authority.id,
-              AuthorityQualifiers.ORGUNIT_ID,
+              AuthorityQualifiers.OrgUnitId,
               user.cristinId
             );
             if (isErrorStatus(authorityWithOrgId.status)) {
               dispatch(
                 setNotification(
-                  t('feedback:error.update_authority', { qualifier: t(`common:${AuthorityQualifiers.ORGUNIT_ID}`) }),
+                  t('feedback:error.update_authority', { qualifier: t(`common:${AuthorityQualifiers.OrgUnitId}`) }),
                   NotificationVariant.Error
                 )
               );

--- a/src/api/authorityApi.ts
+++ b/src/api/authorityApi.ts
@@ -4,9 +4,9 @@ import { AuthorityApiPath } from './apiPaths';
 import { authenticatedApiRequest } from './apiRequest';
 
 export enum AuthorityQualifiers {
-  FEIDE_ID = 'feideid',
-  ORCID = 'orcid',
-  ORGUNIT_ID = 'orgunitid',
+  FeideId = 'feideid',
+  Orcid = 'orcid',
+  OrgUnitId = 'orgunitid',
 }
 
 export const createAuthority = async (firstName: string, lastName: string, feideId?: string, cristinId?: string) => {
@@ -18,17 +18,13 @@ export const createAuthority = async (firstName: string, lastName: string, feide
   if (isSuccessStatus(createAuthorityResponse.status)) {
     const arpId = createAuthorityResponse.data.id;
     if (feideId) {
-      const updateAuthorityResponse = await addQualifierIdForAuthority(arpId, AuthorityQualifiers.FEIDE_ID, feideId);
+      const updateAuthorityResponse = await addQualifierIdForAuthority(arpId, AuthorityQualifiers.FeideId, feideId);
       if (isSuccessStatus(createAuthorityResponse.status)) {
         createAuthorityResponse.data = updateAuthorityResponse.data;
       }
     }
     if (cristinId) {
-      const updateAuthorityResponse = await addQualifierIdForAuthority(
-        arpId,
-        AuthorityQualifiers.ORGUNIT_ID,
-        cristinId
-      );
+      const updateAuthorityResponse = await addQualifierIdForAuthority(arpId, AuthorityQualifiers.OrgUnitId, cristinId);
       if (isSuccessStatus(createAuthorityResponse.status)) {
         createAuthorityResponse.data = updateAuthorityResponse.data;
       }

--- a/src/pages/user/UserAffiliations.tsx
+++ b/src/pages/user/UserAffiliations.tsx
@@ -49,13 +49,13 @@ export const UserAffiliations = ({ user }: UserInstituionProps) => {
     setIsRemovingInstitution(true);
     const updateAuthorityResponse = await removeQualifierIdFromAuthority(
       user.authority.id,
-      AuthorityQualifiers.ORGUNIT_ID,
+      AuthorityQualifiers.OrgUnitId,
       institutionIdToRemove
     );
     if (isErrorStatus(updateAuthorityResponse.status)) {
       dispatch(
         setNotification(
-          t('feedback:error.delete_identifier', { qualifier: t(`common:${AuthorityQualifiers.ORGUNIT_ID}`) }),
+          t('feedback:error.delete_identifier', { qualifier: t(`common:${AuthorityQualifiers.OrgUnitId}`) }),
           NotificationVariant.Error
         )
       );
@@ -86,13 +86,13 @@ export const UserAffiliations = ({ user }: UserInstituionProps) => {
     if (user.authority) {
       const updateAuthorityResponse = await addQualifierIdForAuthority(
         user.authority.id,
-        AuthorityQualifiers.ORGUNIT_ID,
+        AuthorityQualifiers.OrgUnitId,
         newUnitId
       );
       if (isErrorStatus(updateAuthorityResponse.status)) {
         dispatch(
           setNotification(
-            t('feedback:error.update_authority', { qualifier: t(`common:${AuthorityQualifiers.ORGUNIT_ID}`) }),
+            t('feedback:error.update_authority', { qualifier: t(`common:${AuthorityQualifiers.OrgUnitId}`) }),
             NotificationVariant.Error
           )
         );

--- a/src/pages/user/UserOrcid.tsx
+++ b/src/pages/user/UserOrcid.tsx
@@ -80,13 +80,13 @@ export const UserOrcid = ({ user }: UserOrcidProps) => {
       } else if (user.authority && !user.authority.orcids.includes(orcidId)) {
         const updateAuthorityResponse = await addQualifierIdForAuthority(
           user.authority.id,
-          AuthorityQualifiers.ORCID,
+          AuthorityQualifiers.Orcid,
           orcidId
         );
         if (isErrorStatus(updateAuthorityResponse.status)) {
           dispatch(
             setNotification(
-              t('feedback:error.update_authority', { qualifier: t(`common:${AuthorityQualifiers.ORCID}`) }),
+              t('feedback:error.update_authority', { qualifier: t(`common:${AuthorityQualifiers.Orcid}`) }),
               NotificationVariant.Error
             )
           );
@@ -118,13 +118,13 @@ export const UserOrcid = ({ user }: UserOrcidProps) => {
     setIsRemovingOrcid(true);
     const updateAuthorityResponse = await removeQualifierIdFromAuthority(
       user.authority.id,
-      AuthorityQualifiers.ORCID,
+      AuthorityQualifiers.Orcid,
       id
     );
     if (isErrorStatus(updateAuthorityResponse.status)) {
       dispatch(
         setNotification(
-          t('feedback:error.delete_identifier', { qualifier: t(`common:${AuthorityQualifiers.ORGUNIT_ID}`) }),
+          t('feedback:error.delete_identifier', { qualifier: t(`common:${AuthorityQualifiers.Orcid}`) }),
           NotificationVariant.Error
         )
       );

--- a/src/pages/user/authority/ConnectAuthority.tsx
+++ b/src/pages/user/authority/ConnectAuthority.tsx
@@ -46,16 +46,16 @@ export const ConnectAuthority = ({ user, handleCloseModal }: ConnectAuthorityPro
     if (selectedAuthority) {
       setIsUpdatingAuthority(true);
 
-      if (!selectedAuthority?.feideids.includes(user.id)) {
+      if (!selectedAuthority.feideids.includes(user.id)) {
         const updatedAuthorityWithFeide = await addQualifierIdForAuthority(
           selectedArpId,
-          AuthorityQualifiers.FEIDE_ID,
+          AuthorityQualifiers.FeideId,
           user.id
         );
         if (isErrorStatus(updatedAuthorityWithFeide.status)) {
           dispatch(
             setNotification(
-              t('feedback:error.update_authority', { qualifier: t(`common:${AuthorityQualifiers.ORGUNIT_ID}`) }),
+              t('feedback:error.update_authority', { qualifier: t(`common:${AuthorityQualifiers.OrgUnitId}`) }),
               NotificationVariant.Error
             )
           );
@@ -67,13 +67,13 @@ export const ConnectAuthority = ({ user, handleCloseModal }: ConnectAuthorityPro
       if (user.cristinId && !selectedAuthority.orgunitids.includes(user.cristinId)) {
         const updatedAuthorityWithCristinId = await addQualifierIdForAuthority(
           selectedArpId,
-          AuthorityQualifiers.ORGUNIT_ID,
+          AuthorityQualifiers.OrgUnitId,
           user.cristinId
         );
         if (isErrorStatus(updatedAuthorityWithCristinId.status)) {
           dispatch(
             setNotification(
-              t('feedback:error.update_authority', { qualifier: t(`common:${AuthorityQualifiers.ORGUNIT_ID}`) }),
+              t('feedback:error.update_authority', { qualifier: t(`common:${AuthorityQualifiers.OrgUnitId}`) }),
               NotificationVariant.Error
             )
           );

--- a/src/pages/user/authority/ConnectAuthority.tsx
+++ b/src/pages/user/authority/ConnectAuthority.tsx
@@ -41,42 +41,48 @@ export const ConnectAuthority = ({ user, handleCloseModal }: ConnectAuthorityPro
   };
 
   const updateAuthorityForUser = async () => {
-    const selectedAuthority = user.possibleAuthorities.find((authority) => authority.id === selectedArpId);
+    let selectedAuthority = user.possibleAuthorities.find((authority) => authority.id === selectedArpId);
+    const hasFeideConnecion = !!selectedAuthority?.feideids.includes(user.id);
 
     if (selectedAuthority) {
       setIsUpdatingAuthority(true);
-      const updatedAuthorityWithFeide = await addQualifierIdForAuthority(
-        selectedArpId,
-        AuthorityQualifiers.FEIDE_ID,
-        user.id
-      );
-      if (isErrorStatus(updatedAuthorityWithFeide.status)) {
-        dispatch(
-          setNotification(
-            t('feedback:error.update_authority', { qualifier: t(`common:${AuthorityQualifiers.ORGUNIT_ID}`) }),
-            NotificationVariant.Error
-          )
+
+      if (!hasFeideConnecion) {
+        const updatedAuthorityWithFeide = await addQualifierIdForAuthority(
+          selectedArpId,
+          AuthorityQualifiers.FEIDE_ID,
+          user.id
         );
-      } else if (isSuccessStatus(updatedAuthorityWithFeide.status)) {
-        if (user.cristinId && !updatedAuthorityWithFeide.data.orgunitids.includes(user.cristinId)) {
-          const updatedAuthorityWithCristinId = await addQualifierIdForAuthority(
-            selectedArpId,
-            AuthorityQualifiers.ORGUNIT_ID,
-            user.cristinId
+        if (isErrorStatus(updatedAuthorityWithFeide.status)) {
+          dispatch(
+            setNotification(
+              t('feedback:error.update_authority', { qualifier: t(`common:${AuthorityQualifiers.ORGUNIT_ID}`) }),
+              NotificationVariant.Error
+            )
           );
-          if (isErrorStatus(updatedAuthorityWithCristinId.status)) {
-            dispatch(
-              setNotification(
-                t('feedback:error.update_authority', { qualifier: t(`common:${AuthorityQualifiers.ORGUNIT_ID}`) }),
-                NotificationVariant.Error
-              )
-            );
-          } else if (isSuccessStatus(updatedAuthorityWithCristinId.status)) {
-            dispatch(setAuthorityData(updatedAuthorityWithCristinId.data));
-          }
-        } else {
-          dispatch(setAuthorityData(updatedAuthorityWithFeide.data));
+        } else if (isSuccessStatus(updatedAuthorityWithFeide.status)) {
+          selectedAuthority = updatedAuthorityWithFeide.data;
         }
+      }
+
+      if (user.cristinId && !selectedAuthority.orgunitids.includes(user.cristinId)) {
+        const updatedAuthorityWithCristinId = await addQualifierIdForAuthority(
+          selectedArpId,
+          AuthorityQualifiers.ORGUNIT_ID,
+          user.cristinId
+        );
+        if (isErrorStatus(updatedAuthorityWithCristinId.status)) {
+          dispatch(
+            setNotification(
+              t('feedback:error.update_authority', { qualifier: t(`common:${AuthorityQualifiers.ORGUNIT_ID}`) }),
+              NotificationVariant.Error
+            )
+          );
+        } else if (isSuccessStatus(updatedAuthorityWithCristinId.status)) {
+          dispatch(setAuthorityData(updatedAuthorityWithCristinId.data));
+        }
+      } else {
+        dispatch(setAuthorityData(selectedAuthority));
       }
     }
   };

--- a/src/pages/user/authority/ConnectAuthority.tsx
+++ b/src/pages/user/authority/ConnectAuthority.tsx
@@ -42,12 +42,11 @@ export const ConnectAuthority = ({ user, handleCloseModal }: ConnectAuthorityPro
 
   const updateAuthorityForUser = async () => {
     let selectedAuthority = user.possibleAuthorities.find((authority) => authority.id === selectedArpId);
-    const hasFeideConnecion = !!selectedAuthority?.feideids.includes(user.id);
 
     if (selectedAuthority) {
       setIsUpdatingAuthority(true);
 
-      if (!hasFeideConnecion) {
+      if (!selectedAuthority?.feideids.includes(user.id)) {
         const updatedAuthorityWithFeide = await addQualifierIdForAuthority(
           selectedArpId,
           AuthorityQualifiers.FEIDE_ID,

--- a/src/pages/user/institution/InstitutionCard.tsx
+++ b/src/pages/user/institution/InstitutionCard.tsx
@@ -73,14 +73,14 @@ export const InstitutionCard = ({ orgunitId, setInstitutionIdToRemove }: Institu
 
     const updateAuthorityResponse = await updateQualifierIdForAuthority(
       user.authority.id,
-      AuthorityQualifiers.ORGUNIT_ID,
+      AuthorityQualifiers.OrgUnitId,
       initialInstitution,
       newUnitId
     );
     if (isErrorStatus(updateAuthorityResponse.status)) {
       dispatch(
         setNotification(
-          t('feedback:error.update_authority', { qualifier: t(`common:${AuthorityQualifiers.ORGUNIT_ID}`) }),
+          t('feedback:error.update_authority', { qualifier: t(`common:${AuthorityQualifiers.OrgUnitId}`) }),
           NotificationVariant.Error
         )
       );


### PR DESCRIPTION
Unngå å oppdatere FeideID hvis bruker allerede har det. Dette skjedde i tilfeller hvor bruker hadde 2 matchende brukere i ARP