### PR TITLE
NP-46415 Search for distinct parameters when using query

### DIFF
--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -171,6 +171,7 @@ export enum ResultParam {
   CristinIdentifier = 'cristinIdentifier',
   Doi = 'doi',
   ExcludeSubunits = 'excludeSubunits',
+  Fields = 'fields',
   Files = 'files',
   From = 'from',
   FundingIdentifier = 'fundingIdentifier',
@@ -343,6 +344,7 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
   }
   if (params.query) {
     searchParams.set(ResultParam.Query, params.query);
+    searchParams.set(ResultParam.Fields, `${ResultParam.Title},${ResultParam.Abstract},${ResultParam.ContributorName}`);
   }
   if (params.scientificIndex) {
     searchParams.set(ResultParam.ScientificReportPeriodBeforeParam, (+params.scientificIndex + 1).toString());

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1775,7 +1775,7 @@
     "search_for_funding_identifier": "Søk på Tilskudds-ID",
     "search_for_sub_unit": "Søk etter underenhet",
     "search_for_title": "Søk etter tittel",
-    "search_placeholder": "Søk etter tittel, bidragsyter, sammendrag, osv.",
+    "search_placeholder": "Søk etter tittel, bidragsyter eller sammendrag",
     "search_project_placeholder": "Søk etter tittel, prosjekt-ID, tilskudds-ID eller deltaker",
     "search_term_label": "Verdi",
     "sector": "Sektor",


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46415

Begrens hvor mange felter som søkes på når man søker på resultat med fritekstsøk. Dette pga en feil som oppstår i APIet om vi søker på alt.

# Checklist

## Required

- [x] The changes are working as expected
- [x] The changes are tested OK for both desktop and mobile screens
- [x] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

## Optional

- [ ] Solution is verified by PO/designer
