### PR TITLE
Open files in iOS Safari

### DIFF
--- a/src/pages/public_registration/public_files/FileRow.tsx
+++ b/src/pages/public_registration/public_files/FileRow.tsx
@@ -59,7 +59,10 @@ export const FileRow = ({
         if (previewFile) {
           setPreviewFileUrl(downloadFileResponse.id);
         } else {
-          window.open(downloadFileResponse.id, '_blank');
+          // Use timeout to ensure that file is opened on Safari/iOS: NP-30205, https://stackoverflow.com/a/70463940
+          setTimeout(() => {
+            window.open(downloadFileResponse.id, '_blank');
+          });
         }
       }
       previewFile && setIsLoadingPreviewFile(false);


### PR DESCRIPTION
Safari på iOS krever at man åpner eksterne domener på main thread, så dette er en workaround for at det skal virke på alle enheter.