### PR TITLE
NP-46072 Add list item counter above search lists

### DIFF
--- a/src/components/ListPagination.tsx
+++ b/src/components/ListPagination.tsx
@@ -2,6 +2,7 @@ import { Box, BoxProps, MenuItem, Pagination, PaginationItem, Select, Typography
 import { useTranslation } from 'react-i18next';
 import { ROWS_PER_PAGE_OPTIONS } from '../utils/constants';
 import { dataTestId } from '../utils/dataTestIds';
+import { ListPaginationCounter } from './ListPaginationCounter';
 
 interface ListPaginationProps extends Pick<BoxProps, 'sx'> {
   count: number;
@@ -29,8 +30,8 @@ export const ListPagination = ({
   const totalPages = Math.ceil(count / rowsPerPage);
   const pages = Math.min(maxPages, totalPages);
 
-  const itemsStart = count > 0 ? ((page - 1) * rowsPerPage + 1).toLocaleString() : '0';
-  const itemsEnd = Math.min(page * rowsPerPage, count).toLocaleString();
+  const itemsStart = count > 0 ? (page - 1) * rowsPerPage + 1 : 0;
+  const itemsEnd = Math.min(page * rowsPerPage, count);
 
   return (
     <Box
@@ -44,9 +45,7 @@ export const ListPagination = ({
         ...sx,
       }}
       data-testid={dataTestId.common.pagination}>
-      <Typography aria-live="polite">
-        {t('common.pagination_showing_interval', { start: itemsStart, end: itemsEnd, total: count.toLocaleString() })}
-      </Typography>
+      <ListPaginationCounter start={itemsStart} end={itemsEnd} total={count} />
 
       <Pagination
         sx={{

--- a/src/components/ListPaginationCounter.tsx
+++ b/src/components/ListPaginationCounter.tsx
@@ -1,0 +1,22 @@
+import { Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+interface ListPaginationCounterProps {
+  start: number;
+  end: number;
+  total: number;
+}
+
+export const ListPaginationCounter = ({ start, end, total }: ListPaginationCounterProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <Typography aria-live="polite">
+      {t('common.pagination_showing_interval', {
+        start: start.toLocaleString(),
+        end: end.toLocaleString(),
+        total: total.toLocaleString(),
+      })}
+    </Typography>
+  );
+};

--- a/src/components/ListPaginationTop.tsx
+++ b/src/components/ListPaginationTop.tsx
@@ -1,0 +1,27 @@
+import { Box, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+interface ListPaginationTopProps {
+  count: number;
+  rowsPerPage: number;
+  page: number;
+}
+
+export const ListPaginationTop = ({ count, rowsPerPage, page }: ListPaginationTopProps) => {
+  const { t } = useTranslation();
+
+  const itemsStart = count > 0 ? ((page - 1) * rowsPerPage + 1).toLocaleString() : '0';
+  const itemsEnd = Math.min(page * rowsPerPage, count).toLocaleString();
+
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'end' }}>
+      <Typography aria-live="polite">
+        {t('common.pagination_showing_interval', {
+          start: itemsStart,
+          end: itemsEnd,
+          total: count.toLocaleString(),
+        })}
+      </Typography>
+    </Box>
+  );
+};

--- a/src/components/ListPaginationTop.tsx
+++ b/src/components/ListPaginationTop.tsx
@@ -1,5 +1,5 @@
-import { Box, Typography } from '@mui/material';
-import { useTranslation } from 'react-i18next';
+import { Box } from '@mui/material';
+import { ListPaginationCounter } from './ListPaginationCounter';
 
 interface ListPaginationTopProps {
   count: number;
@@ -8,20 +8,12 @@ interface ListPaginationTopProps {
 }
 
 export const ListPaginationTop = ({ count, rowsPerPage, page }: ListPaginationTopProps) => {
-  const { t } = useTranslation();
-
-  const itemsStart = count > 0 ? ((page - 1) * rowsPerPage + 1).toLocaleString() : '0';
-  const itemsEnd = Math.min(page * rowsPerPage, count).toLocaleString();
+  const itemsStart = count > 0 ? (page - 1) * rowsPerPage + 1 : 0;
+  const itemsEnd = Math.min(page * rowsPerPage, count);
 
   return (
     <Box sx={{ display: 'flex', justifyContent: 'end' }}>
-      <Typography aria-live="polite">
-        {t('common.pagination_showing_interval', {
-          start: itemsStart,
-          end: itemsEnd,
-          total: count.toLocaleString(),
-        })}
-      </Typography>
+      <ListPaginationCounter start={itemsStart} end={itemsEnd} total={count} />
     </Box>
   );
 };

--- a/src/pages/search/CristinSearchPagination.tsx
+++ b/src/pages/search/CristinSearchPagination.tsx
@@ -1,19 +1,16 @@
 import { useHistory } from 'react-router-dom';
 import { ListPagination } from '../../components/ListPagination';
-import { ROWS_PER_PAGE_OPTIONS } from '../../utils/constants';
 import { SearchParam } from '../../utils/searchHelpers';
 
 interface CristinSearchPaginationProps {
   totalCount: number;
+  page: number;
+  rowsPerPage: number;
 }
 
-export const CristinSearchPagination = ({ totalCount }: CristinSearchPaginationProps) => {
+export const CristinSearchPagination = ({ totalCount, page, rowsPerPage }: CristinSearchPaginationProps) => {
   const history = useHistory();
   const params = new URLSearchParams(history.location.search);
-  const resultsParam = params.get(SearchParam.Results);
-  const pageParam = params.get(SearchParam.Page);
-
-  const rowsPerPage = resultsParam ? +resultsParam : ROWS_PER_PAGE_OPTIONS[0];
 
   const updatePath = (page: string, results: string) => {
     params.set(SearchParam.Page, page);
@@ -24,7 +21,7 @@ export const CristinSearchPagination = ({ totalCount }: CristinSearchPaginationP
   return (
     <ListPagination
       count={totalCount}
-      page={pageParam ? +pageParam : 1}
+      page={page}
       onPageChange={(newPage) => updatePath(newPage.toString(), rowsPerPage.toString())}
       rowsPerPage={rowsPerPage}
       onRowsPerPageChange={(newRowsPerPage) => updatePath('1', newRowsPerPage.toString())}

--- a/src/pages/search/person_search/PersonSearch.tsx
+++ b/src/pages/search/person_search/PersonSearch.tsx
@@ -1,6 +1,10 @@
 import { Box, List, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router-dom';
 import { ListSkeleton } from '../../../components/ListSkeleton';
+import { ListPaginationTop } from '../../../components/ListPaginationTop';
+import { ROWS_PER_PAGE_OPTIONS } from '../../../utils/constants';
+import { SearchParam } from '../../../utils/searchHelpers';
 import { CristinSearchPagination } from '../CristinSearchPagination';
 import { SearchPageProps } from '../SearchPage';
 import { PersonListItem } from './PersonListItem';
@@ -11,6 +15,15 @@ export const PersonSearch = ({ personQuery }: PersonSearchProps) => {
   const { t } = useTranslation();
 
   const searchResults = personQuery.data?.hits ?? [];
+  const totalHits = personQuery.data?.size ?? 0;
+
+  const history = useHistory();
+  const params = new URLSearchParams(history.location.search);
+  const resultsParam = params.get(SearchParam.Results);
+  const pageParam = params.get(SearchParam.Page);
+  const page = pageParam ? +pageParam : 1;
+
+  const rowsPerPage = resultsParam ? +resultsParam : ROWS_PER_PAGE_OPTIONS[0];
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
@@ -18,12 +31,13 @@ export const PersonSearch = ({ personQuery }: PersonSearchProps) => {
         <ListSkeleton arrayLength={3} minWidth={40} height={100} />
       ) : searchResults && searchResults.length > 0 ? (
         <div>
+          <ListPaginationTop count={totalHits} page={page} rowsPerPage={rowsPerPage} />
           <List>
             {searchResults.map((person) => (
               <PersonListItem key={person.id} person={person} />
             ))}
           </List>
-          <CristinSearchPagination totalCount={personQuery.data?.size ?? 0} />
+          <CristinSearchPagination totalCount={totalHits} page={page} rowsPerPage={rowsPerPage} />
         </div>
       ) : (
         <Typography sx={{ mx: { xs: '0.5rem', md: 0 } }}>{t('common.no_hits')}</Typography>

--- a/src/pages/search/project_search/ProjectSearch.tsx
+++ b/src/pages/search/project_search/ProjectSearch.tsx
@@ -1,6 +1,10 @@
 import { Box, List, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router-dom';
 import { ListSkeleton } from '../../../components/ListSkeleton';
+import { ListPaginationTop } from '../../../components/ListPaginationTop';
+import { ROWS_PER_PAGE_OPTIONS } from '../../../utils/constants';
+import { SearchParam } from '../../../utils/searchHelpers';
 import { CristinSearchPagination } from '../CristinSearchPagination';
 import { SearchPageProps } from '../SearchPage';
 import { ProjectListItem } from './ProjectListItem';
@@ -11,6 +15,15 @@ export const ProjectSearch = ({ projectQuery }: ProjectSearchProps) => {
   const { t } = useTranslation();
 
   const projectsSearchResults = projectQuery.data?.hits ?? [];
+  const totalHits = projectQuery.data?.size ?? 0;
+
+  const history = useHistory();
+  const params = new URLSearchParams(history.location.search);
+  const resultsParam = params.get(SearchParam.Results);
+  const pageParam = params.get(SearchParam.Page);
+  const page = pageParam ? +pageParam : 1;
+
+  const rowsPerPage = resultsParam ? +resultsParam : ROWS_PER_PAGE_OPTIONS[0];
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
@@ -18,12 +31,13 @@ export const ProjectSearch = ({ projectQuery }: ProjectSearchProps) => {
         <ListSkeleton arrayLength={3} minWidth={40} height={100} />
       ) : projectsSearchResults && projectsSearchResults.length > 0 ? (
         <div>
+          <ListPaginationTop count={totalHits} page={page} rowsPerPage={rowsPerPage} />
           <List>
             {projectsSearchResults.map((project) => (
               <ProjectListItem key={project.id} project={project} />
             ))}
           </List>
-          <CristinSearchPagination totalCount={projectQuery.data?.size ?? 0} />
+          <CristinSearchPagination totalCount={totalHits} page={page} rowsPerPage={rowsPerPage} />
         </div>
       ) : (
         <Typography sx={{ mx: { xs: '0.5rem', md: 0 } }}>{t('common.no_hits')}</Typography>

--- a/src/pages/search/registration_search/RegistrationSearch.tsx
+++ b/src/pages/search/registration_search/RegistrationSearch.tsx
@@ -2,6 +2,7 @@ import { Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { ListPagination } from '../../../components/ListPagination';
+import { ListPaginationTop } from '../../../components/ListPaginationTop';
 import { ListSkeleton } from '../../../components/ListSkeleton';
 import { ROWS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 import { SearchParam } from '../../../utils/searchHelpers';
@@ -31,6 +32,7 @@ export const RegistrationSearch = ({ registrationQuery }: Pick<SearchPageProps, 
         <ListSkeleton arrayLength={3} minWidth={40} height={100} />
       ) : registrationQuery.data?.hits && registrationQuery.data.hits.length > 0 ? (
         <>
+          <ListPaginationTop count={registrationQuery.data.totalHits} page={page + 1} rowsPerPage={rowsPerPage} />
           <RegistrationSearchResults searchResult={registrationQuery.data.hits} />
           <ListPagination
             count={registrationQuery.data.totalHits}


### PR DESCRIPTION
This is a temporary fix until the entire `<ListPagination />` component is altered to wrap lists instead of being appended to lists.

Project and Person search utilizes a `<CristinSearchPagination />` component as a middle man in between the search page and the `<ListPagination />` component. Therefore, the shared code for this component and the newly created `<ListPaginationTop />` component had to be pulled up a layer.