### PR TITLE
Np 45760 null rrs

### DIFF
--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -147,6 +147,7 @@ export const FilesTableRow = ({ file, removeFile, baseFieldName, showFileVersion
                   <RadioGroup
                     {...field}
                     row
+                    sx={{ flexWrap: 'nowrap' }}
                     onChange={(event) => {
                       setFieldValue(field.name, JSON.parse(event.target.value));
                       if (isFunderRrs) {
@@ -228,9 +229,9 @@ export const FilesTableRow = ({ file, removeFile, baseFieldName, showFileVersion
             <Box
               sx={{
                 m: '1rem 1rem 0 1rem',
-                display: 'flex',
+                display: 'grid',
+                gridTemplateColumns: '1fr auto',
                 gap: '1rem',
-                justifyContent: 'space-evenly',
               }}>
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
                 {!file.publisherAuthority && customer && (

--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -232,7 +232,6 @@ export const FilesTableRow = ({ file, removeFile, baseFieldName, showFileVersion
                 m: '1rem 1rem 0 1rem',
                 display: 'grid',
                 gridTemplateColumns: '1fr auto',
-                alignItems: 'end',
                 gap: '1rem',
               }}>
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
@@ -274,13 +273,14 @@ export const FilesTableRow = ({ file, removeFile, baseFieldName, showFileVersion
                         label={t('registration.files_and_license.legal_note')}
                         multiline
                         disabled={disabled}
+                        helperText={<ErrorMessage name={field.name} />}
                       />
                     )}
                   </Field>
                 )}
               </Box>
 
-              <Box sx={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+              <Box sx={{ display: 'flex', gap: '0.5rem', alignItems: 'center', alignSelf: 'end' }}>
                 <Field name={embargoFieldName}>
                   {({ field, meta: { error, touched } }: FieldProps) => (
                     <DatePicker

--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -33,7 +33,7 @@ import { ConfirmDialog } from '../../../components/ConfirmDialog';
 import { TruncatableTypography } from '../../../components/TruncatableTypography';
 import { RootState } from '../../../redux/store';
 import { AssociatedFile, AssociatedFileType, RightsRetentionStrategy } from '../../../types/associatedArtifact.types';
-import { licenses } from '../../../types/license.types';
+import { LicenseUri, licenses } from '../../../types/license.types';
 import { SpecificFileFieldNames } from '../../../types/publicationFieldNames';
 import { Registration } from '../../../types/registration.types';
 import { dataTestId } from '../../../utils/dataTestIds';
@@ -147,7 +147,13 @@ export const FilesTableRow = ({ file, removeFile, baseFieldName, showFileVersion
                   <RadioGroup
                     {...field}
                     row
-                    onChange={(event) => setFieldValue(field.name, JSON.parse(event.target.value))}>
+                    onChange={(event) => {
+                      setFieldValue(field.name, JSON.parse(event.target.value));
+                      if (isFunderRrs) {
+                        setFieldValue(licenseFieldName, null);
+                        setFieldValue(rrsFieldName, undefined);
+                      }
+                    }}>
                     <FormControlLabel
                       value={false}
                       control={<Radio />}
@@ -174,7 +180,7 @@ export const FilesTableRow = ({ file, removeFile, baseFieldName, showFileVersion
                 data-testid={dataTestId.registrationWizard.files.selectLicenseField}
                 sx={{ minWidth: '15rem' }}
                 select
-                disabled={disabled}
+                disabled={disabled || isFunderRrs}
                 SelectProps={{
                   renderValue: (option) => {
                     const selectedLicense = licenses.find((license) => equalUris(license.id, option as string));
@@ -234,13 +240,17 @@ export const FilesTableRow = ({ file, removeFile, baseFieldName, showFileVersion
                       <Checkbox
                         checked={isFunderRrs}
                         onChange={() => {
-                          const newRrsValu: RightsRetentionStrategy | undefined = isFunderRrs
-                            ? undefined
-                            : {
-                                type: 'FunderRightsRetentionStrategy',
-                                configuredType: customer.rightsRetentionStrategy.type,
-                              };
-                          setFieldValue(rrsFieldName, newRrsValu);
+                          if (isFunderRrs) {
+                            setFieldValue(rrsFieldName, undefined);
+                            setFieldValue(licenseFieldName, null);
+                          } else {
+                            const newRrsValu: RightsRetentionStrategy = {
+                              type: 'FunderRightsRetentionStrategy',
+                              configuredType: customer.rightsRetentionStrategy.type,
+                            };
+                            setFieldValue(rrsFieldName, newRrsValu);
+                            setFieldValue(licenseFieldName, LicenseUri.CC_BY_4);
+                          }
                         }}
                       />
                     }

--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -232,6 +232,7 @@ export const FilesTableRow = ({ file, removeFile, baseFieldName, showFileVersion
                 m: '1rem 1rem 0 1rem',
                 display: 'grid',
                 gridTemplateColumns: '1fr auto',
+                alignItems: 'end',
                 gap: '1rem',
               }}>
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1223,6 +1223,7 @@
       "license": "Lisens",
       "licenses": "Lisenser",
       "link_to_resource": "Lenke til ressurs",
+      "mark_if_funder_requires_rrs": "Om denne publikasjonen er finansiert av en aktør som pålegger deg å følge RRS (ref. PlanS), så markerer du det her.",
       "no_duplicates": "Kunne ikke legge til \"{{fileName}}\", siden en fil med samme navn allerede finnes",
       "open_file": "Åpne fil",
       "published": "Publisert",

--- a/src/types/associatedArtifact.types.ts
+++ b/src/types/associatedArtifact.types.ts
@@ -1,6 +1,12 @@
 import { Uppy as UppyType } from '@uppy/core';
+import { RightsRetentionStrategyTypes } from './customerInstitution.types';
 
 export type AssociatedFileType = 'PublishedFile' | 'UnpublishedFile' | 'UnpublishableFile';
+
+export interface RightsRetentionStrategy {
+  type: 'FunderRightsRetentionStrategy' | 'CustomerRightsRetentionStrategy' | 'OverriddenRightsRetentionStrategy';
+  configuredType: RightsRetentionStrategyTypes;
+}
 
 export interface AssociatedFile {
   type: AssociatedFileType;
@@ -13,6 +19,7 @@ export interface AssociatedFile {
   embargoDate: Date | null;
   license: string | null;
   legalNote?: string;
+  rightsRetentionStrategy?: RightsRetentionStrategy;
 }
 
 export const emptyFile: AssociatedFile = {

--- a/src/types/publicationFieldNames.ts
+++ b/src/types/publicationFieldNames.ts
@@ -210,6 +210,7 @@ export enum SpecificFileFieldNames {
   EmbargoDate = 'embargoDate',
   License = 'license',
   LegalNote = 'legalNote',
+  RightsRetentionStrategy = 'rightsRetentionStrategy',
 }
 
 // The following fields should be present in "associatedArtifacts[index].<KEY> for links"


### PR DESCRIPTION
Håndter RRS for institusjoner som har innstilling `NullRightsRetentionStrategy`. Andre innstillinger kommer som egne PRs.

- Når fil er markert som "Akseptert", tillat å marker at fil skal følge RRS til finansiør
- Velg CC-BY-lisens og disable lisensfeltet, når bruker velger RRS

![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/e736e508-1911-40ed-a922-8769ff41a1b3)

