### PR TITLE
Np 45655 test env banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { AppRoutes } from './AppRoutes';
 import { getCurrentUserAttributes } from './api/authApi';
 import { CreateCristinPersonDialog } from './components/CreateCristinPersonDialog';
+import { EnvironmentBanner } from './components/EnvironmentBanner';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { PageSpinner } from './components/PageSpinner';
 import { SelectCustomerInstitutionDialog } from './components/SelectCustomerInstitutionDialog';
@@ -105,6 +106,7 @@ export const App = () => {
             <Notifier />
             <SkipLink href="#main-content">{t('common.skip_to_main_content')}</SkipLink>
             <Header />
+            <EnvironmentBanner />
             <Box
               component="main"
               id="main-content"

--- a/src/components/EnvironmentBanner.tsx
+++ b/src/components/EnvironmentBanner.tsx
@@ -16,6 +16,7 @@ export const EnvironmentBanner = () => {
 
   return hostnameIsTestEnvironment && defaultBannerState !== 'none' ? (
     <Box
+      component="aside"
       sx={{ background: '#ffd45a', p: '0.5rem', cursor: 'pointer' }}
       onClick={() => {
         const newMinimizeBannerState = !minimizeBanner;

--- a/src/components/EnvironmentBanner.tsx
+++ b/src/components/EnvironmentBanner.tsx
@@ -1,19 +1,27 @@
 import { Box, Typography } from '@mui/material';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { LocalStorageKey } from '../utils/constants';
 
 const testEnvironments = ['localhost', 'dev', 'test', 'sandbox', 'e2e'];
 const hostname = window.location.hostname;
-const hostnameIsTestEnvironment = testEnvironments.some((testEnvironment) => hostname.startsWith(testEnvironment));
+const hostnameIsTestEnvironment =
+  hostname && testEnvironments.some((testEnvironment) => hostname.startsWith(testEnvironment));
+const defaultBannerState = localStorage.getItem(LocalStorageKey.EnvironmentBanner);
 
 export const EnvironmentBanner = () => {
   const { t } = useTranslation();
-  const [minimizeBanner, setMinimizeBanner] = useState(false);
 
-  return hostnameIsTestEnvironment ? (
+  const [minimizeBanner, setMinimizeBanner] = useState(defaultBannerState === 'minimized');
+
+  return hostnameIsTestEnvironment && defaultBannerState !== 'none' ? (
     <Box
       sx={{ background: '#ffd45a', p: '0.5rem', cursor: 'pointer' }}
-      onClick={() => setMinimizeBanner(!minimizeBanner)}>
+      onClick={() => {
+        const newMinimizeBannerState = !minimizeBanner;
+        setMinimizeBanner(newMinimizeBannerState);
+        localStorage.setItem(LocalStorageKey.EnvironmentBanner, newMinimizeBannerState ? 'minimized' : 'normal');
+      }}>
       {!minimizeBanner && (
         <Typography sx={{ textAlign: 'center' }}>
           {t('common.test_environment')} ({hostname})

--- a/src/components/EnvironmentBanner.tsx
+++ b/src/components/EnvironmentBanner.tsx
@@ -1,0 +1,16 @@
+import { Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+const testEnvironments = ['localhost', 'dev', 'test', 'sandbox', 'e2e'];
+const hostname = window.location.hostname;
+const hostnameIsTestEnvironment = testEnvironments.some((testEnvironment) => hostname.startsWith(testEnvironment));
+
+export const EnvironmentBanner = () => {
+  const { t } = useTranslation();
+
+  return hostnameIsTestEnvironment ? (
+    <Typography sx={{ textAlign: 'center', background: '#ffd45a', p: '0.25rem' }}>
+      {t('common.test_environment')} ({hostname})
+    </Typography>
+  ) : null;
+};

--- a/src/components/EnvironmentBanner.tsx
+++ b/src/components/EnvironmentBanner.tsx
@@ -1,4 +1,5 @@
-import { Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 const testEnvironments = ['localhost', 'dev', 'test', 'sandbox', 'e2e'];
@@ -7,10 +8,17 @@ const hostnameIsTestEnvironment = testEnvironments.some((testEnvironment) => hos
 
 export const EnvironmentBanner = () => {
   const { t } = useTranslation();
+  const [minimizeBanner, setMinimizeBanner] = useState(false);
 
   return hostnameIsTestEnvironment ? (
-    <Typography sx={{ textAlign: 'center', background: '#ffd45a', p: '0.25rem' }}>
-      {t('common.test_environment')} ({hostname})
-    </Typography>
+    <Box
+      sx={{ background: '#ffd45a', p: '0.5rem', cursor: 'pointer' }}
+      onClick={() => setMinimizeBanner(!minimizeBanner)}>
+      {!minimizeBanner && (
+        <Typography sx={{ textAlign: 'center' }}>
+          {t('common.test_environment')} ({hostname})
+        </Typography>
+      )}
+    </Box>
   ) : null;
 };

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -225,6 +225,7 @@
     "start_date": "Startdato",
     "start_page": "Startside",
     "tasks": "Oppgaver",
+    "test_environment": "Testmiljø",
     "title": "Tittel",
     "today": "I dag",
     "type": "Type",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -23,6 +23,7 @@ export enum LocalStorageKey {
   AppUpdateTime = 'appUpdateTime',
   AmplifyRedirect = 'amplify-redirected-from-hosted-ui',
   Beta = 'beta',
+  EnvironmentBanner = 'environmentBanner',
   ExpiredToken = 'expiredToken',
   ShowTagline = 'showTagline',
   RedirectPath = 'redirect-path',


### PR DESCRIPTION
Normal:
![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/a01afa79-ef1d-45e0-a85e-f827c7d0c7ed)

Mimimert:
![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/2bea678a-5700-444a-93a2-c4e46777f9de)

Kan også fjernes ved å sette `environmentBanner: none` i localstorage.

Kan lure seg rundt dette ved å trikse med `hosts`-fila e.l. for å manipulere URL, men hva har man å tjene på det 🤷‍♂️ 