### PR TITLE
NP-46072 Refactor ListPagination component to wrap lists

### DIFF
--- a/src/components/ListPagination.tsx
+++ b/src/components/ListPagination.tsx
@@ -1,10 +1,9 @@
-import { Box, BoxProps, MenuItem, Pagination, PaginationItem, Select, Typography } from '@mui/material';
-import { useTranslation } from 'react-i18next';
-import { ROWS_PER_PAGE_OPTIONS } from '../utils/constants';
-import { dataTestId } from '../utils/dataTestIds';
-import { ListPaginationCounter } from './ListPaginationCounter';
+import { ReactNode } from 'react';
+import { ListPaginationTop } from './ListPaginationTop';
+import { ListPaginationBottom } from './ListPaginationBottom';
 
-interface ListPaginationProps extends Pick<BoxProps, 'sx'> {
+interface ListPaginationProps {
+  children: ReactNode;
   count: number;
   rowsPerPage: number;
   page: number;
@@ -12,77 +11,29 @@ interface ListPaginationProps extends Pick<BoxProps, 'sx'> {
   onRowsPerPageChange: (newRowsPerPage: number) => void;
   rowsPerPageOptions?: number[];
   maxHits?: number; // Default limit of 10_000 hits in ElasticSearch
+  showPaginationTop?: boolean;
 }
 
 export const ListPagination = ({
+  children,
   count,
   rowsPerPage,
   page,
   onPageChange,
   onRowsPerPageChange,
-  rowsPerPageOptions = ROWS_PER_PAGE_OPTIONS,
-  maxHits,
-  sx = {},
+  showPaginationTop,
 }: ListPaginationProps) => {
-  const { t } = useTranslation();
-
-  const maxPages = maxHits ? Math.ceil(maxHits / rowsPerPage) : Infinity;
-  const totalPages = Math.ceil(count / rowsPerPage);
-  const pages = Math.min(maxPages, totalPages);
-
-  const itemsStart = count > 0 ? (page - 1) * rowsPerPage + 1 : 0;
-  const itemsEnd = Math.min(page * rowsPerPage, count);
-
   return (
-    <Box
-      sx={{
-        mx: { xs: '0.25rem', md: '0' },
-        display: 'grid',
-        gridTemplateColumns: { xs: '1fr', sm: 'auto 1fr auto' },
-        gap: '0.25rem 0.5rem',
-        alignItems: 'center',
-        justifyItems: 'center',
-        ...sx,
-      }}
-      data-testid={dataTestId.common.pagination}>
-      <ListPaginationCounter start={itemsStart} end={itemsEnd} total={count} />
-
-      <Pagination
-        sx={{
-          '.MuiPagination-ul': {
-            justifyContent: 'center',
-          },
-        }}
+    <>
+      {showPaginationTop && <ListPaginationTop count={count} rowsPerPage={rowsPerPage} page={page} />}
+      {children}
+      <ListPaginationBottom
+        count={count}
+        rowsPerPage={rowsPerPage}
         page={page}
-        count={pages}
-        onChange={(_, newPage) => onPageChange(newPage)}
-        renderItem={(item) => (
-          <PaginationItem {...item} variant={item.selected ? 'outlined' : 'text'} page={item.page?.toLocaleString()} />
-        )}
+        onPageChange={onPageChange}
+        onRowsPerPageChange={onRowsPerPageChange}
       />
-
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-        <Typography component="label">{t('common.pagination_rows_per_page')}</Typography>
-        <Select
-          inputProps={{
-            'aria-label': t('common.pagination_rows_per_page'),
-          }}
-          sx={{
-            '.MuiSelect-select': {
-              py: '0.3rem',
-            },
-          }}
-          variant="outlined"
-          size="small"
-          value={rowsPerPage}
-          onChange={(event) => onRowsPerPageChange(+event.target.value)}>
-          {rowsPerPageOptions.map((option) => (
-            <MenuItem key={option} value={option}>
-              {option}
-            </MenuItem>
-          ))}
-        </Select>
-      </Box>
-    </Box>
+    </>
   );
 };

--- a/src/components/ListPaginationBottom.tsx
+++ b/src/components/ListPaginationBottom.tsx
@@ -1,0 +1,86 @@
+import { Box, MenuItem, Pagination, PaginationItem, Select, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { ROWS_PER_PAGE_OPTIONS } from '../utils/constants';
+import { dataTestId } from '../utils/dataTestIds';
+import { ListPaginationCounter } from './ListPaginationCounter';
+
+interface ListPaginationBottomProps {
+  count: number;
+  rowsPerPage: number;
+  page: number;
+  onPageChange: (newPage: number) => void;
+  onRowsPerPageChange: (newRowsPerPage: number) => void;
+  rowsPerPageOptions?: number[];
+  maxHits?: number; // Default limit of 10_000 hits in ElasticSearch
+}
+
+export const ListPaginationBottom = ({
+  count,
+  rowsPerPage,
+  page,
+  onPageChange,
+  onRowsPerPageChange,
+  rowsPerPageOptions = ROWS_PER_PAGE_OPTIONS,
+  maxHits,
+}: ListPaginationBottomProps) => {
+  const { t } = useTranslation();
+
+  const maxPages = maxHits ? Math.ceil(maxHits / rowsPerPage) : Infinity;
+  const totalPages = Math.ceil(count / rowsPerPage);
+  const pages = Math.min(maxPages, totalPages);
+
+  const itemsStart = count > 0 ? (page - 1) * rowsPerPage + 1 : 0;
+  const itemsEnd = Math.min(page * rowsPerPage, count);
+
+  return (
+    <Box
+      sx={{
+        mx: { xs: '0.25rem', md: '0' },
+        display: 'grid',
+        gridTemplateColumns: { xs: '1fr', sm: 'auto 1fr auto' },
+        gap: '0.25rem 0.5rem',
+        alignItems: 'center',
+        justifyItems: 'center',
+      }}
+      data-testid={dataTestId.common.pagination}>
+      <ListPaginationCounter start={itemsStart} end={itemsEnd} total={count} />
+
+      <Pagination
+        sx={{
+          '.MuiPagination-ul': {
+            justifyContent: 'center',
+          },
+        }}
+        page={page}
+        count={pages}
+        onChange={(_, newPage) => onPageChange(newPage)}
+        renderItem={(item) => (
+          <PaginationItem {...item} variant={item.selected ? 'outlined' : 'text'} page={item.page?.toLocaleString()} />
+        )}
+      />
+
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        <Typography component="label">{t('common.pagination_rows_per_page')}</Typography>
+        <Select
+          inputProps={{
+            'aria-label': t('common.pagination_rows_per_page'),
+          }}
+          sx={{
+            '.MuiSelect-select': {
+              py: '0.3rem',
+            },
+          }}
+          variant="outlined"
+          size="small"
+          value={rowsPerPage}
+          onChange={(event) => onRowsPerPageChange(+event.target.value)}>
+          {rowsPerPageOptions.map((option) => (
+            <MenuItem key={option} value={option}>
+              {option}
+            </MenuItem>
+          ))}
+        </Select>
+      </Box>
+    </Box>
+  );
+};

--- a/src/components/ListPaginationCounter.tsx
+++ b/src/components/ListPaginationCounter.tsx
@@ -11,7 +11,7 @@ export const ListPaginationCounter = ({ start, end, total }: ListPaginationCount
   const { t } = useTranslation();
 
   return (
-    <Typography aria-live="polite">
+    <Typography>
       {t('common.pagination_showing_interval', {
         start: start.toLocaleString(),
         end: end.toLocaleString(),

--- a/src/components/ListPaginationTop.tsx
+++ b/src/components/ListPaginationTop.tsx
@@ -12,7 +12,7 @@ export const ListPaginationTop = ({ count, rowsPerPage, page }: ListPaginationTo
   const itemsEnd = Math.min(page * rowsPerPage, count);
 
   return (
-    <Box sx={{ display: 'flex', justifyContent: 'end' }}>
+    <Box sx={{ display: 'flex', justifyContent: 'end', mx: { xs: '0.5rem', md: 0 } }}>
       <ListPaginationCounter start={itemsStart} end={itemsEnd} total={count} />
     </Box>
   );

--- a/src/pages/basic_data/app_admin/UserList.tsx
+++ b/src/pages/basic_data/app_admin/UserList.tsx
@@ -22,7 +22,7 @@ import { ListPagination } from '../../../components/ListPagination';
 import { setNotification } from '../../../redux/notificationSlice';
 import { alternatingTableRowColor } from '../../../themes/mainTheme';
 import { InstitutionUser, RoleName } from '../../../types/user.types';
-import { ROWS_PER_PAGE_OPTIONS, isErrorStatus, isSuccessStatus } from '../../../utils/constants';
+import { isErrorStatus, isSuccessStatus, ROWS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 
 interface UserListProps {
   userList: InstitutionUser[];
@@ -100,59 +100,6 @@ export const UserList = ({ userList, tableCaption, roleToRemove, roleToAdd, refe
         </Typography>
       ) : (
         <>
-          <TableContainer component={Paper} sx={{ mb: '0.5rem' }}>
-            <Table size="small" sx={alternatingTableRowColor}>
-              <caption style={visuallyHidden}>{tableCaption}</caption>
-              <TableHead>
-                <TableRow>
-                  <TableCell>{t('common.username')}</TableCell>
-                  <TableCell>{t('common.name')}</TableCell>
-                  <TableCell width="150">{t('common.actions')}</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {adminsOnPage.map((user) => {
-                  const isLoading = updatedRoleForUsers.includes(user.username);
-                  const disableAddButton = user.roles.some((role) => role.rolename === roleToAdd);
-                  return (
-                    <TableRow key={user.username}>
-                      <TableCell>{user.username}</TableCell>
-                      <TableCell>
-                        {user.givenName} {user.familyName}
-                      </TableCell>
-                      <TableCell>
-                        {roleToRemove && (
-                          <Button
-                            color="error"
-                            variant="outlined"
-                            startIcon={<CancelIcon />}
-                            disabled={isLastInstitutionAdmin}
-                            data-testid={`button-remove-role-${roleToRemove}-${user.username}`}
-                            onClick={() => setRemoveRoleForUser(user.username)}>
-                            {t('common.remove')}
-                          </Button>
-                        )}
-                        {roleToAdd && (
-                          <LoadingButton
-                            variant="contained"
-                            size="small"
-                            startIcon={<AddIcon />}
-                            loadingPosition="start"
-                            disabled={disableAddButton}
-                            loading={!disableAddButton && isLoading}
-                            data-testid={`button-add-role-${roleToAdd}-${user.username}`}
-                            onClick={() => handleAddRoleToUser(user)}>
-                            {t('common.add')}
-                          </LoadingButton>
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
-              </TableBody>
-            </Table>
-          </TableContainer>
-
           <ListPagination
             count={sortedList.length}
             rowsPerPage={rowsPerPage}
@@ -161,8 +108,60 @@ export const UserList = ({ userList, tableCaption, roleToRemove, roleToAdd, refe
             onRowsPerPageChange={(newRowsPerPage) => {
               setRowsPerPage(newRowsPerPage);
               setPage(1);
-            }}
-          />
+            }}>
+            <TableContainer component={Paper} sx={{ mb: '0.5rem' }}>
+              <Table size="small" sx={alternatingTableRowColor}>
+                <caption style={visuallyHidden}>{tableCaption}</caption>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>{t('common.username')}</TableCell>
+                    <TableCell>{t('common.name')}</TableCell>
+                    <TableCell width="150">{t('common.actions')}</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {adminsOnPage.map((user) => {
+                    const isLoading = updatedRoleForUsers.includes(user.username);
+                    const disableAddButton = user.roles.some((role) => role.rolename === roleToAdd);
+                    return (
+                      <TableRow key={user.username}>
+                        <TableCell>{user.username}</TableCell>
+                        <TableCell>
+                          {user.givenName} {user.familyName}
+                        </TableCell>
+                        <TableCell>
+                          {roleToRemove && (
+                            <Button
+                              color="error"
+                              variant="outlined"
+                              startIcon={<CancelIcon />}
+                              disabled={isLastInstitutionAdmin}
+                              data-testid={`button-remove-role-${roleToRemove}-${user.username}`}
+                              onClick={() => setRemoveRoleForUser(user.username)}>
+                              {t('common.remove')}
+                            </Button>
+                          )}
+                          {roleToAdd && (
+                            <LoadingButton
+                              variant="contained"
+                              size="small"
+                              startIcon={<AddIcon />}
+                              loadingPosition="start"
+                              disabled={disableAddButton}
+                              loading={!disableAddButton && isLoading}
+                              data-testid={`button-add-role-${roleToAdd}-${user.username}`}
+                              onClick={() => handleAddRoleToUser(user)}>
+                              {t('common.add')}
+                            </LoadingButton>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </ListPagination>
 
           {roleToRemove && (
             <ConfirmDialog

--- a/src/pages/basic_data/app_admin/central_import/CentralImportDuplicateSearch.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportDuplicateSearch.tsx
@@ -2,7 +2,7 @@ import { Box, FormControl, FormControlLabel, Radio, RadioGroup, Typography } fro
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { FetchResultsParams, fetchResults } from '../../../../api/searchApi';
+import { fetchResults, FetchResultsParams } from '../../../../api/searchApi';
 import { ListPagination } from '../../../../components/ListPagination';
 import { ListSkeleton } from '../../../../components/ListSkeleton';
 import { RegistrationListItemContent } from '../../../../components/RegistrationList';
@@ -54,8 +54,16 @@ export const CentralImportDuplicateSearch = ({
               : t('basic_data.central_import.duplicate_search_hits')}
           </Typography>
           {duplicateCandidatesSize > 0 && (
-            <>
-              <FormControl sx={{ width: '100%' }}>
+            <ListPagination
+              count={duplicateCandidatesSize}
+              rowsPerPage={rowsPerPage}
+              page={page}
+              onPageChange={(newPage) => setPage(newPage)}
+              onRowsPerPageChange={(newRowsPerPage) => {
+                setRowsPerPage(newRowsPerPage);
+                setPage(1);
+              }}>
+              <FormControl sx={{ width: '100%', mb: '0.5rem' }}>
                 <RadioGroup
                   value={registrationIdentifier}
                   onChange={(event) => setRegistrationIdentifier(event.target.value)}>
@@ -74,18 +82,7 @@ export const CentralImportDuplicateSearch = ({
                   ))}
                 </RadioGroup>
               </FormControl>
-              <ListPagination
-                sx={{ mt: '0.5rem' }}
-                count={duplicateCandidatesSize}
-                rowsPerPage={rowsPerPage}
-                page={page}
-                onPageChange={(newPage) => setPage(newPage)}
-                onRowsPerPageChange={(newRowsPerPage) => {
-                  setRowsPerPage(newRowsPerPage);
-                  setPage(1);
-                }}
-              />
-            </>
+            </ListPagination>
           )}
         </>
       )}

--- a/src/pages/basic_data/app_admin/central_import/CentralImportPage.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportPage.tsx
@@ -4,10 +4,10 @@ import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import {
+  fetchImportCandidates,
   FetchImportCandidatesParams,
   ImportCandidateOrderBy,
   SortOrder,
-  fetchImportCandidates,
 } from '../../../../api/searchApi';
 import { ErrorBoundary } from '../../../../components/ErrorBoundary';
 import { ListPagination } from '../../../../components/ListPagination';
@@ -94,7 +94,12 @@ export const CentralImportPage = ({ statusFilter, yearFilter }: CentralImportPag
       {importCandidateQuery.isLoading ? (
         <ListSkeleton minWidth={100} maxWidth={100} height={100} />
       ) : searchResults.length > 0 ? (
-        <>
+        <ListPagination
+          count={importCandidateQuery.data?.size ?? 0}
+          rowsPerPage={rowsPerPage}
+          page={page + 1}
+          onPageChange={(newPage) => updatePath(((newPage - 1) * rowsPerPage).toString(), rowsPerPage.toString())}
+          onRowsPerPageChange={(newRowsPerPage) => updatePath('0', newRowsPerPage.toString())}>
           <List>
             {searchResults.map((importCandidate) => (
               <ErrorBoundary key={importCandidate.id}>
@@ -102,14 +107,7 @@ export const CentralImportPage = ({ statusFilter, yearFilter }: CentralImportPag
               </ErrorBoundary>
             ))}
           </List>
-          <ListPagination
-            count={importCandidateQuery.data?.size ?? 0}
-            rowsPerPage={rowsPerPage}
-            page={page + 1}
-            onPageChange={(newPage) => updatePath(((newPage - 1) * rowsPerPage).toString(), rowsPerPage.toString())}
-            onRowsPerPageChange={(newRowsPerPage) => updatePath('0', newRowsPerPage.toString())}
-          />
-        </>
+        </ListPagination>
       ) : (
         <Typography sx={{ mt: '1rem' }}>{t('common.no_hits')}</Typography>
       )}

--- a/src/pages/basic_data/institution_admin/person_register/PersonRegisterPage.tsx
+++ b/src/pages/basic_data/institution_admin/person_register/PersonRegisterPage.tsx
@@ -84,51 +84,6 @@ export const PersonRegisterPage = () => {
         <Typography>{t('basic_data.person_register.no_employees_found')}</Typography>
       ) : (
         <>
-          <TableContainer component={Paper} sx={{ mb: '0.5rem' }}>
-            <Table size="small" sx={alternatingTableRowColor}>
-              <caption style={visuallyHidden}>{t('basic_data.person_register.employee_table_caption')}</caption>
-              <TableHead>
-                <TableRow>
-                  <TableCell>{t('basic_data.person_register.person_id')}</TableCell>
-                  <TableCell>{t('basic_data.person_register.national_identity_number')}</TableCell>
-                  <TableCell>{t('common.name')}</TableCell>
-                  <TableCell>{t('common.employments')}</TableCell>
-                  <TableCell />
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {employeeSearchQuery.isLoading
-                  ? [...Array(5)].map((_, index) => (
-                      <TableRow key={index} sx={{ height: '4rem' }}>
-                        <TableCell>
-                          <Skeleton />
-                        </TableCell>
-                        <TableCell>
-                          <Skeleton />
-                        </TableCell>
-                        <TableCell width="25%">
-                          <Skeleton />
-                        </TableCell>
-                        <TableCell width="60%">
-                          <Skeleton />
-                        </TableCell>
-                        <TableCell></TableCell>
-                      </TableRow>
-                    ))
-                  : employees.map((person) => (
-                      <ErrorBoundary key={person.id}>
-                        <PersonTableRow
-                          cristinPerson={person}
-                          topOrgCristinIdentifier={
-                            user?.topOrgCristinId ? user.topOrgCristinId.split('/').pop() ?? '' : ''
-                          }
-                          refetchEmployees={employeeSearchQuery.refetch}
-                        />
-                      </ErrorBoundary>
-                    ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
           <ListPagination
             count={employeeSearchQuery.data?.size ?? 0}
             rowsPerPage={rowsPerPage}
@@ -137,8 +92,53 @@ export const PersonRegisterPage = () => {
             onRowsPerPageChange={(newRowsPerPage) => {
               setRowsPerPage(newRowsPerPage);
               setPage(1);
-            }}
-          />
+            }}>
+            <TableContainer component={Paper} sx={{ mb: '0.5rem' }}>
+              <Table size="small" sx={alternatingTableRowColor}>
+                <caption style={visuallyHidden}>{t('basic_data.person_register.employee_table_caption')}</caption>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>{t('basic_data.person_register.person_id')}</TableCell>
+                    <TableCell>{t('basic_data.person_register.national_identity_number')}</TableCell>
+                    <TableCell>{t('common.name')}</TableCell>
+                    <TableCell>{t('common.employments')}</TableCell>
+                    <TableCell />
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {employeeSearchQuery.isLoading
+                    ? [...Array(5)].map((_, index) => (
+                        <TableRow key={index} sx={{ height: '4rem' }}>
+                          <TableCell>
+                            <Skeleton />
+                          </TableCell>
+                          <TableCell>
+                            <Skeleton />
+                          </TableCell>
+                          <TableCell width="25%">
+                            <Skeleton />
+                          </TableCell>
+                          <TableCell width="60%">
+                            <Skeleton />
+                          </TableCell>
+                          <TableCell></TableCell>
+                        </TableRow>
+                      ))
+                    : employees.map((person) => (
+                        <ErrorBoundary key={person.id}>
+                          <PersonTableRow
+                            cristinPerson={person}
+                            topOrgCristinIdentifier={
+                              user?.topOrgCristinId ? user.topOrgCristinId.split('/').pop() ?? '' : ''
+                            }
+                            refetchEmployees={employeeSearchQuery.refetch}
+                          />
+                        </ErrorBoundary>
+                      ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </ListPagination>
         </>
       )}
     </BackgroundDiv>

--- a/src/pages/editor/EditorCurators.tsx
+++ b/src/pages/editor/EditorCurators.tsx
@@ -67,7 +67,15 @@ export const EditorCurators = () => {
           <i>{t('editor.curators.no_users_found')}</i>
         </Typography>
       ) : (
-        <>
+        <ListPagination
+          count={filteredCurators.length}
+          rowsPerPage={rowsPerPage}
+          page={validPage}
+          onPageChange={(newPage) => setPage(newPage)}
+          onRowsPerPageChange={(newRowsPerPage) => {
+            setRowsPerPage(newRowsPerPage);
+            setPage(1);
+          }}>
           <TableContainer component={Paper} sx={{ mb: '0.5rem' }}>
             <Table size="small" sx={alternatingTableRowColor}>
               <TableHead>
@@ -84,17 +92,7 @@ export const EditorCurators = () => {
               </TableBody>
             </Table>
           </TableContainer>
-          <ListPagination
-            count={filteredCurators.length}
-            rowsPerPage={rowsPerPage}
-            page={validPage}
-            onPageChange={(newPage) => setPage(newPage)}
-            onRowsPerPageChange={(newRowsPerPage) => {
-              setRowsPerPage(newRowsPerPage);
-              setPage(1);
-            }}
-          />
-        </>
+        </ListPagination>
       )}
     </>
   );

--- a/src/pages/editor/EditorCurators.tsx
+++ b/src/pages/editor/EditorCurators.tsx
@@ -51,7 +51,15 @@ export const EditorCurators = () => {
       <i>{t('editor.curators.no_users_found')}</i>
     </Typography>
   ) : (
-    <>
+    <ListPagination
+      count={curators.length}
+      rowsPerPage={rowsPerPage}
+      page={validPage}
+      onPageChange={(newPage) => setPage(newPage)}
+      onRowsPerPageChange={(newRowsPerPage) => {
+        setRowsPerPage(newRowsPerPage);
+        setPage(1);
+      }}>
       <TableContainer component={Paper} sx={{ mb: '0.5rem' }}>
         <Table size="small" sx={alternatingTableRowColor}>
           <TableHead>
@@ -68,16 +76,6 @@ export const EditorCurators = () => {
           </TableBody>
         </Table>
       </TableContainer>
-      <ListPagination
-        count={curators.length}
-        rowsPerPage={rowsPerPage}
-        page={validPage}
-        onPageChange={(newPage) => setPage(newPage)}
-        onRowsPerPageChange={(newRowsPerPage) => {
-          setRowsPerPage(newRowsPerPage);
-          setPage(1);
-        }}
-      />
-    </>
+    </ListPagination>
   );
 };

--- a/src/pages/messages/components/NviCandidatesList.tsx
+++ b/src/pages/messages/components/NviCandidatesList.tsx
@@ -47,7 +47,16 @@ export const NviCandidatesList = ({
           {nviCandidatesQuery.data?.hits.length === 0 ? (
             <Typography>{t('tasks.nvi.no_nvi_candidates')}</Typography>
           ) : (
-            <>
+            <ListPagination
+              count={nviCandidatesQuery.data?.totalHits ?? 0}
+              rowsPerPage={rowsPerPage}
+              page={page}
+              onPageChange={(newPage) => setPage(newPage)}
+              onRowsPerPageChange={(newRowsPerPage) => {
+                setRowsPerPage(newRowsPerPage);
+                setPage(1);
+              }}
+              maxHits={10_000}>
               <List data-testid={dataTestId.tasksPage.nvi.candidatesList} disablePadding sx={{ mb: '0.5rem' }}>
                 {nviCandidatesQuery.data?.hits.map((nviCandidate, index) => {
                   const currentOffset = (page - 1) * rowsPerPage + index;
@@ -62,18 +71,7 @@ export const NviCandidatesList = ({
                   );
                 })}
               </List>
-              <ListPagination
-                count={nviCandidatesQuery.data?.totalHits ?? 0}
-                rowsPerPage={rowsPerPage}
-                page={page}
-                onPageChange={(newPage) => setPage(newPage)}
-                onRowsPerPageChange={(newRowsPerPage) => {
-                  setRowsPerPage(newRowsPerPage);
-                  setPage(1);
-                }}
-                maxHits={10_000}
-              />
-            </>
+            </ListPagination>
           )}
         </>
       )}

--- a/src/pages/messages/components/TicketList.tsx
+++ b/src/pages/messages/components/TicketList.tsx
@@ -62,7 +62,16 @@ export const TicketList = ({ ticketsQuery, setRowsPerPage, rowsPerPage, setPage,
           {tickets.length === 0 ? (
             <Typography>{t('my_page.messages.no_messages')}</Typography>
           ) : (
-            <>
+            <ListPagination
+              count={ticketsQuery.data?.size ?? 0}
+              rowsPerPage={rowsPerPage}
+              page={page}
+              onPageChange={(newPage) => setPage(newPage)}
+              onRowsPerPageChange={(newRowsPerPage) => {
+                setRowsPerPage(newRowsPerPage);
+                setPage(1);
+              }}
+              maxHits={10_000}>
               <List disablePadding sx={{ mb: '0.5rem' }}>
                 {tickets.map((ticket) => (
                   <ErrorBoundary key={ticket.id}>
@@ -70,18 +79,7 @@ export const TicketList = ({ ticketsQuery, setRowsPerPage, rowsPerPage, setPage,
                   </ErrorBoundary>
                 ))}
               </List>
-              <ListPagination
-                count={ticketsQuery.data?.size ?? 0}
-                rowsPerPage={rowsPerPage}
-                page={page}
-                onPageChange={(newPage) => setPage(newPage)}
-                onRowsPerPageChange={(newRowsPerPage) => {
-                  setRowsPerPage(newRowsPerPage);
-                  setPage(1);
-                }}
-                maxHits={10_000}
-              />
-            </>
+            </ListPagination>
           )}
         </>
       )}

--- a/src/pages/my_page/user_profile/MyProjectRegistrations.tsx
+++ b/src/pages/my_page/user_profile/MyProjectRegistrations.tsx
@@ -76,7 +76,15 @@ export const MyProjectRegistrations = ({
       {projectsQuery.isLoading || projectsQuery.isFetching ? (
         <ListSkeleton arrayLength={3} minWidth={40} height={100} />
       ) : projectsQuery.data && projectsQuery.data.size > 0 ? (
-        <>
+        <ListPagination
+          count={filteredProjects.length}
+          rowsPerPage={rowsPerPage}
+          page={validPage}
+          onPageChange={(newPage) => setPage(newPage)}
+          onRowsPerPageChange={(newRowsPerPage) => {
+            setRowsPerPage(newRowsPerPage);
+            setPage(1);
+          }}>
           <List>
             {projectsToShow.map((project) => (
               <ProjectListItem
@@ -87,17 +95,7 @@ export const MyProjectRegistrations = ({
               />
             ))}
           </List>
-          <ListPagination
-            count={filteredProjects.length}
-            rowsPerPage={rowsPerPage}
-            page={validPage}
-            onPageChange={(newPage) => setPage(newPage)}
-            onRowsPerPageChange={(newRowsPerPage) => {
-              setRowsPerPage(newRowsPerPage);
-              setPage(1);
-            }}
-          />
-        </>
+        </ListPagination>
       ) : (
         <Typography>{t('common.no_hits')}</Typography>
       )}

--- a/src/pages/my_page/user_profile/MyProjects.tsx
+++ b/src/pages/my_page/user_profile/MyProjects.tsx
@@ -37,7 +37,15 @@ export const MyProjects = () => {
       {projectsQuery.isLoading ? (
         <ListSkeleton arrayLength={3} minWidth={40} height={100} />
       ) : projects && projects.length > 0 ? (
-        <>
+        <ListPagination
+          count={projectsQuery.data?.size ?? 0}
+          rowsPerPage={rowsPerPage}
+          page={page}
+          onPageChange={(newPage) => setPage(newPage)}
+          onRowsPerPageChange={(newRowsPerPage) => {
+            setRowsPerPage(newRowsPerPage);
+            setPage(1);
+          }}>
           <List>
             {projects.map((project) => (
               <ProjectListItem
@@ -48,17 +56,7 @@ export const MyProjects = () => {
               />
             ))}
           </List>
-          <ListPagination
-            count={projectsQuery.data?.size ?? 0}
-            rowsPerPage={rowsPerPage}
-            page={page}
-            onPageChange={(newPage) => setPage(newPage)}
-            onRowsPerPageChange={(newRowsPerPage) => {
-              setRowsPerPage(newRowsPerPage);
-              setPage(1);
-            }}
-          />
-        </>
+        </ListPagination>
       ) : (
         <Typography>{t('common.no_hits')}</Typography>
       )}

--- a/src/pages/my_page/user_profile/MyResults.tsx
+++ b/src/pages/my_page/user_profile/MyResults.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { fetchPromotedPublicationsById } from '../../../api/preferencesApi';
-import { FetchResultsParams, fetchResults } from '../../../api/searchApi';
+import { fetchResults, FetchResultsParams } from '../../../api/searchApi';
 import { ListPagination } from '../../../components/ListPagination';
 import { RootState } from '../../../redux/store';
 import { ROWS_PER_PAGE_OPTIONS } from '../../../utils/constants';
@@ -50,23 +50,21 @@ export const MyResults = () => {
           <CircularProgress aria-labelledby="registration-label" />
         </Box>
       ) : registrationsQuery.data && registrationsQuery.data.totalHits > 0 ? (
-        <>
+        <ListPagination
+          count={registrationsQuery.data.totalHits}
+          rowsPerPage={rowsPerPage}
+          page={page}
+          onPageChange={(newPage) => setPage(newPage)}
+          onRowsPerPageChange={(newRowsPerPage) => {
+            setRowsPerPage(newRowsPerPage);
+            setPage(1);
+          }}>
           <RegistrationSearchResults
             canEditRegistration={true}
             searchResult={registrationsQuery.data.hits}
             promotedPublications={promotedPublications}
           />
-          <ListPagination
-            count={registrationsQuery.data.totalHits}
-            rowsPerPage={rowsPerPage}
-            page={page}
-            onPageChange={(newPage) => setPage(newPage)}
-            onRowsPerPageChange={(newRowsPerPage) => {
-              setRowsPerPage(newRowsPerPage);
-              setPage(1);
-            }}
-          />
-        </>
+        </ListPagination>
       ) : (
         <Typography>{t('common.no_hits')}</Typography>
       )}

--- a/src/pages/my_registrations/MyRegistrationsList.tsx
+++ b/src/pages/my_registrations/MyRegistrationsList.tsx
@@ -7,8 +7,8 @@ import { ConfirmDialog } from '../../components/ConfirmDialog';
 import { ListPagination } from '../../components/ListPagination';
 import { RegistrationList } from '../../components/RegistrationList';
 import { setNotification } from '../../redux/notificationSlice';
-import { Registration, RegistrationPreview, emptyRegistration } from '../../types/registration.types';
-import { ROWS_PER_PAGE_OPTIONS, isErrorStatus, isSuccessStatus } from '../../utils/constants';
+import { emptyRegistration, Registration, RegistrationPreview } from '../../types/registration.types';
+import { isErrorStatus, isSuccessStatus, ROWS_PER_PAGE_OPTIONS } from '../../utils/constants';
 import { getIdentifierFromId } from '../../utils/general-helpers';
 import { stringIncludesMathJax, typesetMathJax } from '../../utils/mathJaxHelpers';
 import { getTitleString } from '../../utils/registration-helpers';
@@ -80,23 +80,21 @@ export const MyRegistrationsList = ({ registrations, refetchRegistrations }: MyR
   return (
     <>
       {registrationsCopy.length > 0 ? (
-        <>
+        <ListPagination
+          count={registrations.length}
+          rowsPerPage={rowsPerPage}
+          page={page}
+          onPageChange={(newPage) => setPage(newPage)}
+          onRowsPerPageChange={(newRowsPerPage) => {
+            setRowsPerPage(newRowsPerPage);
+            setPage(1);
+          }}>
           <RegistrationList
             onDeleteDraftRegistration={onClickDeleteRegistration}
             registrations={registrationsCopy}
             canEditRegistration={true}
           />
-          <ListPagination
-            count={registrations.length}
-            rowsPerPage={rowsPerPage}
-            page={page}
-            onPageChange={(newPage) => setPage(newPage)}
-            onRowsPerPageChange={(newRowsPerPage) => {
-              setRowsPerPage(newRowsPerPage);
-              setPage(1);
-            }}
-          />
-        </>
+        </ListPagination>
       ) : (
         <Typography>{t('common.no_hits')}</Typography>
       )}

--- a/src/pages/projects/ProjectResultsAccordion.tsx
+++ b/src/pages/projects/ProjectResultsAccordion.tsx
@@ -2,7 +2,7 @@ import { CircularProgress, Typography } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { FetchResultsParams, fetchResults } from '../../api/searchApi';
+import { fetchResults, FetchResultsParams } from '../../api/searchApi';
 import { ListPagination } from '../../components/ListPagination';
 import { RegistrationList } from '../../components/RegistrationList';
 import { LandingPageAccordion } from '../../components/landing_page/LandingPageAccordion';
@@ -38,20 +38,18 @@ export const ProjectResultsAccordion = ({ projectId }: ProjectResultsProps) => {
       {resultsQuery.isLoading ? (
         <CircularProgress aria-label={t('project.results')} />
       ) : results && results.totalHits > 0 ? (
-        <>
+        <ListPagination
+          rowsPerPageOptions={itemsPerRowOptions}
+          count={results.totalHits}
+          rowsPerPage={rowsPerPage}
+          page={page}
+          onPageChange={(newPage) => setPage(newPage)}
+          onRowsPerPageChange={(newRowsPerPage) => {
+            setRowsPerPage(newRowsPerPage);
+            setPage(1);
+          }}>
           <RegistrationList registrations={results.hits} />
-          <ListPagination
-            rowsPerPageOptions={itemsPerRowOptions}
-            count={results.totalHits}
-            rowsPerPage={rowsPerPage}
-            page={page}
-            onPageChange={(newPage) => setPage(newPage)}
-            onRowsPerPageChange={(newRowsPerPage) => {
-              setRowsPerPage(newRowsPerPage);
-              setPage(1);
-            }}
-          />
-        </>
+        </ListPagination>
       ) : (
         <Typography>{t('project.no_results')}</Typography>
       )}

--- a/src/pages/projects/RelatedProjects.tsx
+++ b/src/pages/projects/RelatedProjects.tsx
@@ -57,24 +57,22 @@ export const RelatedProjects = ({ projectIds }: RelatedProjectsProps) => {
   return isLoading ? (
     <CircularProgress aria-label={t('project.form.related_projects')} />
   ) : projects.length > 0 ? (
-    <>
+    <ListPagination
+      rowsPerPageOptions={itemsPerRowOptions}
+      count={projectIds.length}
+      rowsPerPage={rowsPerPage}
+      page={page}
+      onPageChange={(newPage) => setPage(newPage)}
+      onRowsPerPageChange={(newRowsPerPage) => {
+        setRowsPerPage(newRowsPerPage);
+        setPage(1);
+      }}>
       <List>
         {projects.map((project) => (
           <ProjectListItem key={project.id} project={project} />
         ))}
       </List>
-      <ListPagination
-        rowsPerPageOptions={itemsPerRowOptions}
-        count={projectIds.length}
-        rowsPerPage={rowsPerPage}
-        page={page}
-        onPageChange={(newPage) => setPage(newPage)}
-        onRowsPerPageChange={(newRowsPerPage) => {
-          setRowsPerPage(newRowsPerPage);
-          setPage(1);
-        }}
-      />
-    </>
+    </ListPagination>
   ) : (
     <Typography>{t('project.no_related_projects')}</Typography>
   );

--- a/src/pages/registration/contributors_tab/Contributors.tsx
+++ b/src/pages/registration/contributors_tab/Contributors.tsx
@@ -25,8 +25,8 @@ import {
   Affiliation,
   Contributor,
   ContributorRole,
-  Identity,
   emptyContributor,
+  Identity,
 } from '../../../types/contributor.types';
 import { ContributorFieldNames } from '../../../types/publicationFieldNames';
 import { Registration } from '../../../types/registration.types';
@@ -197,47 +197,57 @@ export const Contributors = ({ contributorRoles, push, replace }: ContributorsPr
       )}
 
       {contributorsToShow.length > 0 && (
-        <TableContainer component={Paper}>
-          <Table size="small" sx={alternatingTableRowColor}>
-            <TableHead>
-              <TableRow>
-                <TableCell>{t('common.order')}</TableCell>
-                <TableCell>{t('registration.contributors.confirmed')}</TableCell>
-                <TableCell>{t('common.role')}</TableCell>
-                <TableCell align="center">
-                  <Tooltip title={t('registration.contributors.corresponding')}>
-                    <MailOutlineIcon />
-                  </Tooltip>
-                </TableCell>
-                <TableCell>{t('common.name')}</TableCell>
-                <TableCell>{t('common.institution')}</TableCell>
-                <TableCell>{t('common.remove')}</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {contributorsToShow.map((contributor, index) => {
-                const contributorIndex = contributors.findIndex(
-                  (c) =>
-                    c.identity.id === contributor.identity.id &&
-                    c.identity.name === contributor.identity.name &&
-                    c.role === contributor.role
-                );
-                return (
-                  <ContributorRow
-                    key={`${contributor.identity.name}${index}`}
-                    contributor={contributor}
-                    onMoveContributor={handleMoveContributor}
-                    onRemoveContributor={handleOnRemove}
-                    onVerifyContributor={onContributorSelected}
-                    isLastElement={contributors.length === contributor.sequence}
-                    contributorRoles={contributorRoles}
-                    contributorIndex={contributorIndex}
-                  />
-                );
-              })}
-            </TableBody>
-          </Table>
-        </TableContainer>
+        <ListPagination
+          count={filteredContributors.length}
+          rowsPerPage={rowsPerPage}
+          page={currentPage}
+          onPageChange={(newPage) => setCurrentPage(newPage)}
+          onRowsPerPageChange={(newRowsPerPage) => {
+            setRowsPerPage(newRowsPerPage);
+            setCurrentPage(1);
+          }}>
+          <TableContainer sx={{ mb: '0.5rem' }} component={Paper}>
+            <Table size="small" sx={alternatingTableRowColor}>
+              <TableHead>
+                <TableRow>
+                  <TableCell>{t('common.order')}</TableCell>
+                  <TableCell>{t('registration.contributors.confirmed')}</TableCell>
+                  <TableCell>{t('common.role')}</TableCell>
+                  <TableCell align="center">
+                    <Tooltip title={t('registration.contributors.corresponding')}>
+                      <MailOutlineIcon />
+                    </Tooltip>
+                  </TableCell>
+                  <TableCell>{t('common.name')}</TableCell>
+                  <TableCell>{t('common.institution')}</TableCell>
+                  <TableCell>{t('common.remove')}</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {contributorsToShow.map((contributor, index) => {
+                  const contributorIndex = contributors.findIndex(
+                    (c) =>
+                      c.identity.id === contributor.identity.id &&
+                      c.identity.name === contributor.identity.name &&
+                      c.role === contributor.role
+                  );
+                  return (
+                    <ContributorRow
+                      key={`${contributor.identity.name}${index}`}
+                      contributor={contributor}
+                      onMoveContributor={handleMoveContributor}
+                      onRemoveContributor={handleOnRemove}
+                      onVerifyContributor={onContributorSelected}
+                      isLastElement={contributors.length === contributor.sequence}
+                      contributorRoles={contributorRoles}
+                      contributorIndex={contributorIndex}
+                    />
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </ListPagination>
       )}
 
       <AddContributorModal
@@ -251,19 +261,7 @@ export const Contributors = ({ contributorRoles, push, replace }: ContributorsPr
           goToLastPage();
         }}
       />
-      {contributorsToShow.length > 0 && (
-        <ListPagination
-          sx={{ my: '0.5rem' }}
-          count={filteredContributors.length}
-          rowsPerPage={rowsPerPage}
-          page={currentPage}
-          onPageChange={(newPage) => setCurrentPage(newPage)}
-          onRowsPerPageChange={(newRowsPerPage) => {
-            setRowsPerPage(newRowsPerPage);
-            setCurrentPage(1);
-          }}
-        />
-      )}
+
       <Button
         sx={{ marginBottom: '1rem', borderRadius: '1rem' }}
         onClick={() => setOpenAddContributor(true)}

--- a/src/pages/registration/contributors_tab/components/AddContributorForm.tsx
+++ b/src/pages/registration/contributors_tab/components/AddContributorForm.tsx
@@ -15,7 +15,7 @@ import { RootState } from '../../../../redux/store';
 import { ContributorRole } from '../../../../types/contributor.types';
 import { Registration } from '../../../../types/registration.types';
 import { CristinPerson } from '../../../../types/user.types';
-import { ROWS_PER_PAGE_OPTIONS, isErrorStatus, isSuccessStatus } from '../../../../utils/constants';
+import { isErrorStatus, isSuccessStatus, ROWS_PER_PAGE_OPTIONS } from '../../../../utils/constants';
 import { dataTestId } from '../../../../utils/dataTestIds';
 import { useDebounce } from '../../../../utils/hooks/useDebounce';
 import { CristinPersonList } from './CristinPersonList';
@@ -107,24 +107,22 @@ export const AddContributorForm = ({
       {personQuery.isFetching ? (
         <ListSkeleton arrayLength={3} minWidth={100} height={80} />
       ) : userSearch && personQuery.data && personQuery.data.size > 0 && debouncedSearchTerm ? (
-        <>
+        <ListPagination
+          count={personQuery.data?.size ?? 0}
+          rowsPerPage={rowsPerPage}
+          page={page}
+          onPageChange={(newPage) => setPage(newPage)}
+          onRowsPerPageChange={(newRowsPerPage) => {
+            setRowsPerPage(newRowsPerPage);
+            setPage(1);
+          }}>
           <CristinPersonList
             personSearch={personQuery.data}
             userId={selectedUser?.id}
             onSelectContributor={setSelectedUser}
             searchTerm={debouncedSearchTerm}
           />
-          <ListPagination
-            count={personQuery.data?.size ?? 0}
-            rowsPerPage={rowsPerPage}
-            page={page}
-            onPageChange={(newPage) => setPage(newPage)}
-            onRowsPerPageChange={(newRowsPerPage) => {
-              setRowsPerPage(newRowsPerPage);
-              setPage(1);
-            }}
-          />
-        </>
+        </ListPagination>
       ) : (
         debouncedSearchTerm && <Typography>{t('common.no_hits')}</Typography>
       )}

--- a/src/pages/research_profile/ResearchProfile.tsx
+++ b/src/pages/research_profile/ResearchProfile.tsx
@@ -1,4 +1,4 @@
-import { Box, Chip, CircularProgress, Divider, IconButton, List, Link as MuiLink, Typography } from '@mui/material';
+import { Box, Chip, CircularProgress, Divider, IconButton, Link as MuiLink, List, Typography } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
@@ -7,7 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { fetchPerson, searchForProjects } from '../../api/cristinApi';
 import { fetchPromotedPublicationsById } from '../../api/preferencesApi';
-import { FetchResultsParams, fetchResults } from '../../api/searchApi';
+import { fetchResults, FetchResultsParams } from '../../api/searchApi';
 import { ListPagination } from '../../components/ListPagination';
 import { PageSpinner } from '../../components/PageSpinner';
 import { ProfilePicture } from '../../components/ProfilePicture';
@@ -193,22 +193,20 @@ const ResearchProfile = () => {
         {registrationsQuery.isLoading || promotedPublicationsQuery.isLoading ? (
           <CircularProgress aria-labelledby="registration-label" />
         ) : registrationsQuery.data && registrationsQuery.data.totalHits > 0 ? (
-          <>
+          <ListPagination
+            count={registrationsQuery.data.totalHits}
+            rowsPerPage={registrationRowsPerPage}
+            page={registrationsPage}
+            onPageChange={(newPage) => setRegistrationsPage(newPage)}
+            onRowsPerPageChange={(newRowsPerPage) => {
+              setRegistrationRowsPerPage(newRowsPerPage);
+              setRegistrationsPage(1);
+            }}>
             <RegistrationSearchResults
               searchResult={registrationsQuery.data.hits}
               promotedPublications={promotedPublications}
             />
-            <ListPagination
-              count={registrationsQuery.data.totalHits}
-              rowsPerPage={registrationRowsPerPage}
-              page={registrationsPage}
-              onPageChange={(newPage) => setRegistrationsPage(newPage)}
-              onRowsPerPageChange={(newRowsPerPage) => {
-                setRegistrationRowsPerPage(newRowsPerPage);
-                setRegistrationsPage(1);
-              }}
-            />
-          </>
+          </ListPagination>
         ) : (
           <Typography>{t('common.no_hits')}</Typography>
         )}
@@ -221,23 +219,21 @@ const ResearchProfile = () => {
         {projectsQuery.isLoading ? (
           <CircularProgress aria-labelledby="project-label" />
         ) : projects.length > 0 ? (
-          <>
+          <ListPagination
+            count={projectsQuery.data?.size ?? 0}
+            rowsPerPage={projectRowsPerPage}
+            page={projectsPage}
+            onPageChange={(newPage) => setProjectsPage(newPage)}
+            onRowsPerPageChange={(newRowsPerPage) => {
+              setProjectRowsPerPage(newRowsPerPage);
+              setProjectsPage(1);
+            }}>
             <List>
               {projects.map((project) => (
                 <ProjectListItem key={project.id} project={project} refetchProjects={projectsQuery.refetch} />
               ))}
             </List>
-            <ListPagination
-              count={projectsQuery.data?.size ?? 0}
-              rowsPerPage={projectRowsPerPage}
-              page={projectsPage}
-              onPageChange={(newPage) => setProjectsPage(newPage)}
-              onRowsPerPageChange={(newRowsPerPage) => {
-                setProjectRowsPerPage(newRowsPerPage);
-                setProjectsPage(1);
-              }}
-            />
-          </>
+          </ListPagination>
         ) : (
           <Typography>{t('common.no_hits')}</Typography>
         )}

--- a/src/pages/search/CristinSearchPagination.tsx
+++ b/src/pages/search/CristinSearchPagination.tsx
@@ -27,7 +27,7 @@ export const CristinSearchPagination = ({ children, totalCount, page, rowsPerPag
       onPageChange={(newPage) => updatePath(newPage.toString(), rowsPerPage.toString())}
       rowsPerPage={rowsPerPage}
       onRowsPerPageChange={(newRowsPerPage) => updatePath('1', newRowsPerPage.toString())}
-      showPaginationTop={true}>
+      showPaginationTop>
       {children}
     </ListPagination>
   );

--- a/src/pages/search/CristinSearchPagination.tsx
+++ b/src/pages/search/CristinSearchPagination.tsx
@@ -1,14 +1,16 @@
+import { ReactNode } from 'react';
 import { useHistory } from 'react-router-dom';
 import { ListPagination } from '../../components/ListPagination';
 import { SearchParam } from '../../utils/searchHelpers';
 
 interface CristinSearchPaginationProps {
+  children: ReactNode;
   totalCount: number;
   page: number;
   rowsPerPage: number;
 }
 
-export const CristinSearchPagination = ({ totalCount, page, rowsPerPage }: CristinSearchPaginationProps) => {
+export const CristinSearchPagination = ({ children, totalCount, page, rowsPerPage }: CristinSearchPaginationProps) => {
   const history = useHistory();
   const params = new URLSearchParams(history.location.search);
 
@@ -25,6 +27,8 @@ export const CristinSearchPagination = ({ totalCount, page, rowsPerPage }: Crist
       onPageChange={(newPage) => updatePath(newPage.toString(), rowsPerPage.toString())}
       rowsPerPage={rowsPerPage}
       onRowsPerPageChange={(newRowsPerPage) => updatePath('1', newRowsPerPage.toString())}
-    />
+      showPaginationTop={true}>
+      {children}
+    </ListPagination>
   );
 };

--- a/src/pages/search/person_search/PersonSearch.tsx
+++ b/src/pages/search/person_search/PersonSearch.tsx
@@ -2,7 +2,6 @@ import { Box, List, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { ListSkeleton } from '../../../components/ListSkeleton';
-import { ListPaginationTop } from '../../../components/ListPaginationTop';
 import { ROWS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 import { SearchParam } from '../../../utils/searchHelpers';
 import { CristinSearchPagination } from '../CristinSearchPagination';
@@ -31,13 +30,13 @@ export const PersonSearch = ({ personQuery }: PersonSearchProps) => {
         <ListSkeleton arrayLength={3} minWidth={40} height={100} />
       ) : searchResults && searchResults.length > 0 ? (
         <div>
-          <ListPaginationTop count={totalHits} page={page} rowsPerPage={rowsPerPage} />
-          <List>
-            {searchResults.map((person) => (
-              <PersonListItem key={person.id} person={person} />
-            ))}
-          </List>
-          <CristinSearchPagination totalCount={totalHits} page={page} rowsPerPage={rowsPerPage} />
+          <CristinSearchPagination totalCount={totalHits} page={page} rowsPerPage={rowsPerPage}>
+            <List>
+              {searchResults.map((person) => (
+                <PersonListItem key={person.id} person={person} />
+              ))}
+            </List>
+          </CristinSearchPagination>
         </div>
       ) : (
         <Typography sx={{ mx: { xs: '0.5rem', md: 0 } }}>{t('common.no_hits')}</Typography>

--- a/src/pages/search/project_search/ProjectSearch.tsx
+++ b/src/pages/search/project_search/ProjectSearch.tsx
@@ -2,7 +2,6 @@ import { Box, List, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { ListSkeleton } from '../../../components/ListSkeleton';
-import { ListPaginationTop } from '../../../components/ListPaginationTop';
 import { ROWS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 import { SearchParam } from '../../../utils/searchHelpers';
 import { CristinSearchPagination } from '../CristinSearchPagination';
@@ -31,13 +30,13 @@ export const ProjectSearch = ({ projectQuery }: ProjectSearchProps) => {
         <ListSkeleton arrayLength={3} minWidth={40} height={100} />
       ) : projectsSearchResults && projectsSearchResults.length > 0 ? (
         <div>
-          <ListPaginationTop count={totalHits} page={page} rowsPerPage={rowsPerPage} />
-          <List>
-            {projectsSearchResults.map((project) => (
-              <ProjectListItem key={project.id} project={project} />
-            ))}
-          </List>
-          <CristinSearchPagination totalCount={totalHits} page={page} rowsPerPage={rowsPerPage} />
+          <CristinSearchPagination totalCount={totalHits} page={page} rowsPerPage={rowsPerPage}>
+            <List>
+              {projectsSearchResults.map((project) => (
+                <ProjectListItem key={project.id} project={project} />
+              ))}
+            </List>
+          </CristinSearchPagination>
         </div>
       ) : (
         <Typography sx={{ mx: { xs: '0.5rem', md: 0 } }}>{t('common.no_hits')}</Typography>

--- a/src/pages/search/registration_search/RegistrationSearch.tsx
+++ b/src/pages/search/registration_search/RegistrationSearch.tsx
@@ -2,7 +2,6 @@ import { Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { ListPagination } from '../../../components/ListPagination';
-import { ListPaginationTop } from '../../../components/ListPaginationTop';
 import { ListSkeleton } from '../../../components/ListSkeleton';
 import { ROWS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 import { SearchParam } from '../../../utils/searchHelpers';
@@ -32,8 +31,6 @@ export const RegistrationSearch = ({ registrationQuery }: Pick<SearchPageProps, 
         <ListSkeleton arrayLength={3} minWidth={40} height={100} />
       ) : registrationQuery.data?.hits && registrationQuery.data.hits.length > 0 ? (
         <>
-          <ListPaginationTop count={registrationQuery.data.totalHits} page={page + 1} rowsPerPage={rowsPerPage} />
-          <RegistrationSearchResults searchResult={registrationQuery.data.hits} />
           <ListPagination
             count={registrationQuery.data.totalHits}
             page={page + 1}
@@ -41,7 +38,9 @@ export const RegistrationSearch = ({ registrationQuery }: Pick<SearchPageProps, 
             rowsPerPage={rowsPerPage}
             onRowsPerPageChange={(newRowsPerPage) => updatePath('0', newRowsPerPage.toString())}
             maxHits={10_000}
-          />
+            showPaginationTop={true}>
+            <RegistrationSearchResults searchResult={registrationQuery.data.hits} />
+          </ListPagination>
         </>
       ) : (
         <Typography sx={{ mx: { xs: '0.5rem', md: 0 } }}>{t('common.no_hits')}</Typography>


### PR DESCRIPTION
- Rewrite the `<ListPagination /> `to be a wrapper for lists instead of an appendable component. Reason being that this gives better control for when pagination controls are wanted above the lists as well.
-> As a result, the contents of `<ListPagination />` is moved to the newly created component `<ListPaginationBottom />`

- Remove the `sx` prop as it was used only twice, and instead styled those two lists themselves instead.

- Remove `aria-live="polite"` from pagination counter as pointed out in another PR.