### PR TITLE
Np 46195 allow edit person with external employments

### DIFF
--- a/src/pages/basic_data/institution_admin/edit_user/PersonFormSection.tsx
+++ b/src/pages/basic_data/institution_admin/edit_user/PersonFormSection.tsx
@@ -1,41 +1,26 @@
 import { Box, TextField, Typography } from '@mui/material';
 import { useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
-import { useSelector } from 'react-redux';
 import { NationalIdNumberField } from '../../../../components/NationalIdNumberField';
 import { AffiliationHierarchy } from '../../../../components/institution/AffiliationHierarchy';
-import { RootState } from '../../../../redux/store';
 import { Employment } from '../../../../types/user.types';
 import { dataTestId } from '../../../../utils/dataTestIds';
-import { getIdentifierFromId } from '../../../../utils/general-helpers';
 import { convertToFlatCristinPerson, isActiveEmployment } from '../../../../utils/user-helpers';
 import { UserFormData } from './UserFormDialog';
 
-export const PersonFormSection = () => {
+interface PersonFormSectionProps {
+  externalEmployments: Employment[];
+}
+
+export const PersonFormSection = ({ externalEmployments }: PersonFormSectionProps) => {
   const { t } = useTranslation();
-  const topOrgCristinId = useSelector((store: RootState) => store.user?.topOrgCristinId);
 
   const { values } = useFormikContext<UserFormData>();
   if (!values.person) {
     return null;
   }
 
-  const { firstName, lastName, employments, orcid, nationalId } = convertToFlatCristinPerson(values.person);
-
-  const topOrgCristinIdentifier = topOrgCristinId ? getIdentifierFromId(topOrgCristinId) : '';
-
-  const employmentsInThisInstitution: Employment[] = [];
-  const employmentsInOtherInstitutions: Employment[] = [];
-  const targetOrganizationIdStart = `${topOrgCristinIdentifier?.split('.')[0]}.`;
-
-  employments.forEach((employment) => {
-    const organizationIdentifier = getIdentifierFromId(employment.organization);
-    if (organizationIdentifier?.startsWith(targetOrganizationIdStart)) {
-      employmentsInThisInstitution.push(employment);
-    } else {
-      employmentsInOtherInstitutions.push(employment);
-    }
-  });
+  const { firstName, lastName, orcid, nationalId } = convertToFlatCristinPerson(values.person);
 
   return (
     <section>
@@ -59,11 +44,11 @@ export const PersonFormSection = () => {
         />
         <NationalIdNumberField nationalId={nationalId} />
         {orcid && <TextField variant="filled" disabled value={orcid} label={t('common.orcid')} />}
-        {employmentsInOtherInstitutions.some(isActiveEmployment) && (
+        {externalEmployments.some(isActiveEmployment) && (
           <div>
             <Typography variant="h3">{t('basic_data.person_register.other_employments')}</Typography>
             <Box component="ul" sx={{ my: 0, pl: '1rem' }}>
-              {employmentsInOtherInstitutions.filter(isActiveEmployment).map((affiliation) => (
+              {externalEmployments.filter(isActiveEmployment).map((affiliation) => (
                 <li key={affiliation.organization}>
                   <Box sx={{ display: 'flex', gap: '0.5rem' }}>
                     <AffiliationHierarchy unitUri={affiliation.organization} commaSeparated />

--- a/src/pages/basic_data/institution_admin/edit_user/UserFormDialog.tsx
+++ b/src/pages/basic_data/institution_admin/edit_user/UserFormDialog.tsx
@@ -132,24 +132,20 @@ export const UserFormDialog = ({ open, onClose, existingUser, existingPerson }: 
       dispatch(setNotification({ message: t('feedback.success.update_institution_user'), variant: 'success' })),
   });
 
-  const initialPerson: CristinPerson | undefined = personQuery.data
-    ? {
-        ...personQuery.data,
-        employments: internalEmployments,
-      }
-    : personQuery.data;
-
-  const initialUser: InstitutionUser | undefined = institutionUserQuery.isError
-    ? {
-        institution: customerId,
-        roles: [{ type: 'Role', rolename: RoleName.Creator }],
-        username: username,
-      }
-    : institutionUserQuery.data;
-
   const initialValues: UserFormData = {
-    person: initialPerson,
-    user: initialUser,
+    person: personQuery.data
+      ? {
+          ...personQuery.data,
+          employments: internalEmployments,
+        }
+      : personQuery.data,
+    user: institutionUserQuery.isError
+      ? {
+          institution: customerId,
+          roles: [{ type: 'Role', rolename: RoleName.Creator }],
+          username: username,
+        }
+      : institutionUserQuery.data,
   };
 
   return (

--- a/src/pages/basic_data/institution_admin/person_register/PersonRegisterPage.tsx
+++ b/src/pages/basic_data/institution_admin/person_register/PersonRegisterPage.tsx
@@ -126,13 +126,7 @@ export const PersonRegisterPage = () => {
                       ))
                     : employees.map((person) => (
                         <ErrorBoundary key={person.id}>
-                          <PersonTableRow
-                            cristinPerson={person}
-                            topOrgCristinIdentifier={
-                              user?.topOrgCristinId ? user.topOrgCristinId.split('/').pop() ?? '' : ''
-                            }
-                            refetchEmployees={employeeSearchQuery.refetch}
-                          />
+                          <PersonTableRow cristinPerson={person} refetchEmployees={employeeSearchQuery.refetch} />
                         </ErrorBoundary>
                       ))}
                 </TableBody>

--- a/src/pages/basic_data/institution_admin/person_register/PersonTableRow.tsx
+++ b/src/pages/basic_data/institution_admin/person_register/PersonTableRow.tsx
@@ -41,20 +41,7 @@ export const PersonTableRow = ({ cristinPerson, topOrgCristinIdentifier, refetch
   const orcidUrl = orcid ? `${ORCID_BASE_URL}/${orcid}` : '';
 
   const fullName = getFullCristinName(cristinPerson.names);
-
   const activeEmployments = employments.filter(isActiveEmployment);
-  const employmentsInThisInstitution: Employment[] = [];
-  const employmentsInOtherInstitutions: Employment[] = [];
-  const targetOrganizationIdStart = `${topOrgCristinIdentifier?.split('.')[0]}.`;
-
-  employments.forEach((employment) => {
-    const organizationIdentifier = employment.organization.split('/').pop();
-    if (organizationIdentifier?.startsWith(targetOrganizationIdStart)) {
-      employmentsInThisInstitution.push(employment);
-    } else {
-      employmentsInOtherInstitutions.push(employment);
-    }
-  });
 
   return (
     <>

--- a/src/pages/basic_data/institution_admin/person_register/PersonTableRow.tsx
+++ b/src/pages/basic_data/institution_admin/person_register/PersonTableRow.tsx
@@ -22,11 +22,10 @@ export interface PersonData {
 
 interface PersonTableRowProps {
   cristinPerson: CristinPerson;
-  topOrgCristinIdentifier: string;
   refetchEmployees: () => void;
 }
 
-export const PersonTableRow = ({ cristinPerson, topOrgCristinIdentifier, refetchEmployees }: PersonTableRowProps) => {
+export const PersonTableRow = ({ cristinPerson, refetchEmployees }: PersonTableRowProps) => {
   const { t } = useTranslation();
 
   const [openDialog, setOpenDialog] = useState(false);


### PR DESCRIPTION
Tillat administrator å endre på brukere som har en ugyldig ansettelse på en annen institusjon. Dette er en feil som ble introdusert ifbm endringer for ansvarsområde.

Fortsatt er det en liten bug hvor bruker ikke får se oppdatert data om man endrer i cristin-data da søket ikke er indeksert opp med riktig data raskt nok etter endring. Løser ikke dette problemet i denne saken, da problemet når er at mange ikke får til å endre på person/bruker i det hele tatt