### PR TITLE
Wrap long file names

### DIFF
--- a/src/pages/public_registration/public_files/FileRow.tsx
+++ b/src/pages/public_registration/public_files/FileRow.tsx
@@ -160,7 +160,7 @@ export const FileRow = ({
             <Typography
               id={`preview-label-${file.identifier}`}
               data-testid={dataTestId.registrationLandingPage.filePreviewHeader}
-              sx={{ fontWeight: 500 }}>
+              sx={{ fontWeight: 500, lineBreak: 'anywhere' }}>
               {t('registration.public_page.preview_of', { fileName: file.name })}
             </Typography>
           </AccordionSummary>


### PR DESCRIPTION
Før:
![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/bfb6a455-468e-4409-ac11-e26de78c74f1)


Etter:
![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/2244c32e-acab-4f3a-8497-a3c8758b70db)
