### PR TITLE
Handle empty mime type

### DIFF
--- a/src/pages/public_registration/public_files/preview_file/PreviewFile.tsx
+++ b/src/pages/public_registration/public_files/preview_file/PreviewFile.tsx
@@ -18,7 +18,7 @@ const isOfficeFile = (mimeType: string) => mimeType.startsWith('application/vnd.
 const isPdf = (mimeType: string) => mimeType === 'application/pdf';
 
 export const PreviewFile = ({ url, file, ...props }: PreviewFileProps) => {
-  const mimeType = file.mimeType.toLowerCase();
+  const mimeType = file.mimeType?.toLowerCase() ?? '';
 
   return isPdf(mimeType) ? (
     <PreviewPdf url={url} altText={file.name} {...props} />

--- a/src/types/associatedArtifact.types.ts
+++ b/src/types/associatedArtifact.types.ts
@@ -7,7 +7,7 @@ export interface AssociatedFile {
   identifier: string;
   name: string;
   size: number;
-  mimeType: string;
+  mimeType?: string;
   administrativeAgreement: boolean;
   publisherAuthority: boolean | null;
   embargoDate: Date | null;


### PR DESCRIPTION
Unngå at importerte filer uten mime-type krasjer. eks: https://dev.nva.sikt.no/registration/018d365a3dea-a241879e-89d4-40cb-bd43-1313596752f8