### PR TITLE
Np 45532 advanced filters layout

### DIFF
--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -138,21 +138,20 @@ const SearchPage = () => {
                 sx={{
                   display: 'grid',
                   gridTemplateColumns: { sm: '1fr', md: 'auto 1fr' },
-                  gap: '0.5rem',
+                  gap: '1rem 0.5rem',
+                  mx: { xs: '1rem', md: 0 },
                 }}>
                 <TextField
                   select
                   value={!paramsSearchType ? SearchTypeValue.Result : paramsSearchType}
                   sx={{
                     mb: !resultIsSelected ? '1rem' : 0,
-                    ml: { xs: '1rem', md: 0 },
-                    minWidth: '10.33rem',
+                    minWidth: '10rem',
                     '.MuiSelect-select': {
                       display: 'flex',
                       gap: '0.5rem',
                       alignItems: 'center',
                       bgcolor: personIsSeleced || projectIsSelected ? `${paramsSearchType}.main` : 'registration.main',
-                      maxHeight: '1rem',
                     },
                   }}
                   inputProps={{ 'aria-label': t('common.type') }}>
@@ -180,7 +179,7 @@ const SearchPage = () => {
                         setValues(emptySearchConfig);
                       }
                     }}>
-                    <PersonIcon />
+                    <PersonIcon fontSize="small" />
                     {t('search.persons')}
                   </MenuItem>
                   <MenuItem
@@ -194,7 +193,7 @@ const SearchPage = () => {
                         setValues(emptySearchConfig);
                       }
                     }}>
-                    <ShowChartIcon />
+                    <ShowChartIcon fontSize="small" />
                     {t('project.project')}
                   </MenuItem>
                 </TextField>

--- a/src/pages/search/registration_search/RegistrationSearchBar.tsx
+++ b/src/pages/search/registration_search/RegistrationSearchBar.tsx
@@ -99,9 +99,7 @@ export const RegistrationSearchBar = ({ aggregations }: RegistrationSearchBarPro
       <FieldArray name="properties">
         {({ push, remove }: FieldArrayRenderProps) => (
           <>
-            <Box
-              gridArea="advanced"
-              sx={{ display: 'flex', flexDirection: 'column', gap: '1rem', ml: { sm: 0, md: '-10.8rem' } }}>
+            <Box gridArea="advanced" sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
               {properties.map((property, index) => {
                 const thisFilter = registrationFilters.find((filter) => filter.field === property.fieldName);
                 if (property.fieldName && !thisFilter?.manuallyAddable) {

--- a/src/pages/search/registration_search/RegistrationSearchBar.tsx
+++ b/src/pages/search/registration_search/RegistrationSearchBar.tsx
@@ -43,10 +43,6 @@ export const RegistrationSearchBar = ({ aggregations }: RegistrationSearchBarPro
   return (
     <Box
       sx={{
-        mx: {
-          xs: '1rem',
-          md: 0,
-        },
         display: 'grid',
         gridTemplateColumns: { xs: '1fr', md: '5fr auto auto' },
         gridTemplateAreas: {


### PR DESCRIPTION
Før:
![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/5cb20312-3380-4f38-b49c-f3a39831d517)


Etter:
![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/d1a840ea-5e9c-4ffe-9f20-aaa615e2bdad)

Usikker på om vi ønsker innrykk på alt, men dette er en veldig rask løsning for å fikse bugen i hvert fall, så kan vi fikse designet i etterkant