### PR TITLE
NP-45912 Refetch curator search after updates

### DIFF
--- a/src/pages/editor/CuratorRow.tsx
+++ b/src/pages/editor/CuratorRow.tsx
@@ -6,11 +6,17 @@ import { ViewingScopeChip } from '../basic_data/institution_admin/edit_user/View
 
 interface CuratorRowProps {
   curator: InstitutionUser;
+  refetchCurators: () => void;
 }
 
-export const CuratorRow = ({ curator }: CuratorRowProps) => {
+export const CuratorRow = ({ curator, refetchCurators }: CuratorRowProps) => {
   const [openDialog, setOpenDialog] = useState(false);
-  const toggleDialog = () => setOpenDialog(!openDialog);
+  const toggleDialog = () => {
+    if (openDialog) {
+      refetchCurators();
+    }
+    setOpenDialog(!openDialog);
+  };
 
   return (
     <>

--- a/src/pages/editor/EditorCurators.tsx
+++ b/src/pages/editor/EditorCurators.tsx
@@ -37,8 +37,8 @@ export const EditorCurators = () => {
     enabled: !!customerId,
     queryFn: () => (customerId ? fetchUsers(customerId, rolesWithAreaOfResponsibility) : undefined),
     meta: { errorMessage: t('feedback.error.get_users_for_institution') },
-    refetchOnWindowFocus: true,
   });
+
   const curators = curatorsQuery.data ?? [];
   const filteredCurators = curators.filter((curator) => {
     const name = `${curator.givenName} ${curator.familyName}`.toLowerCase();
@@ -88,7 +88,7 @@ export const EditorCurators = () => {
 
               <TableBody>
                 {curatorsOnPage.map((curator) => (
-                  <CuratorRow key={curator.username} curator={curator} />
+                  <CuratorRow key={curator.username} curator={curator} refetchCurators={curatorsQuery.refetch} />
                 ))}
               </TableBody>
             </Table>

--- a/src/pages/editor/EditorCurators.tsx
+++ b/src/pages/editor/EditorCurators.tsx
@@ -37,6 +37,7 @@ export const EditorCurators = () => {
     enabled: !!customerId,
     queryFn: () => (customerId ? fetchUsers(customerId, rolesWithAreaOfResponsibility) : undefined),
     meta: { errorMessage: t('feedback.error.get_users_for_institution') },
+    refetchOnWindowFocus: true,
   });
   const curators = curatorsQuery.data ?? [];
   const filteredCurators = curators.filter((curator) => {


### PR DESCRIPTION
Hent kuratorer på nytt når man lukker dialogen, for å sikre at vi ikke viser utdatert data. Dette var spesielt synlig når man endret ansvarsområde, siden man fikk se gammel data når dialogen ble lukket.