### PR TITLE
Np 44640 store orcid credentials simplifications

### DIFF
--- a/src/pages/my_page/user_profile/UserOrcid.tsx
+++ b/src/pages/my_page/user_profile/UserOrcid.tsx
@@ -100,7 +100,8 @@ export const UserOrcid = ({ user }: UserOrcidProps) => {
             dispatch(setNotification({ message: t('feedback.error.storing_orcid_credentials'), variant: 'error' }));
           } else {
             const postOrcidCredentialsResponse = await postOrcidCredentials(orcidCredentials);
-            if (isErrorStatus(postOrcidCredentialsResponse.status)) {
+            if (postOrcidCredentialsResponse.status !== 409 && isErrorStatus(postOrcidCredentialsResponse.status)) {
+              // Ignore 409 Conflict, since this means that the data is correct anyway
               dispatch(setNotification({ message: t('feedback.error.storing_orcid_credentials'), variant: 'error' }));
             }
           }

--- a/src/pages/my_page/user_profile/UserOrcid.tsx
+++ b/src/pages/my_page/user_profile/UserOrcid.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import CancelIcon from '@mui/icons-material/Cancel';
@@ -69,6 +69,7 @@ export const UserOrcid = ({ user }: UserOrcidProps) => {
     queryFn: () => fetchPerson(userCristinId),
     onError: () => dispatch(setNotification({ message: t('feedback.error.get_person'), variant: 'error' })),
   });
+  const fetchCristinPersonRef = useRef(cristinPersonQuery.refetch);
   const cristinPerson = cristinPersonQuery.data;
 
   const currentOrcid = getValueByKey('ORCID', cristinPerson?.identifiers);
@@ -93,6 +94,7 @@ export const UserOrcid = ({ user }: UserOrcidProps) => {
         });
         if (isSuccessStatus(addOrcidResponse.status)) {
           dispatch(setNotification({ message: t('feedback.success.update_orcid'), variant: 'success' }));
+          await fetchCristinPersonRef.current();
           const orcidCredentials = getOrcidCredentials(history.location.search, orcidInfoResponse.data.id);
           if (!orcidCredentials) {
             dispatch(setNotification({ message: t('feedback.error.storing_orcid_credentials'), variant: 'error' }));
@@ -107,29 +109,20 @@ export const UserOrcid = ({ user }: UserOrcidProps) => {
         }
       }
       setIsAddingOrcid(false);
-      history.replace(`${UrlPathTemplate.MyPageMyPersonalia}?refresh=true`);
+      history.replace(UrlPathTemplate.MyPageMyPersonalia);
     };
 
-    const orcidAccessToken = new URLSearchParams(history.location.search).get('access_token');
+    const searchParams = new URLSearchParams(history.location.search);
+
+    const orcidAccessToken = searchParams.get('access_token');
     if (orcidAccessToken) {
       addOrcid(orcidAccessToken);
     }
-    const orcidError = new URLSearchParams(history.location.search).get('error');
+    const orcidError = searchParams.get('error');
     if (orcidError) {
       dispatch(setNotification({ message: t('feedback.error.orcid_login'), variant: 'error' }));
     }
   }, [dispatch, t, history, userCristinId]);
-
-  useEffect(() => {
-    const fetchUser = async () => {
-      await cristinPersonQuery.refetch();
-      history.replace(UrlPathTemplate.MyPageMyPersonalia);
-    };
-    const refresh = new URLSearchParams(history.location.search).get('refresh');
-    if (refresh) {
-      fetchUser();
-    }
-  }, [cristinPersonQuery, history]);
 
   const removeOrcid = async () => {
     setIsRemovingOrcid(true);
@@ -141,7 +134,7 @@ export const UserOrcid = ({ user }: UserOrcidProps) => {
       });
       if (isSuccessStatus(removeOrcidResponse.status)) {
         dispatch(setNotification({ message: t('feedback.success.update_orcid'), variant: 'success' }));
-        cristinPersonQuery.refetch();
+        await cristinPersonQuery.refetch();
       } else if (isErrorStatus(removeOrcidResponse.status)) {
         dispatch(setNotification({ message: t('feedback.error.update_orcid'), variant: 'success' }));
       }


### PR DESCRIPTION
Hele `UserOrcid` og flyten her er subotimal i utgangspunktet, men tror dette vil gjøre det greit nok. For brukeren vil det være forvirrende om lagring av orcid-data feiler, siden det skjer _etter_ at koblingen til Orcid har lyktes. Da blir det på en måte missvisende at man får en feilmelding, men syns dette er greit nok for nå.