### PR TITLE
NP-46943 Ignore special files on pre-commit prettier hook

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,3 +1,3 @@
 {
-  "*": "prettier --write"
+  "*.{ts,tsx,js,jsx,json,html,md,json,txt,yml}": "prettier --write"
 }


### PR DESCRIPTION
Unngå error på prettier fra pre-commit hook når vi committer filer som ikke har noen prettier formatter, som feks `CODEOWNERS`, `.svg`, etc