### PR TITLE
Handle missing aggregation values

### DIFF
--- a/src/pages/search/registration_search/RegistrationSearchBar.tsx
+++ b/src/pages/search/registration_search/RegistrationSearchBar.tsx
@@ -161,7 +161,7 @@ export const RegistrationSearchBar = ({ aggregations }: RegistrationSearchBarPro
                       fieldValueText = t(`registration.publication_types.${property.value as PublicationInstanceType}`);
                       break;
                     case SearchFieldName.ContributorId: {
-                      const personName = aggregations.entityDescription.contributors.identity.id.buckets.find(
+                      const personName = aggregations.entityDescription?.contributors?.identity?.id?.buckets.find(
                         (bucket) => bucket.key === property.value
                       )?.name.buckets[0].key;
                       if (personName) {
@@ -176,7 +176,7 @@ export const RegistrationSearchBar = ({ aggregations }: RegistrationSearchBarPro
                       break;
                     }
                     case SearchFieldName.TopLevelOrganizationId: {
-                      const institutionLabels = aggregations.topLevelOrganizations.id.buckets.find(
+                      const institutionLabels = aggregations.topLevelOrganizations?.id?.buckets.find(
                         (bucket) => bucket.key === property.value
                       );
                       const institutionName = institutionLabels ? getLabelFromBucket(institutionLabels) : '';
@@ -192,7 +192,7 @@ export const RegistrationSearchBar = ({ aggregations }: RegistrationSearchBarPro
                       break;
                     }
                     case SearchFieldName.FundingSource: {
-                      const fundingLabels = aggregations.fundings.identifier.buckets.find(
+                      const fundingLabels = aggregations.fundings?.identifier?.buckets.find(
                         (bucket) => bucket.key === property.value
                       );
                       const fundingName = fundingLabels ? getLabelFromBucket(fundingLabels) : '';

--- a/src/pages/search/registration_search/filters/RegistrationFacetsFilter.tsx
+++ b/src/pages/search/registration_search/filters/RegistrationFacetsFilter.tsx
@@ -47,14 +47,14 @@ export const RegistrationFacetsFilter = ({ aggregations, isLoadingSearch }: Regi
     submitForm();
   };
 
-  const topLevelOrganizationFacet = aggregations.topLevelOrganizations.id;
-  const typeFacet = aggregations.entityDescription.reference.publicationInstance.type;
-  const contributorFacet = aggregations.entityDescription.contributors.identity.id;
-  const fundingFacet = aggregations.fundings.identifier;
+  const topLevelOrganizationFacet = aggregations.topLevelOrganizations?.id;
+  const typeFacet = aggregations.entityDescription?.reference?.publicationInstance?.type;
+  const contributorFacet = aggregations.entityDescription?.contributors?.identity?.id;
+  const fundingFacet = aggregations.fundings?.identifier;
 
   return (
     <>
-      {typeFacet.buckets.length > 0 && (
+      {typeFacet && typeFacet.buckets.length > 0 && (
         <FacetItem title={t('common.category')} dataTestId={dataTestId.startPage.typeFacets}>
           {typeFacet.buckets.map((bucket) => {
             const registrationType = bucket.key as PublicationInstanceType;
@@ -75,7 +75,7 @@ export const RegistrationFacetsFilter = ({ aggregations, isLoadingSearch }: Regi
         </FacetItem>
       )}
 
-      {topLevelOrganizationFacet.buckets.length > 0 && (
+      {topLevelOrganizationFacet && topLevelOrganizationFacet.buckets.length > 0 && (
         <FacetItem title={t('common.institution')} dataTestId={dataTestId.startPage.institutionFacets}>
           {topLevelOrganizationFacet.buckets.map((bucket) => (
             <ListItem
@@ -96,7 +96,7 @@ export const RegistrationFacetsFilter = ({ aggregations, isLoadingSearch }: Regi
         </FacetItem>
       )}
 
-      {contributorFacet.buckets.length > 0 && (
+      {contributorFacet && contributorFacet.buckets.length > 0 && (
         <FacetItem
           title={t('registration.contributors.contributor')}
           dataTestId={dataTestId.startPage.contributorFacets}>
@@ -121,7 +121,7 @@ export const RegistrationFacetsFilter = ({ aggregations, isLoadingSearch }: Regi
         </FacetItem>
       )}
 
-      {fundingFacet.buckets.length > 0 && (
+      {fundingFacet && fundingFacet.buckets.length > 0 && (
         <FacetItem title={t('common.funding')} dataTestId={dataTestId.startPage.institutionFacets}>
           {fundingFacet.buckets.map((bucket) => (
             <ListItem disablePadding key={bucket.key} data-testid={dataTestId.startPage.facetItem(bucket.key)}>

--- a/src/types/registration.types.ts
+++ b/src/types/registration.types.ts
@@ -266,29 +266,29 @@ interface ContributorAggregationBucket extends AggregationBucket {
 }
 
 export interface RegistrationAggregations {
-  topLevelOrganizations: {
-    id: {
+  topLevelOrganizations?: {
+    id?: {
       buckets: LabelAggregationBucket[];
     };
   };
-  entityDescription: {
-    reference: {
-      publicationInstance: {
-        type: {
+  entityDescription?: {
+    reference?: {
+      publicationInstance?: {
+        type?: {
           buckets: AggregationBucket[];
         };
       };
     };
-    contributors: {
-      identity: {
-        id: {
+    contributors?: {
+      identity?: {
+        id?: {
           buckets: ContributorAggregationBucket[];
         };
       };
     };
   };
-  fundings: {
-    identifier: {
+  fundings?: {
+    identifier?: {
       buckets: LabelAggregationBucket[];
     };
   };


### PR DESCRIPTION
Aggregeringene har en tendens til å forsvinne og bytte navn, så setter alt til optional slik at frontend ikke krasjer når det skjer

Fortsettelse av hotfix: https://github.com/BIBSYSDEV/NVA-Frontend/pull/4537