### PR TITLE
NP-3525 Handle error due to new deploys

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -21,6 +21,29 @@ class ErrorBoundaryClass extends Component<ErrorBoundaryClassProps> {
     }
   }
 
+  // Force page refresh if a chunk is not found. This error is usually caused by a new
+  // version of the app being deployed, and the old chunks currently used has been invalidated.
+  componentDidCatch(error: any) {
+    const { t } = this.props;
+
+    if (/Loading chunk [\d]+ failed/.test(error)) {
+      const localstorageKey = 'appUpdateTime';
+      const lastUpdateTime = parseInt(localStorage.getItem(localstorageKey) ?? '');
+      const currentTime = Date.now();
+
+      if (!isNaN(lastUpdateTime)) {
+        const timeSinceUpdate = currentTime - lastUpdateTime;
+        if (timeSinceUpdate < 10000) {
+          return; // Skip refreshing if less than 10sec since previous refresh, to avoid infinite loop
+        }
+      }
+
+      alert(t('common:reload_page_info'));
+      localStorage.setItem(localstorageKey, currentTime.toString());
+      window.location.reload();
+    }
+  }
+
   render() {
     const { t, children } = this.props;
     const { hasError } = this.state;

--- a/src/translations/en/common.json
+++ b/src/translations/en/common.json
@@ -61,6 +61,7 @@
   "registration": "Registration",
   "registrations": "Registrations",
   "reject_doi": "Reject DOI",
+  "reload_page_info": "A new version of NVA is available and the page must be reloaded.",
   "remove": "Remove",
   "required_description": "Fields with asterisk are required",
   "requires_login": "Requires login",

--- a/src/translations/nb/common.json
+++ b/src/translations/nb/common.json
@@ -61,6 +61,7 @@
   "registration": "Registrering",
   "registrations": "Registreringer",
   "reject_doi": "Avvis DOI",
+  "reload_page_info": "En ny versjon av NVA er tilgjengelig og siden må lastes på nytt.",
   "remove": "Fjern",
   "required_description": "Felt med stjerne er obligatorisk",
   "requires_login": "Krever innlogging",


### PR DESCRIPTION
Håndter feil for brukere som har appen oppe mens det rulles ut en ny versjon. Tving brukere som får feilmelding pga lazy loading av komponeneter til å laste siden på nytt.