### PR TITLE
Np 42253 update messages view

### DIFF
--- a/src/pages/messages/MessageList.tsx
+++ b/src/pages/messages/MessageList.tsx
@@ -1,4 +1,3 @@
-import { Fragment } from 'react';
 import { Box, Typography } from '@mui/material';
 import { Message } from '../../types/publication_types/messages.types';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
@@ -10,22 +9,27 @@ interface MessageListProps {
 export const MessageList = ({ messages }: MessageListProps) => (
   <ErrorBoundary>
     <Box
+      component="ul"
       sx={{
-        display: 'grid',
-        gridTemplateColumns: { xs: '1fr', md: 'auto 1fr' },
-        columnGap: '0.5rem',
+        display: 'flex',
+        flexDirection: 'column',
+        listStyleType: 'none',
+        p: 0,
+        m: 0,
+        gap: '0.25rem',
       }}>
       {messages.map((message) => {
         const firstName = message.sender.preferredFirstName ?? message.sender.firstName;
         const lastName = message.sender.preferredLastName ?? message.sender.lastName;
+
         return (
-          <Fragment key={message.identifier}>
+          <li key={message.identifier}>
             <Typography>
               <b data-testid="message-author">{`${firstName} ${lastName}`}</b>{' '}
-              <span data-testid="message-timestamp">({new Date(message.createdDate).toLocaleDateString()})</span>:
+              <span data-testid="message-timestamp">({new Date(message.createdDate).toLocaleString()})</span>
             </Typography>
             <Typography data-testid="message-text">{message.text}</Typography>
-          </Fragment>
+          </li>
         );
       })}
     </Box>


### PR DESCRIPTION
Forrige visning ble veldig rar når to personer med ulik lengde på navnet snakket sammen, så flytter nå navnet til en egen rad. Ingen scrollbar atm, så siden blir uendelig lang når det er uendelig antall medlinger.
![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/59abb114-5a5e-4381-8da2-1d264bb40fa5)
