### PR TITLE
NP-46408 Add default status 'pending' on status filter on task page

### DIFF
--- a/src/components/AreaOfResponsibiltySelector.tsx
+++ b/src/components/AreaOfResponsibiltySelector.tsx
@@ -54,7 +54,7 @@ export const AreaOfResponsibilitySelector = () => {
     },
     meta: { errorMessage: t('feedback.error.get_institution') },
   });
-  const organizationOptions = useMemo(() => organizationQuery.data ?? [], [organizationQuery]);
+  const organizationOptions = useMemo(() => organizationQuery.data ?? [], [organizationQuery.data]);
 
   useEffect(() => {
     const sp = new URLSearchParams(history.location.search);

--- a/src/components/DialoguesWithoutCuratorButton.tsx
+++ b/src/components/DialoguesWithoutCuratorButton.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { TicketSearchParam, fetchCustomerTickets } from '../api/searchApi';
+import { fetchCustomerTickets, TicketSearchParam } from '../api/searchApi';
 import { notificationsParams } from '../pages/messages/TasksPage';
 import { RootState } from '../redux/store';
 import { TicketStatus } from '../types/publication_types/ticket.types';

--- a/src/components/TicketStatusFilter.tsx
+++ b/src/components/TicketStatusFilter.tsx
@@ -1,27 +1,34 @@
 import { Checkbox, FormControl, InputLabel, MenuItem, Select, SelectChangeEvent, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { TicketSearchParam } from '../api/searchApi';
 import { TicketStatus, ticketStatusValues } from '../types/publication_types/ticket.types';
 import { dataTestId } from '../utils/dataTestIds';
 
-export const TicketStatusFilter = () => {
+interface TicketStatusFilterProps {
+  isOnTasksPage: boolean;
+}
+
+export const TicketStatusFilter = ({ isOnTasksPage }: TicketStatusFilterProps) => {
   const { t } = useTranslation();
   const history = useHistory();
-  const searchParams = new URLSearchParams(history.location.search);
-  const selectedStatuses = (searchParams.get(TicketSearchParam.Status)?.split(',') ??
-    ticketStatusValues) as TicketStatus[];
+
+  const defaultStatusFilter = (isOnTasksPage ? ['Pending'] : ticketStatusValues) as TicketStatus[];
+  const [selectedStatuses, setSelectedStatuses] = useState(defaultStatusFilter);
+
+  useEffect(() => {
+    const searchParams = new URLSearchParams(history.location.search);
+    if (selectedStatuses.length > 0) {
+      searchParams.set(TicketSearchParam.Status, selectedStatuses.join(','));
+      history.push({ search: searchParams.toString() });
+    } else {
+      setSelectedStatuses(ticketStatusValues);
+    }
+  }, [history, selectedStatuses]);
 
   const handleChange = (event: SelectChangeEvent<string[]>) => {
-    const newSelectedStatuses = event.target.value as TicketStatus[];
-
-    if (newSelectedStatuses.length > 0) {
-      searchParams.set(TicketSearchParam.Status, newSelectedStatuses.join(','));
-    } else {
-      searchParams.delete(TicketSearchParam.Status);
-    }
-
-    history.push({ search: searchParams.toString() });
+    setSelectedStatuses(event.target.value as TicketStatus[]);
   };
 
   return (

--- a/src/components/TicketStatusFilter.tsx
+++ b/src/components/TicketStatusFilter.tsx
@@ -1,10 +1,10 @@
 import { Checkbox, FormControl, InputLabel, MenuItem, Select, SelectChangeEvent, Typography } from '@mui/material';
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { TicketSearchParam } from '../api/searchApi';
 import { TicketStatus, ticketStatusValues } from '../types/publication_types/ticket.types';
 import { dataTestId } from '../utils/dataTestIds';
+import { useEffect } from 'react';
 
 interface TicketStatusFilterProps {
   defaultStatusFilter?: TicketStatus[];
@@ -13,22 +13,28 @@ interface TicketStatusFilterProps {
 export const TicketStatusFilter = ({ defaultStatusFilter = ticketStatusValues }: TicketStatusFilterProps) => {
   const { t } = useTranslation();
   const history = useHistory();
+  const searchParams = new URLSearchParams(history.location.search);
 
-  const [selectedStatuses, setSelectedStatuses] = useState(defaultStatusFilter);
-
-  useEffect(() => {
-    const searchParams = new URLSearchParams(history.location.search);
-    if (selectedStatuses.length > 0) {
-      searchParams.set(TicketSearchParam.Status, selectedStatuses.join(','));
-      history.push({ search: searchParams.toString() });
-    } else {
-      setSelectedStatuses(ticketStatusValues);
-    }
-  }, [history, selectedStatuses]);
+  const statusesFromParams = searchParams.get(TicketSearchParam.Status)?.split(',') ?? [];
+  const selectedStatuses = (statusesFromParams.length > 0 ? statusesFromParams : defaultStatusFilter) as TicketStatus[];
 
   const handleChange = (event: SelectChangeEvent<string[]>) => {
-    setSelectedStatuses(event.target.value as TicketStatus[]);
+    const stats = event.target.value as TicketStatus[];
+    if (stats.length > 0) {
+      searchParams.set(TicketSearchParam.Status, stats.join(','));
+    } else {
+      searchParams.set(TicketSearchParam.Status, ticketStatusValues.join(','));
+    }
+    history.push({ search: searchParams.toString() });
   };
+
+  useEffect(() => {
+    const sp = new URLSearchParams(history.location.search);
+    if (!sp.get(TicketSearchParam.Status)) {
+      sp.set(TicketSearchParam.Status, defaultStatusFilter.join(','));
+      history.push({ search: sp.toString() });
+    }
+  }, [defaultStatusFilter, history]);
 
   return (
     <FormControl variant="outlined" size="small" sx={{ width: '100%' }}>

--- a/src/components/TicketStatusFilter.tsx
+++ b/src/components/TicketStatusFilter.tsx
@@ -7,14 +7,13 @@ import { TicketStatus, ticketStatusValues } from '../types/publication_types/tic
 import { dataTestId } from '../utils/dataTestIds';
 
 interface TicketStatusFilterProps {
-  isOnTasksPage: boolean;
+  defaultStatusFilter?: TicketStatus[];
 }
 
-export const TicketStatusFilter = ({ isOnTasksPage }: TicketStatusFilterProps) => {
+export const TicketStatusFilter = ({ defaultStatusFilter = ticketStatusValues }: TicketStatusFilterProps) => {
   const { t } = useTranslation();
   const history = useHistory();
 
-  const defaultStatusFilter = (isOnTasksPage ? ['Pending'] : ticketStatusValues) as TicketStatus[];
   const [selectedStatuses, setSelectedStatuses] = useState(defaultStatusFilter);
 
   useEffect(() => {

--- a/src/pages/messages/components/TicketList.tsx
+++ b/src/pages/messages/components/TicketList.tsx
@@ -64,7 +64,7 @@ export const TicketList = ({ ticketsQuery, setRowsPerPage, rowsPerPage, setPage,
 
       <Grid container columns={16} spacing={2} sx={{ px: { xs: '0.5rem', md: 0 } }}>
         <Grid item xs={16} md={5} lg={4}>
-          <TicketStatusFilter />
+          <TicketStatusFilter isOnTasksPage={isOnTasksPage} />
         </Grid>
         <Grid item xs={16} md={isOnTasksPage ? 6 : 11} lg={isOnTasksPage ? 8 : 12}>
           <SearchForm placeholder={t('tasks.search_placeholder')} />

--- a/src/pages/messages/components/TicketList.tsx
+++ b/src/pages/messages/components/TicketList.tsx
@@ -14,7 +14,7 @@ import { ListSkeleton } from '../../../components/ListSkeleton';
 import { SearchForm } from '../../../components/SearchForm';
 import { SortSelector } from '../../../components/SortSelector';
 import { TicketStatusFilter } from '../../../components/TicketStatusFilter';
-import { TicketSearchResponse } from '../../../types/publication_types/ticket.types';
+import { TicketSearchResponse, ticketStatusValues } from '../../../types/publication_types/ticket.types';
 import { RoleName } from '../../../types/user.types';
 import { stringIncludesMathJax, typesetMathJax } from '../../../utils/mathJaxHelpers';
 import { UrlPathTemplate } from '../../../utils/urlPaths';
@@ -64,7 +64,7 @@ export const TicketList = ({ ticketsQuery, setRowsPerPage, rowsPerPage, setPage,
 
       <Grid container columns={16} spacing={2} sx={{ px: { xs: '0.5rem', md: 0 } }}>
         <Grid item xs={16} md={5} lg={4}>
-          <TicketStatusFilter isOnTasksPage={isOnTasksPage} />
+          <TicketStatusFilter defaultStatusFilter={isOnTasksPage ? ['Pending'] : ticketStatusValues} />
         </Grid>
         <Grid item xs={16} md={isOnTasksPage ? 6 : 11} lg={isOnTasksPage ? 8 : 12}>
           <SearchForm placeholder={t('tasks.search_placeholder')} />


### PR DESCRIPTION
# Description

Set the default value for the status filter on the task page to "Pending" ("Behandles"). Should not set default value on my-page.

Will also clean up the technical debt of "NP-46271 Ansvarsområde" after last sprint, where url params were set directly in the useQuery-function. This is now fixed by using useMemo and useEffect instead. Had to fix this to get the status filter working because of a race condition spawned by the Promise in useQuery.

Default value for curator filter in a different PR.

Link to Jira issue: https://unit.atlassian.net/browse/NP-46408

# Checklist

## Required

- [x] The changes are working as expected
- [x] The changes are tested OK for both desktop and mobile screens
- [x] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

## Optional

- [x] Solution is verified by PO/designer
