### PR TITLE
NP-46408 Set default filter for curator on task page to be signed in user

### DIFF
--- a/src/components/CuratorSelector.tsx
+++ b/src/components/CuratorSelector.tsx
@@ -1,4 +1,5 @@
 import { Autocomplete, Avatar, Box, Typography } from '@mui/material';
+import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
@@ -30,11 +31,23 @@ export const CuratorSelector = ({ roleFilter }: CuratorSelectorProps) => {
     queryFn: () => fetchUsers(customerId, roleFilter),
     meta: { errorMessage: t('feedback.error.get_curators_for_institution') },
   });
+  const curators = useMemo(() => curatorsQuery.data ?? [], [curatorsQuery.data]);
 
   // Ensure current user is first in list of curators
-  const curatorOptions = (curatorsQuery.data ?? []).sort((a, b) =>
+  const curatorOptions = (curators ?? []).sort((a, b) =>
     a.username === user?.nvaUsername ? -1 : b.username === user?.nvaUsername ? 1 : 0
   );
+
+  useEffect(() => {
+    const sp = new URLSearchParams(history.location.search);
+    if (!sp.get(TicketSearchParam.Assignee)) {
+      sp.set(
+        TicketSearchParam.Assignee,
+        curators.find((curator) => curator.cristinId === user?.cristinId)?.username ?? ''
+      );
+      history.push({ search: sp.toString() });
+    }
+  }, [curators, history, user]);
 
   const selectedCurator =
     curatorOptions.find((curator) => curator.username === searchParams.get(TicketSearchParam.Assignee)) ?? null;


### PR DESCRIPTION
Am experiencing an initial flickering on the filter sometimes. Not sure if it is a bug, bad code, or dev server. 

# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46408

# Checklist

## Required

- [x] The changes are working as expected
- [x] The changes are tested OK for both desktop and mobile screens
- [x] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

## Optional

- [x] Solution is verified by PO/designer
