### PR TITLE
Minor layout changes for search page

### DIFF
--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -100,7 +100,8 @@ const SearchPage = () => {
               <Box
                 sx={{
                   display: 'flex',
-                  flexDirection: 'column',
+                  flexDirection: { xs: 'row', md: 'column' },
+                  flexWrap: 'wrap',
                   gap: '0.5rem',
                   button: { textTransform: 'none' },
                   m: '1rem',

--- a/src/pages/search/registration_search/filters/RegistrationFacetsFilter.tsx
+++ b/src/pages/search/registration_search/filters/RegistrationFacetsFilter.tsx
@@ -59,7 +59,9 @@ export const RegistrationFacetsFilter = ({ aggregations, isLoadingSearch }: Regi
                 }}
                 onClick={() => updateFilter(ResourceFieldNames.RegistrationType, bucket.key)}
                 selected={properties.some((searchProperty) => searchProperty.value === bucket.key)}>
-                <span>{t(`registration.publication_types.${bucket.key as PublicationInstanceType}`)}</span>
+                <Box component="span" sx={{ wordBreak: 'break-word' }}>
+                  {t(`registration.publication_types.${bucket.key as PublicationInstanceType}`)}
+                </Box>
                 {(bucket.docCount || bucket.doc_count) && <span>({bucket.docCount ?? bucket.doc_count})</span>}
               </ListItemButton>
             </Box>


### PR DESCRIPTION
Sørg for at lange typenavn ikke går utenfor boksen, og bruk row-flexbox på mobil for typer