### PR TITLE
NP-46367 Update logic for ticket fetching

### DIFF
--- a/src/pages/public_registration/RegistrationLandingPage.tsx
+++ b/src/pages/public_registration/RegistrationLandingPage.tsx
@@ -2,16 +2,15 @@ import { Box } from '@mui/material';
 import { Query, useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { useTranslation } from 'react-i18next';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { useHistory, useParams } from 'react-router-dom';
 import { fetchRegistration, fetchRegistrationTickets } from '../../api/registrationApi';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
 import { PageSpinner } from '../../components/PageSpinner';
 import { setNotification } from '../../redux/notificationSlice';
-import { RootState } from '../../redux/store';
 import { DeletedRegistrationProblem } from '../../types/error_responses';
 import { Registration, RegistrationStatus } from '../../types/registration.types';
-import { userIsRegistrationCurator, userIsRegistrationOwner } from '../../utils/registration-helpers';
+import { userCanEditRegistration } from '../../utils/registration-helpers';
 import { IdentifierParams } from '../../utils/urlPaths';
 import NotFound from '../errorpages/NotFound';
 import { NotPublished } from '../errorpages/NotPublished';
@@ -24,7 +23,6 @@ export const RegistrationLandingPage = () => {
   const dispatch = useDispatch();
   const { identifier } = useParams<IdentifierParams>();
   const shouldNotRedirect = new URLSearchParams(history.location.search).has('shouldNotRedirect');
-  const user = useSelector((store: RootState) => store.user);
 
   const registrationQuery = useQuery({
     queryKey: ['registration', identifier, shouldNotRedirect],
@@ -52,20 +50,21 @@ export const RegistrationLandingPage = () => {
   });
 
   const registration = registrationQuery.data;
-  const registrationId = registration?.id ?? '';
+  const registrationId = registration?.id;
 
-  const isRegistrationAdmin =
-    userIsRegistrationOwner(user, registration) || userIsRegistrationCurator(user, registration);
+  const canEditRegistration = !!registration && userCanEditRegistration(registration);
+
   const isAllowedToSeePublicRegistration =
     registration?.status === RegistrationStatus.Published ||
-    isRegistrationAdmin ||
+    canEditRegistration ||
     registration?.status === RegistrationStatus.DraftForDeletion ||
     registration?.status === RegistrationStatus.Unpublished;
 
+  const canFetchTickets = canEditRegistration && !!registrationId;
   const ticketsQuery = useQuery({
-    enabled: isRegistrationAdmin,
+    enabled: canFetchTickets,
     queryKey: ['registrationTickets', registrationId],
-    queryFn: () => fetchRegistrationTickets(registrationId),
+    queryFn: registrationId ? () => fetchRegistrationTickets(registrationId) : undefined,
     meta: { errorMessage: t('feedback.error.get_tickets') },
   });
 
@@ -83,14 +82,14 @@ export const RegistrationLandingPage = () => {
         gridTemplateAreas: { xs: '"tasks" "registration"', sm: '"registration tasks"' },
         gap: '1rem',
       }}>
-      {registrationQuery.isLoading || (isRegistrationAdmin && ticketsQuery.isLoading) ? (
+      {registrationQuery.isLoading || (canFetchTickets && ticketsQuery.isLoading) ? (
         <PageSpinner aria-label={t('common.result')} />
       ) : registration ? (
         isAllowedToSeePublicRegistration ? (
           <ErrorBoundary>
             <PublicRegistrationContent registration={registration} />
 
-            {isRegistrationAdmin && ticketsQuery.isSuccess && (
+            {canEditRegistration && ticketsQuery.isSuccess && (
               <ActionPanel
                 registration={registration}
                 refetchRegistrationAndTickets={refetchRegistrationAndTickets}


### PR DESCRIPTION
Problem med at bare kuratorer og eier av et resultat får se `ActionPanel`, da bare de har tilgang til å hente tickets.
Jeg tror at alle som har tilgang til `update` i `allowedOperations` også skal ha tilgang til å hente tickets, og at det blir en backendjobb for å få på plass mesteparten her. Må avklare med PO hva vi ønsker her.