### PR TITLE
NP-46004 Fix ISBN parsing bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "i18n-iso-countries": "^7.7.0",
         "i18next": "^22.5.1",
         "i18next-browser-languagedetector": "^7.2.0",
-        "isbn-utils": "^1.1.0",
+        "isbn3": "^1.1.44",
         "nva-language": "^1.0.15",
         "pretty-bytes": "^6.1.1",
         "react": "^18.2.0",
@@ -16259,12 +16259,17 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
-    "node_modules/isbn-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/isbn-utils/-/isbn-utils-1.1.0.tgz",
-      "integrity": "sha512-IrWfYWHqRficGId19f3d6h0zTdBYp/jToRcg/0LVLtonSR+sIxj+chWb9qdQAN3WYydMmHTtKDvTqeUO4XyzAA==",
+    "node_modules/isbn3": {
+      "version": "1.1.44",
+      "resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.1.44.tgz",
+      "integrity": "sha512-lHwBx85hTHPwtSHrieC+AG73doLOIpNbb6OEchh3v2MZrxKJ+HN24ksgparYjRRgNtzVxzuNQd8VBZMEBxcMBw==",
+      "bin": {
+        "isbn": "bin/isbn",
+        "isbn-audit": "bin/isbn-audit",
+        "isbn-checksum": "bin/isbn-checksum"
+      },
       "engines": {
-        "node": ">=0.6"
+        "node": ">= 6.4.0"
       }
     },
     "node_modules/isexe": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "i18n-iso-countries": "^7.7.0",
     "i18next": "^22.5.1",
     "i18next-browser-languagedetector": "^7.2.0",
-    "isbn-utils": "^1.1.0",
+    "isbn3": "^1.1.44",
     "nva-language": "^1.0.15",
     "pretty-bytes": "^6.1.1",
     "react": "^18.2.0",

--- a/src/pages/public_registration/PublicPublicationContext.tsx
+++ b/src/pages/public_registration/PublicPublicationContext.tsx
@@ -20,7 +20,7 @@ import {
 } from '@mui/material';
 import { visuallyHidden } from '@mui/utils';
 import { useQuery } from '@tanstack/react-query';
-import { hyphenate } from 'isbn-utils';
+import { hyphenate } from 'isbn3';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';

--- a/src/pages/public_registration/PublicPublicationInstance.tsx
+++ b/src/pages/public_registration/PublicPublicationInstance.tsx
@@ -1,5 +1,5 @@
 import { Typography } from '@mui/material';
-import { hyphenate as hyphenateIsbn } from 'isbn-utils';
+import { hyphenate } from 'isbn3';
 import { useTranslation } from 'react-i18next';
 import i18n from '../../translations/i18n';
 import { ArtisticType } from '../../types/publicationFieldNames';
@@ -170,7 +170,7 @@ export const PublicIsbnContent = ({ isbnList }: { isbnList?: string[] }) => {
       {t('registration.resource_type.isbn')}:{' '}
       {isbnList
         .filter((isbn) => isbn)
-        .map((isbn) => hyphenateIsbn(isbn))
+        .map((isbn) => hyphenate(isbn))
         .join(', ')}
     </Typography>
   ) : null;

--- a/src/utils/validation/registration/referenceValidation.ts
+++ b/src/utils/validation/registration/referenceValidation.ts
@@ -1,4 +1,4 @@
-import { parse as parseIsbn } from 'isbn-utils';
+import { parse as parseIsbn } from 'isbn3';
 import * as Yup from 'yup';
 import i18n from '../../../translations/i18n';
 import {
@@ -163,7 +163,7 @@ export const emptyStringToNull = (value: string, originalValue: string) => (orig
 export const isbnListField = Yup.array().of(
   Yup.string()
     .min(13, resourceErrorMessage.isbnTooShort)
-    .test('isbn-test', resourceErrorMessage.isbnInvalid, (isbn) => !isbn || !!parseIsbn(isbn ?? '')?.isIsbn13())
+    .test('isbn-test', resourceErrorMessage.isbnInvalid, (isbn) => !isbn || !!parseIsbn(isbn ?? ''))
 );
 
 const pagesMonographField = Yup.object()


### PR DESCRIPTION
Erstatt https://www.npmjs.com/package/isbn-utils med https://www.npmjs.com/package/isbn3, da førstnevte er gammel og viser seg og å ikke håndtere alle ISBNer