### PR TITLE
NP-45607 Handle error based on response

### DIFF
--- a/src/QueryProvider.tsx
+++ b/src/QueryProvider.tsx
@@ -25,8 +25,13 @@ export const QueryProvider = ({ children }: QueryProviderProps) => {
       queryCache: new QueryCache({
         onError: (error: any, query) => {
           const queryErrorMessage = query.meta?.errorMessage;
+          const handleError = query.meta?.handleError;
+          if (handleError && typeof handleError === 'function') {
+            handleError(error, query);
+            return;
+          }
 
-          if (queryErrorMessage === false) {
+          if (!queryErrorMessage) {
             return;
           }
 


### PR DESCRIPTION
Misliker løsningen sterkt, men beste jeg kommer opp med sånn flyten er nå (i nøden spiser fanden fluer). I praksis blir det en workaround for å erstatte `onError` som er deprecated, og fjernet i v5.
Jeg mener at dette ikke skal påvirke noe annet enn de ytterst få tilfellene som faktisk vil returnere `410 Gone` med dette