### PR TITLE
Create PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+# Description
+
+Link to Jira issue:
+
+# Checklist
+
+## Required
+
+- [ ] The changes is working as expected
+- [ ] The changes are tested OK for both desktop and mobile screens
+- [ ] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
+- [ ] Interactive elements have data-testids
+- [ ] I have done a QA of my own changes
+
+## Optional
+
+- [ ] Solution is verified by PO/designer

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ Link to Jira issue:
 
 ## Required
 
-- [ ] The changes is working as expected
+- [ ] The changes are working as expected
 - [ ] The changes are tested OK for both desktop and mobile screens
 - [ ] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
 - [ ] Interactive elements have data-testids


### PR DESCRIPTION
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository#adding-a-pull-request-template

Det går tidvis mye tid på PR med mange round-trips som ikke trenger å være der. Dette er typisk ting man glemmer å sjekke selv, men som er åpenbart når noen poengterer det.

Spesielt `I have done a QA of my own changes` tror jeg vi kan prøve å bli mer bevisste på, hvor man selv går gjennom diffen og spør seg selv om alt fortsatt er gjeldende. Ofte er noe endret i starten, men når det til slutt er over i QA så er det ikke relevant lenger, men man glemmer å fjerne. Dette er ting man oftest ser selv om man går gjennom egen PR fra start-til-slutt. Det er også et ekstra insentiv til å lage små PRs 😅 

Tanken er at alle bokser under `Required` må være checked før man setter en PR til `Ready for review`
