### PR TITLE
Retry cypress test 3 times on fail

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -18,4 +18,8 @@ export default defineConfig({
     baseUrl: 'http://localhost:3000',
     specPattern: 'cypress/e2e/**/*.{js,jsx,ts,tsx}',
   },
+  retries: {
+    runMode: 3,
+    openMode: 3,
+  },
 });


### PR DESCRIPTION
Ser ut som det noen ganger feiler pga av noe treghet med `cy.setUserRolesInRedux([])`. Klarer ikke se noen grunn til hvorfor, og den metoden var uansett bare en enkel workaround for basic testing av tilgangskontroll, så legger inn retries i stedet for å knote i timesvis med det