### PR TITLE
Np 3466 allow parentheses in search

### DIFF
--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -21,6 +21,6 @@ describe('Search', () => {
     cy.get(`[data-testid=${dataTestId.startPage.searchField}] input`).type(searchTerm);
     cy.get(`[data-testid=${dataTestId.startPage.searchButton}]`).click();
     cy.get(`[data-testid=${dataTestId.startPage.searchPagination}]`).contains('1-10');
-    cy.url().should('include', `query=${searchTerm}`);
+    cy.url().should('include', `query=%22${searchTerm}%22`);
   });
 });

--- a/src/pages/search/SearchBar.tsx
+++ b/src/pages/search/SearchBar.tsx
@@ -25,7 +25,7 @@ export const SearchBar = () => {
             fullWidth
             variant="outlined"
             label={t('search')}
-            helperText={t('search_help')}
+            placeholder={t('search_placeholder')}
             InputProps={{
               endAdornment: (
                 <>

--- a/src/pages/search/filters/AdvancedSearchRow.tsx
+++ b/src/pages/search/filters/AdvancedSearchRow.tsx
@@ -14,6 +14,18 @@ interface AdvancedSearchRowProps {
   removeFilter: () => void;
 }
 
+export const registrationFilters = [
+  { field: DescriptionFieldNames.Title, i18nKey: 'common:title' },
+  { field: DescriptionFieldNames.Abstract, i18nKey: 'registration:description.abstract' },
+  { field: ResourceFieldNames.SubType, i18nKey: 'registration_type' },
+  { field: DescriptionFieldNames.Tags, i18nKey: 'registration:description.keywords' },
+  {
+    field: `${ContributorFieldNames.Contributors}.${SpecificContributorFieldNames.Name}`,
+    i18nKey: 'registration:contributors.contributor',
+  },
+  { field: `${DescriptionFieldNames.Date}.year`, i18nKey: 'year_published' },
+];
+
 export const AdvancedSearchRow = ({ removeFilter, baseFieldName }: AdvancedSearchRowProps) => {
   const { t } = useTranslation('search');
 
@@ -22,14 +34,11 @@ export const AdvancedSearchRow = ({ removeFilter, baseFieldName }: AdvancedSearc
       <Field name={`${baseFieldName}.fieldName`}>
         {({ field }: FieldProps<string>) => (
           <TextField {...field} select variant="outlined" label={t('field_label')}>
-            <MenuItem value={DescriptionFieldNames.Title}>{t('common:title')}</MenuItem>
-            <MenuItem value={DescriptionFieldNames.Abstract}>{t('registration:description.abstract')}</MenuItem>
-            <MenuItem value={ResourceFieldNames.SubType}>{t('registration_type')}</MenuItem>
-            <MenuItem value={DescriptionFieldNames.Tags}>{t('registration:description.keywords')}</MenuItem>
-            <MenuItem value={`${ContributorFieldNames.Contributors}.${SpecificContributorFieldNames.Name}`}>
-              {t('registration:contributors.contributor')}
-            </MenuItem>
-            <MenuItem value={`${DescriptionFieldNames.Date}.year`}>{t('year_published')}</MenuItem>
+            {registrationFilters.map((filter) => (
+              <MenuItem key={filter.i18nKey} value={filter.field}>
+                {t(filter.i18nKey)}
+              </MenuItem>
+            ))}
           </TextField>
         )}
       </Field>

--- a/src/translations/en/search.json
+++ b/src/translations/en/search.json
@@ -9,7 +9,7 @@
   "registration_type": "Registration type",
   "remove_filter": "Remove filter",
   "search": "Search",
-  "search_help": "Use quotes (\"abs\") for exact matches, or wildcard (*) to search for substrings",
+  "search_placeholder": "Search for title, contributor, abstract, etc.",
   "select_filters": "Select filters to narrow down search:",
   "search_term_label": "Value",
   "sort_by": "Order by",

--- a/src/translations/nb/search.json
+++ b/src/translations/nb/search.json
@@ -9,7 +9,7 @@
   "registration_type": "Registreringstype",
   "remove_filter": "Fjern filter",
   "search": "Søk",
-  "search_help": "Bruk anførselstegn (\"abc\") for eksakte treff, eller jokertegn (*) for å søke etter deler av ord",
+  "search_placeholder": "Søk etter tittel, bidragsyter, sammendrag, etc.",
   "select_filters": "Velg filtre for å snevre inn søket:",
   "search_term_label": "Verdi",
   "sort_by": "Sorter etter",

--- a/src/utils/searchHelpers.ts
+++ b/src/utils/searchHelpers.ts
@@ -30,7 +30,10 @@ enum Operator {
 }
 
 // Add quoatation marks if no wildcard
-const formatValue = (value: string) => {
+const formatValue = (value?: string) => {
+  if (!value) {
+    return '';
+  }
   const hasWildcard = value.includes('*');
   const hasQuotationMarks = value.startsWith('"') && value.endsWith('"');
 

--- a/src/utils/searchHelpers.ts
+++ b/src/utils/searchHelpers.ts
@@ -81,8 +81,7 @@ export const createSearchConfigFromSearchParams = (params: URLSearchParams): Sea
   }
   const searchTermIndex = filters?.findIndex(
     // Find filter that does not point to specific field
-    (filter) =>
-      filter && !registrationFilters.some((f) => filter.startsWith(f.field) || filter.startsWith(`(${f.field}`))
+    (filter) => filter && !registrationFilters.some((f) => filter.includes(`${f.field}:`))
   );
   const searchTerm = searchTermIndex >= 0 ? filters.splice(searchTermIndex, 1)[0] : '';
 

--- a/src/utils/searchHelpers.ts
+++ b/src/utils/searchHelpers.ts
@@ -1,3 +1,5 @@
+import { registrationFilters } from '../pages/search/filters/AdvancedSearchRow';
+
 export enum SearchParam {
   From = 'from',
   OrderBy = 'orderBy',
@@ -74,8 +76,11 @@ export const createSearchConfigFromSearchParams = (params: URLSearchParams): Sea
   if (!filters) {
     return { searchTerm: '', properties: [] };
   }
-
-  const searchTermIndex = filters?.findIndex((filter) => filter && !filter.startsWith('(') && !filter.endsWith(')'));
+  const searchTermIndex = filters?.findIndex(
+    // Find filter that does not point to specific field
+    (filter) =>
+      filter && !registrationFilters.some((f) => filter.startsWith(f.field) || filter.startsWith(`(${f.field}`))
+  );
   const searchTerm = searchTermIndex >= 0 ? filters.splice(searchTermIndex, 1)[0] : '';
 
   const properties: PropertySearch[] = filters.map((filter) => {


### PR DESCRIPTION
Bruk `"` for search term.
Sikre at riktig søketerm blir brukt som fritekstsøk.
Bruk placeholder i stedet for helperText.
++