### PR TITLE
Disable create employment button when form data is not valid

### DIFF
--- a/src/pages/basic_data/institution_admin/AddEmployeePage.tsx
+++ b/src/pages/basic_data/institution_admin/AddEmployeePage.tsx
@@ -130,7 +130,7 @@ export const AddEmployeePage = () => {
         validationSchema={addEmployeeValidationSchema}
         onSubmit={onSubmit}
         validateOnMount>
-        {({ isSubmitting, values, setFieldValue, errors }: FormikProps<AddEmployeeData>) => (
+        {({ isSubmitting, values, setFieldValue, errors, isValid }: FormikProps<AddEmployeeData>) => (
           <Form noValidate>
             <Box
               sx={{
@@ -168,6 +168,7 @@ export const AddEmployeePage = () => {
               <LoadingButton
                 variant="contained"
                 size="large"
+                disabled={!isValid}
                 loading={isSubmitting}
                 type="submit"
                 startIcon={<AddCircleOutlineIcon />}>


### PR DESCRIPTION
Ketil rapporterte feil der formen ble "låst" om brukeren trykte ENTER mens man ventet på søketreff fra personsøk