### PR TITLE
NP-46271 Default viewingscope to users deafult viewingscope when none selected

### DIFF
--- a/src/pages/messages/TasksPage.tsx
+++ b/src/pages/messages/TasksPage.tsx
@@ -153,13 +153,16 @@ const TasksPage = () => {
     .filter(Boolean)
     .join(' AND ');
 
+  const getViewingScopeFromUrlOrDefaultToUsersViewingScope =
+    searchParams.get(TicketSearchParam.ViewingScope) || organizationScope.join(',');
+
   const ticketSearchParams: FetchTicketsParams = {
     query: ticketQueryString,
     results: rowsPerPage,
     from: (page - 1) * rowsPerPage,
     orderBy: searchParams.get(TicketSearchParam.OrderBy) as 'createdDate' | null,
     sortOrder: searchParams.get(TicketSearchParam.SortOrder) as 'asc' | 'desc' | null,
-    viewingScope: searchParams.get(TicketSearchParam.ViewingScope),
+    viewingScope: getViewingScopeFromUrlOrDefaultToUsersViewingScope,
     excludeSubUnits: excludeSubunits,
   };
 


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46271

# Checklist

## Required

- [x] The changes are working as expected
- [ ] ~~The changes are tested OK for both desktop and mobile screens~~
- [ ] ~~The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)~~
- [ ] ~~Interactive elements have data-testids~~
- [x] I have done a QA of my own changes

## Optional

- [x] Solution is verified by PO/designer
