### PR TITLE
Limit who is set as assignee to version bumps

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
+* @elkebab @iBuzza @joachimjorgensen @anetteOlli @torbjokv @truhacevkir
+
 /package.json @elkebab @iBuzza
 /package-lock.json @elkebab @iBuzza
-
-* @elkebab @iBuzza @joachimjorgensen @anetteOlli @torbjokv @truhacevkir @siricv


### PR DESCRIPTION
Misforsto presedensen i `CODEOWNERS`, da det viser seg at den siste tar presedens (ikke første som jeg trodde). Da håper jeg dette gjør at alle ikke settes til assignee for PRs fra dependabot