### PR TITLE
Np 45740 show relevant licenses

### DIFF
--- a/src/pages/registration/FilesAndLicensePanel.tsx
+++ b/src/pages/registration/FilesAndLicensePanel.tsx
@@ -23,7 +23,7 @@ import { BackgroundDiv } from '../../components/styled/Wrappers';
 import { RootState } from '../../redux/store';
 import { alternatingTableRowColor } from '../../themes/mainTheme';
 import { AssociatedFile, AssociatedLink, NullAssociatedArtifact, Uppy } from '../../types/associatedArtifact.types';
-import { licenses } from '../../types/license.types';
+import { licenses, LicenseUri } from '../../types/license.types';
 import { FileFieldNames, SpecificLinkFieldNames } from '../../types/publicationFieldNames';
 import { Registration } from '../../types/registration.types';
 import { dataTestId } from '../../utils/dataTestIds';
@@ -277,20 +277,27 @@ export const FilesAndLicensePanel = ({ uppy }: FilesAndLicensePanelProps) => {
                                       modalTitle={t('registration.files_and_license.licenses')}
                                       modalDataTestId={dataTestId.registrationWizard.files.licenseModal}
                                       buttonDataTestId={dataTestId.registrationWizard.files.licenseHelpButton}>
-                                      {licenses.map((license) => (
-                                        <Box key={license.id} sx={{ mb: '1rem', whiteSpace: 'pre-wrap' }}>
-                                          <Typography variant="h3" gutterBottom>
-                                            {license.name}
-                                          </Typography>
-                                          <Box component="img" src={license.logo} alt="" sx={{ width: '8rem' }} />
-                                          <Typography paragraph>{license.description}</Typography>
-                                          {license.link && (
-                                            <Link href={license.link} target="blank">
-                                              {license.link}
-                                            </Link>
-                                          )}
-                                        </Box>
-                                      ))}
+                                      {licenses
+                                        .filter(
+                                          (license) =>
+                                            license.version === 4 ||
+                                            license.id === LicenseUri.CC0 ||
+                                            license.id === LicenseUri.RightsReserved
+                                        )
+                                        .map((license) => (
+                                          <Box key={license.id} sx={{ mb: '1rem', whiteSpace: 'pre-wrap' }}>
+                                            <Typography variant="h3" gutterBottom>
+                                              {license.name}
+                                            </Typography>
+                                            <Box component="img" src={license.logo} alt="" sx={{ width: '8rem' }} />
+                                            <Typography paragraph>{license.description}</Typography>
+                                            {license.link && (
+                                              <Link href={license.link} target="blank">
+                                                {license.link}
+                                              </Link>
+                                            )}
+                                          </Box>
+                                        ))}
                                     </HelperTextModal>
                                   </Box>
                                 </TableCell>

--- a/src/pages/registration/FilesAndLicensePanel.tsx
+++ b/src/pages/registration/FilesAndLicensePanel.tsx
@@ -277,6 +277,9 @@ export const FilesAndLicensePanel = ({ uppy }: FilesAndLicensePanelProps) => {
                                       modalTitle={t('registration.files_and_license.licenses')}
                                       modalDataTestId={dataTestId.registrationWizard.files.licenseModal}
                                       buttonDataTestId={dataTestId.registrationWizard.files.licenseHelpButton}>
+                                      <Typography paragraph>
+                                        {t('registration.files_and_license.file_and_license_info')}
+                                      </Typography>
                                       {licenses
                                         .filter(
                                           (license) =>

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -577,7 +577,7 @@
       "cc_by_nc_sa": "Dele — kopiere, distribuere og spre verket i hvilket som helst medium eller format. \nBearbeide — remixe, endre, og bygge videre på materialet. \n\nDu må oppgi korrekt kreditering, oppgi en lenke til lisensen, og indikere om endringer er blitt gjort. \nDu kan ikke benytte materialet til kommersielle formål. \nDersom du remixer, bearbeider eller bygger på materialet, må du distribuere dine bidrag under samme lisens som originalen.",
       "cc_by_nd": "Dele — kopiere, distribuere og spre verket i hvilket som helst medium eller format til et hvilket som helst formål, inkludert kommersielle. \n\nDu må oppgi korrekt kreditering, oppgi en lenke til lisensen, og indikere om endringer er blitt gjort. \nDersom du remixer, bearbeider eller bygger på materialet, kan du ikke distribuere det endrede materialet.",
       "cc_by_sa": "Dele — kopiere, distribuere og spre verket i hvilket som helst medium eller format. \nBearbeide — remixe, endre, og bygge videre på materialet til et hvilket som helst formål, inkludert kommersielle. \n\nDu må oppgi korrekt kreditering, oppgi en lenke til lisensen, og indikere om endringer er blitt gjort. \nDersom du remixer, bearbeider eller bygger på materialet, må du distribuere dine bidrag under samme lisens som originalen.",
-      "rights_reserved": "Dette arbeidet er publisert her for personlig bruk og kun i overensstemmelse med utgivers regler og betingelser for bruk av egenarkiverte versjoner."
+      "rights_reserved": "Dette arbeidet er publisert her for personlig bruk og kun i overensstemmelse med utgivers regler og betingelser for bruk av egenarkiverte versjoner. \n\n\"Utgivers betingelser\" er ikke en lisens, men en erklæring om at noen rettigheter er forbeholdt utgiveren, forfatteren og muligens andre. Leseren må selv klargjøre hva loven tillater ham å gjøre med dette verket, utover å lese det."
     },
     "labels": {
       "cc0": "CC0 ({{version}})",
@@ -1184,6 +1184,7 @@
       "administrative_contract": "Intern fil som aldri skal publiseres. F.eks. forfatteravtale eller annen dokumentasjon for det registrerte resultatet",
       "conditions_for_using_file": "Betingelser for bruk",
       "embargo": "Embargo/utsatt publisering",
+      "file_and_license_info": "Enhver fil i NVA må ha en lisens, slik at leser er informert om hva som er tillatt å gjøre med innholdet.",
       "file_publish_date_helper_text": "Filen er låst fram til angitt dato",
       "files": "Filer",
       "files_are_not_published": "Filer publiseres ikke",

--- a/src/types/license.types.ts
+++ b/src/types/license.types.ts
@@ -1,7 +1,7 @@
 import * as LicenseImages from '../resources/images/licenses';
 import i18n from '../translations/i18n';
 
-enum LicenseUri {
+export enum LicenseUri {
   CC_BY_4 = 'https://creativecommons.org/licenses/by/4.0',
   CC_BY_3 = 'https://creativecommons.org/licenses/by/3.0',
   CC_BY_2 = 'https://creativecommons.org/licenses/by/2.0',


### PR DESCRIPTION
- Only show version 4 licenses, CC0 and RightsReserved in helper modal for licenses.
- Adding helper text at the top of the modal
- Adding a paragraph to RightsReserved description