### PR TITLE
Rename sort by key for person search

### DIFF
--- a/src/pages/search/CristinSearchPagination.tsx
+++ b/src/pages/search/CristinSearchPagination.tsx
@@ -1,8 +1,6 @@
 import { ReactNode } from 'react';
 import { useHistory } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
 import { ListPagination } from '../../components/ListPagination';
-import { SortSelector } from '../../components/SortSelector';
 import { SearchParam } from '../../utils/searchHelpers';
 
 interface CristinSearchPaginationProps {
@@ -10,10 +8,16 @@ interface CristinSearchPaginationProps {
   totalCount: number;
   page: number;
   rowsPerPage: number;
+  sortingComponent?: ReactNode;
 }
 
-export const CristinSearchPagination = ({ children, totalCount, page, rowsPerPage }: CristinSearchPaginationProps) => {
-  const { t } = useTranslation();
+export const CristinSearchPagination = ({
+  children,
+  totalCount,
+  page,
+  rowsPerPage,
+  sortingComponent,
+}: CristinSearchPaginationProps) => {
   const history = useHistory();
   const params = new URLSearchParams(history.location.search);
 
@@ -22,28 +26,6 @@ export const CristinSearchPagination = ({ children, totalCount, page, rowsPerPag
     params.set(SearchParam.Results, results);
     history.push({ search: params.toString() });
   };
-
-  const sortingComponent = (
-    <SortSelector
-      orderKey="orderBy"
-      sortKey="sort"
-      aria-label={t('search.sort_by')}
-      size="small"
-      variant="standard"
-      options={[
-        {
-          orderBy: 'name',
-          sortOrder: 'asc',
-          label: t('search.sort_by_name_asc'),
-        },
-        {
-          orderBy: 'name',
-          sortOrder: 'desc',
-          label: t('search.sort_by_name_desc'),
-        },
-      ]}
-    />
-  );
 
   return (
     <ListPagination

--- a/src/pages/search/person_search/PersonSearch.tsx
+++ b/src/pages/search/person_search/PersonSearch.tsx
@@ -2,6 +2,7 @@ import { Box, List, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { ListSkeleton } from '../../../components/ListSkeleton';
+import { SortSelector } from '../../../components/SortSelector';
 import { ROWS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 import { SearchParam } from '../../../utils/searchHelpers';
 import { CristinSearchPagination } from '../CristinSearchPagination';
@@ -24,13 +25,39 @@ export const PersonSearch = ({ personQuery }: PersonSearchProps) => {
 
   const rowsPerPage = resultsParam ? +resultsParam : ROWS_PER_PAGE_OPTIONS[0];
 
+  const sortingComponent = (
+    <SortSelector
+      orderKey="orderBy"
+      sortKey="sort"
+      aria-label={t('search.sort_by')}
+      size="small"
+      variant="standard"
+      options={[
+        {
+          orderBy: 'name',
+          sortOrder: 'asc',
+          label: t('search.sort_by_last_name_asc'),
+        },
+        {
+          orderBy: 'name',
+          sortOrder: 'desc',
+          label: t('search.sort_by_last_name_desc'),
+        },
+      ]}
+    />
+  );
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
       {personQuery.isLoading ? (
         <ListSkeleton arrayLength={3} minWidth={40} height={100} />
       ) : searchResults && searchResults.length > 0 ? (
         <div>
-          <CristinSearchPagination totalCount={totalHits} page={page} rowsPerPage={rowsPerPage}>
+          <CristinSearchPagination
+            totalCount={totalHits}
+            page={page}
+            rowsPerPage={rowsPerPage}
+            sortingComponent={sortingComponent}>
             <List>
               {searchResults.map((person) => (
                 <PersonListItem key={person.id} person={person} />

--- a/src/pages/search/project_search/ProjectSearch.tsx
+++ b/src/pages/search/project_search/ProjectSearch.tsx
@@ -2,6 +2,7 @@ import { Box, List, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { ListSkeleton } from '../../../components/ListSkeleton';
+import { SortSelector } from '../../../components/SortSelector';
 import { ROWS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 import { SearchParam } from '../../../utils/searchHelpers';
 import { CristinSearchPagination } from '../CristinSearchPagination';
@@ -24,13 +25,39 @@ export const ProjectSearch = ({ projectQuery }: ProjectSearchProps) => {
 
   const rowsPerPage = resultsParam ? +resultsParam : ROWS_PER_PAGE_OPTIONS[0];
 
+  const sortingComponent = (
+    <SortSelector
+      orderKey="orderBy"
+      sortKey="sort"
+      aria-label={t('search.sort_by')}
+      size="small"
+      variant="standard"
+      options={[
+        {
+          orderBy: 'name',
+          sortOrder: 'asc',
+          label: t('search.sort_by_name_asc'),
+        },
+        {
+          orderBy: 'name',
+          sortOrder: 'desc',
+          label: t('search.sort_by_name_desc'),
+        },
+      ]}
+    />
+  );
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
       {projectQuery.isLoading ? (
         <ListSkeleton arrayLength={3} minWidth={40} height={100} />
       ) : projectsSearchResults && projectsSearchResults.length > 0 ? (
         <div>
-          <CristinSearchPagination totalCount={totalHits} page={page} rowsPerPage={rowsPerPage}>
+          <CristinSearchPagination
+            totalCount={totalHits}
+            page={page}
+            rowsPerPage={rowsPerPage}
+            sortingComponent={sortingComponent}>
             <List>
               {projectsSearchResults.map((project) => (
                 <ProjectListItem key={project.id} project={project} />

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1764,6 +1764,8 @@
     "select_one_or_more_categories": "Velg en eller flere kategorier",
     "sort_by": "Sorter etter",
     "sort_by_modified_date": "Sist endret",
+    "sort_by_last_name_asc": "Etternavn A-Å",
+    "sort_by_last_name_desc": "Etternavn Å-A",
     "sort_by_name_asc": "Navn A-Å",
     "sort_by_name_desc": "Navn Å-A",
     "sort_by_published_date_asc": "Publiseringsdato (eldste først)",


### PR DESCRIPTION
Sorteringskomponenten for listevisning personsøk og prosjektsøk var felles, så måtte flytte den opp et nivå for å kunne å ha forskjellig navn på sortBy uten å vikle inn logikk.