### PR TITLE
NP-45938 Remove toLowerCase() from doi url start

### DIFF
--- a/src/pages/registration/new_registration/LinkRegistration.tsx
+++ b/src/pages/registration/new_registration/LinkRegistration.tsx
@@ -98,7 +98,7 @@ export const LinkRegistration = ({ expanded, onChange }: StartRegistrationAccord
   const isLookingUpDoi = resultsQuery.isFetching || mutateDoi.isLoading;
 
   const onSubmit = async (values: DoiFormValues, { setValues }: FormikHelpers<DoiFormValues>) => {
-    let doiUrl = values.link.trim().toLowerCase();
+    let doiUrl = values.link.trim();
 
     if (!isValidUrl(doiUrl)) {
       const regexMatch = doiRegExp.exec(doiUrl);


### PR DESCRIPTION
Url parameters are case sensitive, which means that toLowerCase() will return 404 whenever provided url contains upper case letters. 