### PR TITLE
Revert "Bump @aws-amplify/auth from 5.6.1 to 5.6.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nva-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@aws-amplify/auth": "^5.6.2",
+        "@aws-amplify/auth": "^5.6.1",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@fontsource/roboto": "^5.0.8",
@@ -81,21 +81,21 @@
       }
     },
     "node_modules/@aws-amplify/auth": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-5.6.2.tgz",
-      "integrity": "sha512-YwbGgwUP6VoRxPMT3e+bwK/onl+MEsA7PC/NdXj34MI6o4K0wcth1X6q9i8umnIhWMfmKNewqW1j+GhR4elH5Q==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-5.6.1.tgz",
+      "integrity": "sha512-irl0oX524JbMFJfL9KLJ1BIKzF/7fjwEl437DIijQEBHnALcL09oitS+L5laePCRR3OFLrrt8PksJ0S2DVCn8Q==",
       "dependencies": {
-        "@aws-amplify/core": "5.8.2",
-        "amazon-cognito-identity-js": "6.3.3",
+        "@aws-amplify/core": "5.8.1",
+        "amazon-cognito-identity-js": "6.3.2",
         "buffer": "4.9.2",
         "tslib": "^1.8.0",
         "url": "0.11.0"
       }
     },
     "node_modules/@aws-amplify/core": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.2.tgz",
-      "integrity": "sha512-Bv87DqUek9E/omVbsvSgeaQhwTj4q+rhhFgUi2abbnMc6vh7+H8BqRvJ/2ytp4NTBZMtdJulxT+5awKQKoibFQ==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.1.tgz",
+      "integrity": "sha512-rUtnsrYNGN2+vgtRe3TGR+ZPDH6DYaSDho2sCtHAZEMN0RTNvnpWGBxa5oLlanrkps8DUdEY8VEeqZkDC0K4Jg==",
       "dependencies": {
         "@aws-crypto/sha256-js": "1.2.2",
         "@aws-sdk/client-cloudwatch-logs": "3.6.1",
@@ -8227,9 +8227,9 @@
       }
     },
     "node_modules/amazon-cognito-identity-js": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-6.3.3.tgz",
-      "integrity": "sha512-pw70WNbyfRPgCr3SsvMlCO/sADUSVytTMwhyTALPG62lmdBeYkvaXMLkQDerN15odSQHG+WFlNmDPCySEfKlNA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-6.3.2.tgz",
+      "integrity": "sha512-g1MqdAuvIsUtzI4b9gqusk/J5hH93XVlTV4/pjWb2cKnsWJfyMo/52EKWJL5dI2cp37dZhXt/xS1l9me42ENDg==",
       "dependencies": {
         "@aws-crypto/sha256-js": "1.2.2",
         "buffer": "4.9.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     ]
   },
   "dependencies": {
-    "@aws-amplify/auth": "^5.6.2",
+    "@aws-amplify/auth": "^5.6.1",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@fontsource/roboto": "^5.0.8",


### PR DESCRIPTION
Reverts BIBSYSDEV/NVA-Frontend#4417

v5.6.2 ser ut til å brekke innlogging atm