### PR TITLE
making fetchRegistration api call to consume publication.identifier

### DIFF
--- a/src/api/registrationApi.ts
+++ b/src/api/registrationApi.ts
@@ -86,7 +86,7 @@ export const fetchRegistrationsByOwner = async () => {
 };
 export const fetchRegistrationTickets = async (registrationId: string) => {
   const getTickets = await authenticatedApiRequest2<TicketCollection>({
-    url: `${registrationId}/tickets`,
+    url: `publication/${registrationId}/tickets`,
   });
   return getTickets.data;
 };

--- a/src/pages/public_registration/RegistrationLandingPage.tsx
+++ b/src/pages/public_registration/RegistrationLandingPage.tsx
@@ -50,7 +50,6 @@ export const RegistrationLandingPage = () => {
   });
 
   const registration = registrationQuery.data;
-  const registrationId = registration?.id ?? '';
 
   const isRegistrationAdmin =
     userIsRegistrationOwner(user, registration) || userIsRegistrationCurator(user, registration);
@@ -62,8 +61,8 @@ export const RegistrationLandingPage = () => {
 
   const ticketsQuery = useQuery({
     enabled: isRegistrationAdmin,
-    queryKey: ['registrationTickets', registrationId],
-    queryFn: () => fetchRegistrationTickets(registrationId),
+    queryKey: ['registrationTickets', identifier],
+    queryFn: () => fetchRegistrationTickets(identifier),
     meta: { errorMessage: t('feedback.error.get_tickets') },
   });
 

--- a/src/pages/registration/SupportModalContent.tsx
+++ b/src/pages/registration/SupportModalContent.tsx
@@ -17,8 +17,8 @@ export const SupportModalContent = ({ registration }: SupportModalContentProps) 
 
   const ticketsQuery = useQuery({
     enabled: !!registration,
-    queryKey: ['registrationTickets', registration.id],
-    queryFn: () => fetchRegistrationTickets(registration.id),
+    queryKey: ['registrationTickets', registration.identifier],
+    queryFn: () => fetchRegistrationTickets(registration.identifier),
     onError: () => dispatch(setNotification({ message: t('feedback.error.get_tickets'), variant: 'error' })),
   });
 


### PR DESCRIPTION
Publication served from publication-api does not have publication.id, it has publication.identifier.
Updating fetchRegistrationTickets to use publication.identifier from publication. 

Problem:

Unable to fetch tickets for deleted [registration](https://dev.nva.sikt.no/registration/018d550eb538-395a6118-afb9-4b24-aa07-04b434457eb3).
Probably because fetchRegistration() returns publication tombstone.

