### PR TITLE
Fix key for OrganizationRenderOption

### DIFF
--- a/src/components/OrganizationRenderOption.tsx
+++ b/src/components/OrganizationRenderOption.tsx
@@ -14,7 +14,7 @@ export const OrganizationRenderOption = ({ props, option }: OrganizationRenderOp
   const currentLanguage = i18n.language;
 
   return (
-    <li {...props} key={option.id}>
+    <li {...props}>
       <div>
         <Typography fontWeight="bold">{getLanguageString(option.labels)}</Typography>
         <Typography>

--- a/src/components/institution/SelectInstitutionForm.tsx
+++ b/src/components/institution/SelectInstitutionForm.tsx
@@ -116,7 +116,9 @@ export const SelectInstitutionForm = ({ onSubmit, onClose, suggestedInstitutions
                   options={options}
                   inputValue={field.value ? getLanguageString(field.value.labels) : searchTerm}
                   getOptionLabel={(option) => getLanguageString(option.labels)}
-                  renderOption={(props, option) => <OrganizationRenderOption props={props} option={option} />}
+                  renderOption={(props, option) => (
+                    <OrganizationRenderOption key={option.id} props={props} option={option} />
+                  )}
                   filterOptions={(options) => options}
                   onInputChange={(_, value, reason) => {
                     if (field.value) {
@@ -149,7 +151,9 @@ export const SelectInstitutionForm = ({ onSubmit, onClose, suggestedInstitutions
                   <Autocomplete
                     options={getSortedSubUnits(values.unit?.hasPart)}
                     getOptionLabel={(option) => getLanguageString(option.labels)}
-                    renderOption={(props, option) => <OrganizationRenderOption props={props} option={option} />}
+                    renderOption={(props, option) => (
+                      <OrganizationRenderOption key={option.id} props={props} option={option} />
+                    )}
                     onChange={(_, value) => setFieldValue(field.name, value)}
                     filterOptions={(options, state) =>
                       options.filter((option) =>


### PR DESCRIPTION
# Description

Removed key from li element.

Link to Jira issue:

N/A

# Checklist

## Required

- [x] The changes are working as expected
- [x] The changes are tested OK for both desktop and mobile screens
- [x] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

## Optional

- [x] Solution is verified by PO/designer
