### PR TITLE
NP-46385 Add key to subunits in advanced search

### DIFF
--- a/src/pages/search/advanced_search/OrganizationFilters.tsx
+++ b/src/pages/search/advanced_search/OrganizationFilters.tsx
@@ -79,6 +79,7 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
         inputMode="search"
         sx={{ minWidth: '15rem' }}
         getOptionLabel={(option) => getLanguageString(option.labels)}
+        getOptionKey={(option) => option.id}
         filterOptions={(options) => options}
         onInputChange={(_, value, reason) => {
           if (reason !== 'reset') {
@@ -126,6 +127,7 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
         disabled={!topLevelOrganizationId || subUnits.length === 0}
         sx={{ minWidth: '15rem' }}
         getOptionLabel={(option) => getLanguageString(option.labels)}
+        getOptionKey={(option) => option.id}
         onChange={(_, selectedUnit) => {
           const params = new URLSearchParams(history.location.search);
           if (selectedUnit) {


### PR DESCRIPTION
# Description
Added `getOptionKey` to ensure unique options when searching for subunits in advanced search

Link to Jira issue:
https://unit.atlassian.net/browse/NP-46385

# Checklist

## Required

- [x] The changes are working as expected
- [x] The changes are tested OK for both desktop and mobile screens
- [x] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

## Optional

- [x] Solution is verified by PO/designer
