### PR TITLE
Wait after cypress updates redux due to flaky tests

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -41,6 +41,7 @@ Cypress.Commands.add('setUserRolesInRedux', (roles) => {
         })
       )
     );
+  cy.wait(500);
 });
 
 Cypress.Commands.add('setNotificationInRedux', (notification) => {


### PR DESCRIPTION
Forrige forsøk (https://github.com/BIBSYSDEV/NVA-Frontend/pull/4079) ser ut til å løse problemet for akkurat den, men da er det noen andre tester som sklir ut igjen... Prøver på ny. Om dette virker kan vi vurdere om vi ønsker å revertere det forrige forsøket