### PR TITLE
Np 29038 update search item border

### DIFF
--- a/src/components/PageWithSideMenu.tsx
+++ b/src/components/PageWithSideMenu.tsx
@@ -32,7 +32,7 @@ const StyledSideMenuHeader = styled(StyledPaperHeader)({
   padding: '0.5rem',
 });
 
-export const SidePanel = (props: BoxProps) => <Box component="section" sx={{ bgcolor: 'secondary.dark' }} {...props} />;
+export const SidePanel = (props: BoxProps) => <Box component="section" sx={{ bgcolor: 'secondary.main' }} {...props} />;
 
 interface SideNavHeaderProps {
   icon?: SvgIconComponent;

--- a/src/components/RegistrationList.tsx
+++ b/src/components/RegistrationList.tsx
@@ -39,8 +39,9 @@ const RegistrationListItem = ({ registration }: RegistrationListItemProps) => {
     <ListItem
       sx={{
         border: '2px solid',
+        borderColor: '#D3C9AF',
         borderLeft: '1.25rem solid',
-        borderColor: 'registration.main',
+        borderLeftColor: 'registration.main',
       }}>
       <ListItemText disableTypography data-testid={dataTestId.startPage.searchResultItem}>
         <Typography variant="overline" sx={{ color: 'primary.main' }}>

--- a/src/components/RegistrationList.tsx
+++ b/src/components/RegistrationList.tsx
@@ -39,7 +39,7 @@ const RegistrationListItem = ({ registration }: RegistrationListItemProps) => {
     <ListItem
       sx={{
         border: '2px solid',
-        borderColor: '#D3C9AF',
+        borderColor: 'secondary.dark',
         borderLeft: '1.25rem solid',
         borderLeftColor: 'registration.main',
       }}>

--- a/src/components/landing_page/LandingPageAccordion.tsx
+++ b/src/components/landing_page/LandingPageAccordion.tsx
@@ -21,7 +21,7 @@ export const LandingPageAccordion = ({ heading, children, dataTestId, ...props }
       '&.MuiAccordion-root.Mui-expanded': {
         margin: 0,
       },
-      bgcolor: 'secondary.main',
+      bgcolor: 'secondary.light',
     }}
     data-testid={dataTestId}
     {...props}>

--- a/src/components/styled/Wrappers.tsx
+++ b/src/components/styled/Wrappers.tsx
@@ -34,7 +34,7 @@ export const InputContainerBox = styled(Box)({
 });
 
 export const BackgroundDiv = styled(Box)(({ theme }) => ({
-  background: theme.palette.secondary.main,
+  background: theme.palette.secondary.light,
   [theme.breakpoints.up('md')]: {
     padding: '1rem 2rem',
   },

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -37,7 +37,7 @@ const Dashboard = () => {
         <title>{t('common.start_page')}</title>
       </Helmet>
       {showBanner && (
-        <Box sx={{ bgcolor: 'secondary.dark', p: '1rem 0.5rem', width: '100%' }}>
+        <Box sx={{ bgcolor: 'secondary.main', p: '1rem 0.5rem', width: '100%' }}>
           <Box
             sx={{
               gridArea: 'tagline',

--- a/src/pages/my_page/user_profile/ResearchProfilePanel.tsx
+++ b/src/pages/my_page/user_profile/ResearchProfilePanel.tsx
@@ -33,7 +33,7 @@ export const ResearchProfilePanel = ({ person, isLoadingPerson }: ResearchProfil
       <Helmet>
         <title>{fullName}</title>
       </Helmet>
-      <BackgroundDiv sx={{ bgcolor: 'secondary.dark', height: '100%', padding: '1rem' }}>
+      <BackgroundDiv sx={{ bgcolor: 'secondary.main', height: '100%', padding: '1rem' }}>
         {isLoadingPerson ? (
           <PageSpinner aria-label={t('my_page.research_profile')} />
         ) : (

--- a/src/pages/public_registration/public_files/FilesLandingPageAccordion.tsx
+++ b/src/pages/public_registration/public_files/FilesLandingPageAccordion.tsx
@@ -33,7 +33,7 @@ export const FilesLandingPageAccordion = ({ registration }: PublicRegistrationCo
       defaultExpanded
       heading={
         showRegistrationHasFilesAwaitingApproval ? (
-          <Box component="span" sx={{ bgcolor: 'secondary.light', p: '0.25rem' }}>
+          <Box component="span" sx={{ background: '#FEFBF3', p: '0.25rem' }}>
             {t('registration.files_and_license.files_awaits_approval')}
           </Box>
         ) : (

--- a/src/pages/registration/RegistrationForm.tsx
+++ b/src/pages/registration/RegistrationForm.tsx
@@ -96,7 +96,7 @@ export const RegistrationForm = ({ identifier }: RegistrationFormProps) => {
             <PageHeader variant="h1">{getTitleString(values.entityDescription?.mainTitle)}</PageHeader>
             <RegistrationFormStepper tabNumber={tabNumber} setTabNumber={setTabNumber} />
             <RequiredDescription />
-            <BackgroundDiv sx={{ bgcolor: 'secondary.dark' }}>
+            <BackgroundDiv sx={{ bgcolor: 'secondary.main' }}>
               <Box id="form" mb="2rem">
                 {tabNumber === RegistrationTab.Description && (
                   <ErrorBoundary>

--- a/src/pages/registration/new_registration/RegistrationAccordion.tsx
+++ b/src/pages/registration/new_registration/RegistrationAccordion.tsx
@@ -2,7 +2,7 @@ import { Accordion } from '@mui/material';
 import { styled } from '@mui/system';
 
 export const RegistrationAccordion = styled(Accordion)(({ theme }) => ({
-  background: theme.palette.secondary.dark,
+  background: theme.palette.secondary.main,
   '.MuiAccordionSummary-content': {
     alignItems: 'center',
     padding: '1rem 0',

--- a/src/pages/search/person_search/PersonListItem.tsx
+++ b/src/pages/search/person_search/PersonListItem.tsx
@@ -20,8 +20,9 @@ export const PersonListItem = ({ person }: PersonListItemProps) => {
     <ListItem
       sx={{
         border: '2px solid',
+        borderColor: '#D3C9AF',
         borderLeft: '1.25rem solid',
-        borderColor: 'person.main',
+        borderLeftColor: 'person.main',
         flexDirection: 'column',
         alignItems: 'start',
       }}>

--- a/src/pages/search/person_search/PersonListItem.tsx
+++ b/src/pages/search/person_search/PersonListItem.tsx
@@ -20,7 +20,7 @@ export const PersonListItem = ({ person }: PersonListItemProps) => {
     <ListItem
       sx={{
         border: '2px solid',
-        borderColor: '#D3C9AF',
+        borderColor: 'secondary.dark',
         borderLeft: '1.25rem solid',
         borderLeftColor: 'person.main',
         flexDirection: 'column',

--- a/src/pages/search/project_search/ProjectListItem.tsx
+++ b/src/pages/search/project_search/ProjectListItem.tsx
@@ -22,8 +22,9 @@ export const ProjectListItem = ({ project }: ProjectListItemProps) => {
     <ListItem
       sx={{
         border: '2px solid',
+        borderColor: '#D3C9AF',
         borderLeft: '1.25rem solid',
-        borderColor: 'project.main',
+        borderLeftColor: 'project.main',
         flexDirection: 'column',
         alignItems: 'start',
       }}>

--- a/src/pages/search/project_search/ProjectListItem.tsx
+++ b/src/pages/search/project_search/ProjectListItem.tsx
@@ -22,7 +22,7 @@ export const ProjectListItem = ({ project }: ProjectListItemProps) => {
     <ListItem
       sx={{
         border: '2px solid',
-        borderColor: '#D3C9AF',
+        borderColor: 'secondary.dark',
         borderLeft: '1.25rem solid',
         borderLeftColor: 'project.main',
         flexDirection: 'column',

--- a/src/themes/mainTheme.ts
+++ b/src/themes/mainTheme.ts
@@ -8,9 +8,9 @@ enum Color {
   Black = '#222',
   ErrorMain = '#AC0303',
   PrimaryMain = '#0F0035',
-  SecondaryLight = '#FEFBF3',
-  SecondaryMain = '#F9F4E6',
-  SecondaryDark = '#EDE2C7',
+  SecondaryLight = '#F9F4E6',
+  SecondaryMain = '#EDE2C7',
+  SecondaryDark = '#D3C9AF',
   SuccessMain = '#025810',
   InfoMain = '#4367F6',
   InfoLight = '#C2D3EA',
@@ -91,7 +91,7 @@ export const mainTheme = createTheme(
       },
       background: {
         default: Color.White,
-        paper: Color.SecondaryMain,
+        paper: Color.SecondaryLight,
       },
     },
     typography: {
@@ -283,9 +283,9 @@ export const mainTheme = createTheme(
 
 export const alternatingTableRowColor: SxProps = {
   tr: {
-    bgcolor: 'secondary.main',
+    bgcolor: 'secondary.light',
     '&:nth-of-type(odd)': {
-      bgcolor: 'secondary.light',
+      bgcolor: '#FEFBF3',
     },
   },
 };

--- a/src/themes/mainTheme.ts
+++ b/src/themes/mainTheme.ts
@@ -282,10 +282,17 @@ export const mainTheme = createTheme(
 );
 
 export const alternatingTableRowColor: SxProps = {
-  tr: {
-    bgcolor: 'secondary.light',
-    '&:nth-of-type(odd)': {
+  thead: {
+    tr: {
       bgcolor: '#FEFBF3',
+    },
+  },
+  tbody: {
+    tr: {
+      bgcolor: 'secondary.light',
+      '&:nth-of-type(even)': {
+        bgcolor: '#FEFBF3',
+      },
     },
   },
 };


### PR DESCRIPTION
Tidligere secondary.light ligger ikke i figma og var bare noe vi har lagt inn selv, så forskjyver secondary colors ett hakk, og forholder med til verdier i figma
![bilde](https://user-images.githubusercontent.com/6313468/213695636-c1787c78-25be-487e-91b6-87f6a2bc3462.png)
