### PR TITLE
Migrate to husky v9

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npm run pre-commit

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "react-scripts build",
     "pre-commit": "npx lint-staged && npm run unused-i18n-keys",
-    "prepare": "husky install",
+    "prepare": "husky",
     "start": "react-scripts -r @cypress/instrument-cra start",
     "start:mock": "set REACT_APP_USE_MOCK=true&& npm start",
     "test": "cypress run",


### PR DESCRIPTION
Migrer til v9 av husky, for å unngå deprecation-warnings i konsollen når man kjører `npm i` o.l.

Basert på migration guide her: https://github.com/typicode/husky/releases/tag/v9.0.1