### PR TITLE
Handle UnconfirmedOrganization on import candidate

### DIFF
--- a/src/pages/basic_data/app_admin/central_import/CentralImportResultItem.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportResultItem.tsx
@@ -73,7 +73,12 @@ export const CentralImportResultItem = ({ importCandidate }: CentralImportResult
 
           {importCandidate.organizations.length > 0 && (
             <Typography sx={{ mt: '0.5rem' }}>
-              {importCandidate.organizations.map((organization) => getLanguageString(organization.labels)).join(', ')}
+              {importCandidate.organizations
+                .map((organization) =>
+                  organization.type === 'Organization' ? getLanguageString(organization.labels) : organization.name
+                )
+                .filter(Boolean)
+                .join(', ')}
             </Typography>
           )}
         </ListItemText>

--- a/src/types/importCandidate.types.ts
+++ b/src/types/importCandidate.types.ts
@@ -1,3 +1,4 @@
+import { UnconfirmedOrganization } from './common.types';
 import { Contributor } from './contributor.types';
 import { Organization } from './organization.types';
 import { ArtisticPublicationInstance } from './publication_types/artisticRegistration.types';
@@ -48,7 +49,7 @@ export interface ImportCandidateSummary {
   mainTitle: string;
   totalContributors: number;
   totalVerifiedContributors: number;
-  organizations: Omit<Organization, 'acronym'>[];
+  organizations: (Pick<Organization, 'type' | 'id' | 'labels'> | UnconfirmedOrganization)[];
   publisher: Pick<Publisher, 'id' | 'name'>;
   journal: Pick<Journal, 'id'>;
   publicationInstance: PublicationInstance;


### PR DESCRIPTION
Håndter `UnconfirmedOrganization` på importkandidat. Egen task på backend å ekspandere `organization` i søket, slik at også bekreftede orgs vil vises som forventet.