### PR TITLE
NP-45023 Update design of central import search hit

### DIFF
--- a/src/pages/basic_data/BasicDataPage.tsx
+++ b/src/pages/basic_data/BasicDataPage.tsx
@@ -118,7 +118,7 @@ const BasicDataPage = () => {
                 startIcon={
                   <FilterDramaIcon
                     sx={{
-                      bgcolor: 'grey.400',
+                      bgcolor: 'centralImport.main',
                       padding: '0.1rem',
                     }}
                   />

--- a/src/pages/basic_data/app_admin/central_import/CentralImportDuplicateSearch.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportDuplicateSearch.tsx
@@ -1,4 +1,4 @@
-import { Divider, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -32,39 +32,41 @@ export const CentralImportDuplicateSearch = ({ duplicateSearchFilters }: Central
 
   const searchQuery = queryArray.length > 0 ? `(${queryArray.join(' AND ')})` : '';
 
-  const duplicatesQuery = useQuery({
+  const duplicateCandidatesQuery = useQuery({
     queryKey: ['registrationsSearch', rowsPerPage, page, searchQuery],
     queryFn: () => fetchResults(rowsPerPage, (page - 1) * rowsPerPage, searchQuery),
     meta: { errorMessage: t('feedback.error.get_registrations') },
   });
+  const duplicateCandidatesSize = duplicateCandidatesQuery.data?.size ?? 0;
 
   return (
-    <>
-      {duplicatesQuery.isLoading ? (
+    <Box sx={{ border: '1px solid black', padding: { xs: '0.5rem', sm: '0.5rem 1rem' }, mt: '1rem' }}>
+      {duplicateCandidatesQuery.isLoading ? (
         <ListSkeleton minWidth={100} maxWidth={100} height={100} />
       ) : (
         <>
           <Typography variant="subtitle1">
-            {t('basic_data.central_import.duplicate_search_hits_shown', {
-              ShownResultsCount: duplicatesQuery.data?.hits.length ?? 0,
-              TotalResultsCount: duplicatesQuery.data?.size ?? 0,
-            })}
-            :
+            {duplicateCandidatesSize === 0
+              ? t('basic_data.central_import.duplicate_search_no_hits')
+              : t('basic_data.central_import.duplicate_search_hits')}
           </Typography>
-          <Divider />
-          <RegistrationList registrations={duplicatesQuery.data?.hits ?? []} />
-          <ListPagination
-            count={duplicatesQuery.data?.size ?? 0}
-            rowsPerPage={rowsPerPage}
-            page={page}
-            onPageChange={(newPage) => setPage(newPage)}
-            onRowsPerPageChange={(newRowsPerPage) => {
-              setRowsPerPage(newRowsPerPage);
-              setPage(1);
-            }}
-          />
+          {duplicateCandidatesSize > 0 && (
+            <>
+              <RegistrationList registrations={duplicateCandidatesQuery.data?.hits ?? []} />
+              <ListPagination
+                count={duplicateCandidatesSize}
+                rowsPerPage={rowsPerPage}
+                page={page}
+                onPageChange={(newPage) => setPage(newPage)}
+                onRowsPerPageChange={(newRowsPerPage) => {
+                  setRowsPerPage(newRowsPerPage);
+                  setPage(1);
+                }}
+              />
+            </>
+          )}
         </>
       )}
-    </>
+    </Box>
   );
 };

--- a/src/pages/basic_data/app_admin/central_import/CentralImportDuplicationCheckPage.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportDuplicationCheckPage.tsx
@@ -1,4 +1,4 @@
-import { Button, Divider, Typography } from '@mui/material';
+import { Button, Typography } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -45,8 +45,9 @@ export const CentralImportDuplicationCheckPage = () => {
   ) : importCandidate ? (
     <>
       {importCandidate && <CentralImportResultItem importCandidate={importCandidate} />}
-      <Divider sx={{ marginBottom: '2rem' }} />
-      <Typography variant="h3">{t('basic_data.central_import.search_for_duplicates')}:</Typography>
+      <Typography variant="h3" sx={{ mt: '1rem' }}>
+        {t('basic_data.central_import.search_for_duplicates')}:
+      </Typography>
       <DuplicateSearchFilterForm
         importCandidate={importCandidate}
         setDuplicateSearchFilters={setDuplicateSearchFilters}

--- a/src/pages/basic_data/app_admin/central_import/CentralImportDuplicationCheckPage.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportDuplicationCheckPage.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Divider, Typography } from '@mui/material';
+import { Button, Divider, Typography } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -40,34 +40,23 @@ export const CentralImportDuplicationCheckPage = () => {
     });
   }, [importCandidate]);
 
-  return (
+  return importCandidateQuery.isLoading ? (
+    <PageSpinner aria-label={t('basic_data.central_import.central_import')} />
+  ) : importCandidate ? (
     <>
-      <Typography id="duplicate-check-label" variant="h2" gutterBottom>
-        {t('basic_data.central_import.duplicate_check')}
-      </Typography>
-      <>
-        {importCandidateQuery.isLoading ? (
-          <PageSpinner aria-labelledby="duplicate-check-label" />
-        ) : importCandidate ? (
-          <>
-            {importCandidate && <CentralImportResultItem importCandidate={importCandidate} />}
-            <Divider sx={{ marginBottom: '2rem' }} />
-            <Typography variant="h3">{t('basic_data.central_import.search_for_duplicates')}:</Typography>
-            <DuplicateSearchFilterForm
-              importCandidate={importCandidate}
-              setDuplicateSearchFilters={setDuplicateSearchFilters}
-            />
-            <Button variant="outlined" color="primary" component={Link} to={getImportCandidatePagePath(identifier)}>
-              {t('basic_data.central_import.import')}
-            </Button>
-            <Box sx={{ border: '1px solid black', padding: { xs: '0.5rem', sm: '0.5rem 2rem' }, mt: '1rem' }}>
-              <CentralImportDuplicateSearch duplicateSearchFilters={duplicateSearchFilters} />
-            </Box>
-          </>
-        ) : (
-          <NotFound />
-        )}
-      </>
+      {importCandidate && <CentralImportResultItem importCandidate={importCandidate} />}
+      <Divider sx={{ marginBottom: '2rem' }} />
+      <Typography variant="h3">{t('basic_data.central_import.search_for_duplicates')}:</Typography>
+      <DuplicateSearchFilterForm
+        importCandidate={importCandidate}
+        setDuplicateSearchFilters={setDuplicateSearchFilters}
+      />
+      <Button variant="outlined" color="primary" component={Link} to={getImportCandidatePagePath(identifier)}>
+        {t('basic_data.central_import.import')}
+      </Button>
+      <CentralImportDuplicateSearch duplicateSearchFilters={duplicateSearchFilters} />
     </>
+  ) : (
+    <NotFound />
   );
 };

--- a/src/pages/basic_data/app_admin/central_import/CentralImportDuplicationCheckPage.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportDuplicationCheckPage.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router-dom';
 import { PublicationsApiPath } from '../../../../api/apiPaths';
 import { PageSpinner } from '../../../../components/PageSpinner';
-import { StyledPageContent } from '../../../../components/styled/Wrappers';
+import { SearchListItem } from '../../../../components/styled/Wrappers';
 import { emptyDuplicateSearchFilter } from '../../../../types/duplicateSearchTypes';
 import { Registration } from '../../../../types/registration.types';
 import { useFetch } from '../../../../utils/hooks/useFetch';
@@ -42,32 +42,33 @@ export const CentralImportDuplicationCheckPage = () => {
 
   return (
     <>
-      <Typography id="duplicate-check-label" variant="h2">
+      <Typography id="duplicate-check-label" variant="h2" gutterBottom>
         {t('basic_data.central_import.duplicate_check')}
       </Typography>
-      <StyledPageContent>
+      <>
         {isLoadingRegistration ? (
           <PageSpinner aria-labelledby="duplicate-check-label" />
         ) : registration ? (
           <>
-            <Typography variant="h3">{t('basic_data.central_import.import_publication')}:</Typography>
-            <Typography gutterBottom sx={{ fontSize: '1rem', fontWeight: '600', fontStyle: 'italic' }}>
-              {getTitleString(registration.entityDescription?.mainTitle)}
-            </Typography>
-            <Typography display="inline" variant="body2">
-              {contributors.map((contributor) => contributor.identity.name).join('; ')}
-            </Typography>
-            {registration.entityDescription?.reference?.doi && (
-              <MuiLink
-                underline="hover"
-                href={registration.entityDescription.reference.doi}
-                target="_blank"
-                rel="noopener noreferrer">
-                <Typography gutterBottom variant="body2" sx={{ color: 'primary.main' }}>
-                  {registration.entityDescription.reference.doi}
-                </Typography>
-              </MuiLink>
-            )}
+            <SearchListItem sx={{ borderLeftColor: 'centralImport.main' }}>
+              <Typography gutterBottom sx={{ fontSize: '1rem', fontWeight: '600', fontStyle: 'italic' }}>
+                {getTitleString(registration.entityDescription?.mainTitle)}
+              </Typography>
+              <Typography display="inline" variant="body2">
+                {contributors.map((contributor) => contributor.identity.name).join('; ')}
+              </Typography>
+              {registration.entityDescription?.reference?.doi && (
+                <MuiLink
+                  underline="hover"
+                  href={registration.entityDescription.reference.doi}
+                  target="_blank"
+                  rel="noopener noreferrer">
+                  <Typography gutterBottom variant="body2" sx={{ color: 'primary.main' }}>
+                    {registration.entityDescription.reference.doi}
+                  </Typography>
+                </MuiLink>
+              )}
+            </SearchListItem>
             <Divider sx={{ marginBottom: '2rem' }} />
             <Typography variant="h3">{t('basic_data.central_import.search_for_duplicates')}:</Typography>
             <DuplicateSearchFilterForm
@@ -84,7 +85,7 @@ export const CentralImportDuplicationCheckPage = () => {
         ) : (
           <NotFound />
         )}
-      </StyledPageContent>
+      </>
     </>
   );
 };

--- a/src/pages/basic_data/app_admin/central_import/CentralImportPage.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportPage.tsx
@@ -43,23 +43,21 @@ export const CentralImportPage = () => {
   return importCandidateQuery.isLoading ? (
     <ListSkeleton minWidth={100} maxWidth={100} height={100} />
   ) : (
-    searchResults && (
-      <>
-        <List>
-          {searchResults.map((importCandidate) => (
-            <CentralImportResultItem importCandidate={importCandidate} key={importCandidate.id} />
-          ))}
-        </List>
-        {searchResults.length > 0 && (
-          <ListPagination
-            count={importCandidateQuery.data?.size ?? -1}
-            rowsPerPage={rowsPerPage}
-            page={page + 1}
-            onPageChange={(newPage) => updatePath(((newPage - 1) * rowsPerPage).toString(), rowsPerPage.toString())}
-            onRowsPerPageChange={(newRowsPerPage) => updatePath('0', newRowsPerPage.toString())}
-          />
-        )}
-      </>
-    )
+    <>
+      <List>
+        {searchResults.map((importCandidate) => (
+          <CentralImportResultItem importCandidate={importCandidate} key={importCandidate.id} />
+        ))}
+      </List>
+      {searchResults.length > 0 && (
+        <ListPagination
+          count={importCandidateQuery.data?.size ?? -1}
+          rowsPerPage={rowsPerPage}
+          page={page + 1}
+          onPageChange={(newPage) => updatePath(((newPage - 1) * rowsPerPage).toString(), rowsPerPage.toString())}
+          onRowsPerPageChange={(newRowsPerPage) => updatePath('0', newRowsPerPage.toString())}
+        />
+      )}
+    </>
   );
 };

--- a/src/pages/basic_data/app_admin/central_import/CentralImportPage.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportPage.tsx
@@ -1,4 +1,4 @@
-import { Divider, List, Typography } from '@mui/material';
+import { List } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -40,33 +40,26 @@ export const CentralImportPage = () => {
 
   const searchResults = importCandidateQuery.data?.hits ?? [];
 
-  return (
-    <>
-      <Typography variant="h3">{t('basic_data.central_import.publications')}</Typography>
-      {importCandidateQuery.isLoading ? (
-        <ListSkeleton minWidth={100} maxWidth={100} height={100} />
-      ) : (
-        searchResults && (
-          <>
-            <Typography variant="subtitle1">{t('search.hits', { count: importCandidateQuery.data?.size })}:</Typography>
-            <Divider />
-            <List>
-              {searchResults.map((importCandidate) => (
-                <CentralImportResultItem importCandidate={importCandidate} key={importCandidate.id} />
-              ))}
-            </List>
-            {searchResults.length > 0 && (
-              <ListPagination
-                count={importCandidateQuery.data?.size ?? -1}
-                rowsPerPage={rowsPerPage}
-                page={page + 1}
-                onPageChange={(newPage) => updatePath(((newPage - 1) * rowsPerPage).toString(), rowsPerPage.toString())}
-                onRowsPerPageChange={(newRowsPerPage) => updatePath('0', newRowsPerPage.toString())}
-              />
-            )}
-          </>
-        )
-      )}
-    </>
+  return importCandidateQuery.isLoading ? (
+    <ListSkeleton minWidth={100} maxWidth={100} height={100} />
+  ) : (
+    searchResults && (
+      <>
+        <List>
+          {searchResults.map((importCandidate) => (
+            <CentralImportResultItem importCandidate={importCandidate} key={importCandidate.id} />
+          ))}
+        </List>
+        {searchResults.length > 0 && (
+          <ListPagination
+            count={importCandidateQuery.data?.size ?? -1}
+            rowsPerPage={rowsPerPage}
+            page={page + 1}
+            onPageChange={(newPage) => updatePath(((newPage - 1) * rowsPerPage).toString(), rowsPerPage.toString())}
+            onRowsPerPageChange={(newRowsPerPage) => updatePath('0', newRowsPerPage.toString())}
+          />
+        )}
+      </>
+    )
   );
 };

--- a/src/pages/basic_data/app_admin/central_import/CentralImportPage.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportPage.tsx
@@ -19,6 +19,7 @@ export const CentralImportPage = () => {
   const fromParam = params.get(SearchParam.From);
   const rowsPerPage = (resultsParam && +resultsParam) || ROWS_PER_PAGE_OPTIONS[0];
   const page = (fromParam && resultsParam && Math.floor(+fromParam / rowsPerPage)) || 0;
+
   const importCandidateQuery = useQuery({
     queryKey: ['importCandidates', rowsPerPage, page, ''],
     queryFn: () => fetchImportCandidates(rowsPerPage, page * rowsPerPage, ''),

--- a/src/pages/basic_data/app_admin/central_import/CentralImportResultItem.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportResultItem.tsx
@@ -1,11 +1,12 @@
-import { Grid, ListItem, ListItemText, Link as MuiLink, Typography } from '@mui/material';
+import { Box, ListItemText, Link as MuiLink, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { ContributorIndicators } from '../../../../components/ContributorIndicators';
+import { SearchListItem } from '../../../../components/styled/Wrappers';
 import { ImportCandidateSummary } from '../../../../types/importCandidate.types';
 import { dataTestId } from '../../../../utils/dataTestIds';
 import { getIdentifierFromId } from '../../../../utils/general-helpers';
-import { getLanguageString } from '../../../../utils/translation-helpers';
-import { getDuplicateCheckPagePath } from '../../../../utils/urlPaths';
+import { getDuplicateCheckPagePath, getResearchProfilePath } from '../../../../utils/urlPaths';
 
 interface CentralImportResultItemProps {
   importCandidate: ImportCandidateSummary;
@@ -14,60 +15,69 @@ interface CentralImportResultItemProps {
 export const CentralImportResultItem = ({ importCandidate }: CentralImportResultItemProps) => {
   const { t } = useTranslation();
 
+  const typeString = importCandidate.publicationInstance?.type
+    ? t(`registration.publication_types.${importCandidate.publicationInstance.type}`)
+    : '';
+  const heading = [typeString, importCandidate.publicationYear].filter(Boolean).join(' — ');
+
   const verifiedContributorCount = importCandidate.totalVerifiedContributors;
   const contributorsCount = importCandidate.totalContributors;
 
-  const allContributorInstitutions = importCandidate.organizations?.map(
-    (affiliation) => affiliation.labels && getLanguageString(affiliation.labels)
-  );
-  const institutions = allContributorInstitutions ? [...new Set(allContributorInstitutions.flat())] : [];
-  const publicationInstanceType = importCandidate?.publicationInstance.type;
-
   return (
-    <ListItem divider data-testid={`${dataTestId.basicData.centralImport.resultItem}-${importCandidate.id}`}>
-      <ListItemText disableTypography>
-        <Grid container spacing={2} justifyContent="space-between" alignItems="baseline">
-          <Grid item md={2} xs={12}>
-            {publicationInstanceType && (
-              <Typography>{t(`registration.publication_types.${publicationInstanceType}`)}</Typography>
-            )}
-          </Grid>
-          <Grid item md={5} xs={12}>
-            {importCandidate.doi && (
-              <MuiLink underline="hover" href={importCandidate.doi} target="_blank" rel="noopener noreferrer">
-                <Typography gutterBottom variant="body2" sx={{ color: 'primary.main', wordBreak: 'break-word' }}>
-                  {importCandidate.doi}
-                </Typography>
-              </MuiLink>
-            )}
-            {importCandidate.mainTitle && (
-              <Typography
-                gutterBottom
-                sx={{
-                  fontSize: '1rem',
-                  fontWeight: '600',
-                  fontStyle: 'italic',
-                  wordBreak: 'break-word',
-                }}>
-                <MuiLink component={Link} to={getDuplicateCheckPagePath(getIdentifierFromId(importCandidate.id))}>
-                  {importCandidate.mainTitle}
-                </MuiLink>
+    <SearchListItem sx={{ borderLeftColor: 'centralImport.main' }}>
+      <Box sx={{ display: 'flex', width: '100%', gap: '1rem' }}>
+        <ListItemText disableTypography data-testid={dataTestId.startPage.searchResultItem}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: { xs: '1rem', sm: '2rem' } }}>
+            {heading && (
+              <Typography variant="overline" sx={{ color: 'primary.main' }}>
+                {heading}
               </Typography>
             )}
-          </Grid>
-          <Grid item md={2} xs={12}>
-            <Typography>
-              {t('basic_data.central_import.verified_contributor_count', {
-                verifiedContributorCount,
-                contributorsCount,
-              })}
-            </Typography>
-          </Grid>
-          <Grid item md={3} xs={12}>
-            {institutions && <Typography variant="body1">{institutions.join('; ')}</Typography>}
-          </Grid>
-        </Grid>
-      </ListItemText>
-    </ListItem>
+          </Box>
+          <Typography gutterBottom sx={{ fontSize: '1rem', fontWeight: '600', wordWrap: 'break-word' }}>
+            <MuiLink component={Link} to={getDuplicateCheckPagePath(getIdentifierFromId(importCandidate.id))}>
+              {importCandidate.mainTitle}
+            </MuiLink>
+          </Typography>
+          <Box
+            sx={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              columnGap: '1rem',
+              whiteSpace: 'nowrap',
+            }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', columnGap: '0.5rem', flexWrap: 'wrap' }}>
+              {importCandidate.contributors.map((contributor, index) => (
+                <Box
+                  key={index}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    '&:not(:last-child)': { '&:after': { content: '";"' } },
+                  }}>
+                  <Typography variant="body2">
+                    {contributor.identity.id ? (
+                      <MuiLink component={Link} to={getResearchProfilePath(contributor.identity.id)}>
+                        {contributor.identity.name}
+                      </MuiLink>
+                    ) : (
+                      contributor.identity.name
+                    )}
+                  </Typography>
+                  <ContributorIndicators contributor={contributor} />
+                </Box>
+              ))}
+
+              <Typography>
+                {t('basic_data.central_import.verified_contributor_count', {
+                  verifiedContributorCount,
+                  contributorsCount,
+                })}
+              </Typography>
+            </Box>
+          </Box>
+        </ListItemText>
+      </Box>
+    </SearchListItem>
   );
 };

--- a/src/pages/basic_data/app_admin/central_import/DuplicateSearchFilterForm.tsx
+++ b/src/pages/basic_data/app_admin/central_import/DuplicateSearchFilterForm.tsx
@@ -4,7 +4,7 @@ import { Field, FieldProps, Form, Formik, FormikProps } from 'formik';
 import { ChangeEvent, Dispatch, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DuplicateSearchFilters, DuplicateSearchForm } from '../../../../types/duplicateSearchTypes';
-import { Registration } from '../../../../types/registration.types';
+import { ImportCandidateSummary } from '../../../../types/importCandidate.types';
 import { dataTestId } from '../../../../utils/dataTestIds';
 
 const StyledFormElementWrapper = muiStyled('div')({
@@ -17,20 +17,20 @@ const StyledFormControlLabel = muiStyled(FormControlLabel)({
 });
 
 interface DuplicateSearchFilterFormProps {
-  publication: Registration;
+  importCandidate: ImportCandidateSummary;
   setDuplicateSearchFilters: Dispatch<SetStateAction<DuplicateSearchFilters>>;
 }
 
 export const DuplicateSearchFilterForm = ({
-  publication,
+  importCandidate,
   setDuplicateSearchFilters,
 }: DuplicateSearchFilterFormProps) => {
   const { t } = useTranslation();
 
   const initialSearchParams: DuplicateSearchForm = {
-    doi: publication.entityDescription?.reference?.doi ?? '',
-    title: publication.entityDescription?.mainTitle ?? '',
-    author: publication.entityDescription?.contributors[0]?.identity.name ?? '',
+    doi: importCandidate.doi ?? '',
+    title: importCandidate.mainTitle ?? '',
+    author: importCandidate.contributors[0]?.identity.name ?? '',
     issn: '',
     yearPublished: '',
     isDoiChecked: true,

--- a/src/themes/mainTheme.ts
+++ b/src/themes/mainTheme.ts
@@ -6,6 +6,7 @@ import i18n from '../translations/i18n';
 // Colors: https://www.figma.com/file/3hggk6SX2ca81U8kwaZKFs/Farger-NVA
 enum Color {
   Black = '#222',
+  CentralImportMain = '#D9D9D9',
   ErrorMain = '#AC0303',
   PrimaryMain = '#0F0035',
   SecondaryLight = '#F9F4E6',
@@ -39,6 +40,7 @@ declare module '@mui/material/styles' {
     publishingRequest: PaletteColorOptions;
     doiRequest: PaletteColorOptions;
     generalSupportCase: PaletteColorOptions;
+    centralImport: PaletteColorOptions;
   }
   interface PaletteOptions {
     registration?: PaletteColorOptions;
@@ -47,6 +49,7 @@ declare module '@mui/material/styles' {
     publishingRequest?: PaletteColorOptions;
     doiRequest?: PaletteColorOptions;
     generalSupportCase?: PaletteColorOptions;
+    centralImport?: PaletteColorOptions;
   }
 }
 declare module '@mui/material/Button' {
@@ -104,6 +107,9 @@ export const mainTheme = createTheme(
       },
       project: {
         main: Color.Project,
+      },
+      centralImport: {
+        main: Color.CentralImportMain,
       },
       publishingRequest: {
         main: Color.PublishingRequest,

--- a/src/translations/enTranslations.json
+++ b/src/translations/enTranslations.json
@@ -50,7 +50,6 @@
       "duplicate_check": "Duplicate check",
       "duplicate_search_hits_shown": "Hits (Showing {{ShownResultsCount}} of {{TotalResultsCount}})",
       "import": "Import",
-      "import_publication": "Import publication",
       "or_search_with": "or search with",
       "publications": "Publications",
       "reset_search_values": "Reset values",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -47,11 +47,10 @@
     "central_import": {
       "author": "$t(registration.contributors.types.Creator)",
       "central_import": "Sentralimport",
-      "duplicate_check": "Duplikatsjekk",
-      "duplicate_search_hits_shown": "Søket ga følgende treff: (viser {{ShownResultsCount}} av {{TotalResultsCount}})",
+      "duplicate_search_hits": "Søket ga følgende treff:",
+      "duplicate_search_no_hits": "Søket ga ingen treff",
       "import": "Importer",
       "or_search_with": "eller søk med",
-      "publications": "Publikasjoner",
       "reset_search_values": "Tilbakestill verdier",
       "search_again": "Søk igjen",
       "search_for_duplicates": "Søk etter duplikater",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -50,14 +50,13 @@
       "duplicate_check": "Duplikatsjekk",
       "duplicate_search_hits_shown": "Søket ga følgende treff: (viser {{ShownResultsCount}} av {{TotalResultsCount}})",
       "import": "Importer",
-      "import_publication": "Import publication",
       "or_search_with": "eller søk med",
       "publications": "Publikasjoner",
       "reset_search_values": "Tilbakestill verdier",
       "search_again": "Søk igjen",
       "search_for_duplicates": "Søk etter duplikater",
       "see_publication": "Se publikasjon",
-      "verified_contributor_count": "({{verifiedContributorCount}} av {{contributorsCount}})"
+      "verified_contributor_count": "({{verifiedContributorCount}} av {{contributorsCount}} verifisert)"
     },
     "institutions": {
       "add_institution": "Opprett institusjon",

--- a/src/translations/nnTranslations.json
+++ b/src/translations/nnTranslations.json
@@ -50,7 +50,6 @@
       "duplicate_check": "Duplikatsjekk",
       "duplicate_search_hits_shown": "Søkjet gav følgjande treff: (viser {{ShownResultsCount}} av {{TotalResultsCount}})",
       "import": "Importer",
-      "import_publication": "Import publication",
       "or_search_with": "eller søk med",
       "publications": "Publikasjonar",
       "reset_search_values": "Tilbakestill verdiar",

--- a/src/types/importCandidate.types.ts
+++ b/src/types/importCandidate.types.ts
@@ -1,3 +1,4 @@
+import { Contributor } from './contributor.types';
 import { Organization } from './organization.types';
 import { ArtisticPublicationInstance } from './publication_types/artisticRegistration.types';
 import { BookPublicationInstance } from './publication_types/bookRegistration.types';
@@ -37,6 +38,7 @@ export interface ImportCandidateSummary {
   publisher: Pick<Publisher, 'id' | 'name'>;
   journal: Pick<Journal, 'id'>;
   publicationInstance: PublicationInstance;
+  contributors: Contributor[];
 }
 
 type PublicationInstance =

--- a/src/types/importCandidate.types.ts
+++ b/src/types/importCandidate.types.ts
@@ -13,11 +13,7 @@ import { ReportPublicationInstance } from './publication_types/reportRegistratio
 import { ResearchDataPublicationInstance } from './publication_types/researchDataRegistration.types';
 import { Journal, Publisher, Registration } from './registration.types';
 
-export enum ImportStatus {
-  Imported = 'IMPORTED',
-  NotImported = 'NOT_IMPORTED',
-  NotApplicable = 'NOT_APPLICABLE',
-}
+type ImportStatus = 'IMPORTED' | 'NOT_IMPORTED' | 'NOT_APPLICABLE';
 
 export interface ImportCandidate extends Omit<Registration, 'type'> {
   type: 'ImportCandidate';

--- a/src/utils/testfiles/mockImportCandidate.ts
+++ b/src/utils/testfiles/mockImportCandidate.ts
@@ -1,4 +1,4 @@
-import { ImportCandidateSummary, ImportStatus } from '../../types/importCandidate.types';
+import { ImportCandidateSummary } from '../../types/importCandidate.types';
 import { JournalType } from '../../types/publicationFieldNames';
 
 export const mockImportCandidate: ImportCandidateSummary = {
@@ -6,7 +6,7 @@ export const mockImportCandidate: ImportCandidateSummary = {
   id: 'https://api.dev.nva.aws.unit.no/registration/12345679',
   contributors: [],
   additionalIdentifiers: ['12345'],
-  importStatus: ImportStatus.NotImported,
+  importStatus: 'NOT_IMPORTED',
   doi: '',
   publicationYear: '2020',
   mainTitle:

--- a/src/utils/testfiles/mockImportCandidate.ts
+++ b/src/utils/testfiles/mockImportCandidate.ts
@@ -4,6 +4,7 @@ import { JournalType } from '../../types/publicationFieldNames';
 export const mockImportCandidate: ImportCandidateSummary = {
   type: `ImportCandidate`,
   id: 'https://api.dev.nva.aws.unit.no/registration/12345679',
+  contributors: [],
   additionalIdentifiers: ['12345'],
   importStatus: ImportStatus.NotImported,
   doi: '',


### PR DESCRIPTION
Finpuss av resultatvisning etc for sentralimport. Faktisk importflyt kommer i senere PRs

Dette kunne nok med fordel vært delt opp i flere PRs..

- [x] Oppdater visning av ImportCandidate på duplikatside(?). Per nå returneres en Publication-type fra API her, mens søket har annen modell.
- [x] grovpussing av tekster rundt duplikatsøk ("viser 0 av 0", etc).
