### PR TITLE
NP-46357 Sort results on publicationDate instead of publishedDate

### DIFF
--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -179,6 +179,11 @@ export enum ResultParam {
   Unit = 'unit',
 }
 
+export enum ResultSearchOrder {
+  ModifiedDate = 'modifiedDate',
+  PublicationDate = 'publicationDate',
+}
+
 export interface FetchResultsParams {
   [ResultParam.Abstract]?: string | null;
   [ResultParam.Aggregation]?: 'all' | 'none' | null;
@@ -200,7 +205,7 @@ export interface FetchResultsParams {
   [ResultParam.Isbn]?: string | null;
   [ResultParam.Issn]?: string | null;
   [ResultParam.Journal]?: string | null;
-  [ResultParam.Order]?: string | null;
+  [ResultParam.Order]?: ResultSearchOrder | null;
   [ResultParam.Project]?: string | null;
   [ResultParam.PublicationLanguageShould]?: string | null;
   [ResultParam.PublicationYearBefore]?: string | null;

--- a/src/pages/dashboard/HomePage.tsx
+++ b/src/pages/dashboard/HomePage.tsx
@@ -13,7 +13,7 @@ import {
   searchForPerson,
   searchForProjects,
 } from '../../api/cristinApi';
-import { fetchResults, FetchResultsParams, ResultParam, SortOrder } from '../../api/searchApi';
+import { FetchResultsParams, ResultParam, ResultSearchOrder, SortOrder, fetchResults } from '../../api/searchApi';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
 import { NavigationListAccordion } from '../../components/NavigationListAccordion';
 import { LinkButton, NavigationList, SideNavHeader, StyledPageWithSideMenu } from '../../components/PageWithSideMenu';
@@ -74,7 +74,7 @@ const HomePage = () => {
     isbn: params.get(ResultParam.Isbn),
     issn: params.get(ResultParam.Issn),
     journal: params.get(ResultParam.Journal),
-    order: params.get(ResultParam.Order),
+    order: params.get(ResultParam.Order) as ResultSearchOrder | null,
     publicationYearSince: params.get(ResultParam.PublicationYearSince),
     publicationYearBefore: params.get(ResultParam.PublicationYearBefore),
     publisher: params.get(ResultParam.Publisher),

--- a/src/pages/search/advanced_search/AdvancedSearchPage.tsx
+++ b/src/pages/search/advanced_search/AdvancedSearchPage.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
-import { FetchResultsParams, ResultParam, SortOrder, fetchResults } from '../../../api/searchApi';
+import { FetchResultsParams, ResultParam, ResultSearchOrder, SortOrder, fetchResults } from '../../../api/searchApi';
 import { CategoryChip } from '../../../components/CategorySelector';
 import { SearchForm } from '../../../components/SearchForm';
 import { PublicationInstanceType } from '../../../types/registration.types';
@@ -58,7 +58,7 @@ export const AdvancedSearchPage = () => {
     fundingIdentifier: params.get(ResultParam.FundingIdentifier),
     fundingSource: params.get(ResultParam.FundingSource),
     journal: params.get(ResultParam.Journal),
-    order: params.get(ResultParam.Order),
+    order: params.get(ResultParam.Order) as ResultSearchOrder | null,
     publicationLanguageShould: params.get(ResultParam.PublicationLanguageShould),
     publicationYearBefore: params.get(ResultParam.PublicationYearBefore),
     publicationYearSince: params.get(ResultParam.PublicationYearSince),

--- a/src/pages/search/registration_search/RegistrationSearch.tsx
+++ b/src/pages/search/registration_search/RegistrationSearch.tsx
@@ -4,7 +4,6 @@ import { useHistory } from 'react-router-dom';
 import { ListPagination } from '../../../components/ListPagination';
 import { ListSkeleton } from '../../../components/ListSkeleton';
 import { SortSelector } from '../../../components/SortSelector';
-import { RegistrationFieldName } from '../../../types/publicationFieldNames';
 import { ROWS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 import { SearchParam } from '../../../utils/searchHelpers';
 import { SearchPageProps } from '../SearchPage';
@@ -36,17 +35,17 @@ export const RegistrationSearch = ({ registrationQuery }: Pick<SearchPageProps, 
       variant="standard"
       options={[
         {
-          orderBy: RegistrationFieldName.ModifiedDate,
+          orderBy: 'modifiedDate',
           sortOrder: 'desc',
           label: t('search.sort_by_modified_date'),
         },
         {
-          orderBy: RegistrationFieldName.PublishedDate,
+          orderBy: 'publicationDate',
           sortOrder: 'desc',
           label: t('search.sort_by_published_date_desc'),
         },
         {
-          orderBy: RegistrationFieldName.PublishedDate,
+          orderBy: 'publicationDate',
           sortOrder: 'asc',
           label: t('search.sort_by_published_date_asc'),
         },

--- a/src/pages/search/registration_search/RegistrationSearch.tsx
+++ b/src/pages/search/registration_search/RegistrationSearch.tsx
@@ -1,6 +1,7 @@
 import { Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
+import { ResultSearchOrder } from '../../../api/searchApi';
 import { ListPagination } from '../../../components/ListPagination';
 import { ListSkeleton } from '../../../components/ListSkeleton';
 import { SortSelector } from '../../../components/SortSelector';
@@ -35,17 +36,17 @@ export const RegistrationSearch = ({ registrationQuery }: Pick<SearchPageProps, 
       variant="standard"
       options={[
         {
-          orderBy: 'modifiedDate',
+          orderBy: ResultSearchOrder.ModifiedDate,
           sortOrder: 'desc',
           label: t('search.sort_by_modified_date'),
         },
         {
-          orderBy: 'publicationDate',
+          orderBy: ResultSearchOrder.PublicationDate,
           sortOrder: 'desc',
           label: t('search.sort_by_published_date_desc'),
         },
         {
-          orderBy: 'publicationDate',
+          orderBy: ResultSearchOrder.PublicationDate,
           sortOrder: 'asc',
           label: t('search.sort_by_published_date_asc'),
         },

--- a/src/types/publicationFieldNames.ts
+++ b/src/types/publicationFieldNames.ts
@@ -119,12 +119,6 @@ export const allPublicationInstanceTypes = [
   ...Object.values(OtherRegistrationType),
 ];
 
-export enum RegistrationFieldName {
-  Identifier = 'identifier',
-  ModifiedDate = 'modifiedDate',
-  PublishedDate = 'publishedDate',
-}
-
 // Enums representing name of fields used by Formik
 export const contextTypeBaseFieldName = 'entityDescription.reference.publicationContext';
 export const instanceTypeBaseFieldName = 'entityDescription.reference.publicationInstance';


### PR DESCRIPTION
Sorter på oppgitt publiseringsår (publicationDate) i steted for når det faktisk ble publisert i NVA.
Per nå virker det bare sortinger per år, så er det en backendoppgave å fikse filtrering internt per år og noen andre mindre detaljer