### PR TITLE
Allow DOI fetch that does not return type

### DIFF
--- a/src/utils/registration-helpers.ts
+++ b/src/utils/registration-helpers.ts
@@ -605,7 +605,7 @@ export const userCanEditRegistration = (user: User | null, registration: Registr
   }
 
   const isValidCurator = userIsRegistrationCurator(user, registration);
-  if (isDegreeWithProtectedFiles(registration.entityDescription?.reference?.publicationInstance.type)) {
+  if (isDegreeWithProtectedFiles(registration.entityDescription?.reference?.publicationInstance?.type)) {
     return isValidCurator && user.isThesisCurator;
   }
 


### PR DESCRIPTION
Unngå at det krasjer når bruker oppgir DOI til et datasett, eller andre typer vi ikke håndterer i /doi-fetch enda