### PR TITLE
NP-46404 Disbale save button if user has no internal employments

### DIFF
--- a/src/pages/basic_data/institution_admin/edit_user/UserFormDialog.tsx
+++ b/src/pages/basic_data/institution_admin/edit_user/UserFormDialog.tsx
@@ -230,7 +230,7 @@ export const UserFormDialog = ({ open, onClose, existingUser, existingPerson }: 
               <Button onClick={onClose}>{t('common.cancel')}</Button>
               <LoadingButton
                 loading={isSubmitting}
-                disabled={!values.person || !values.user}
+                disabled={!values.person || internalEmployments.length === 0 || !values.user}
                 variant="contained"
                 type="submit">
                 {t('common.save')}


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46404

Stygg bug hvor brukere ved en feil kan risikere å miste alle ansettelser. Dette er ikke en skikkelig løsning av problemet, men bare et forsøk på å hindre bruker fra å lagre når man er i en status som ikke gir mening, og som vil fjerne alle ansettelser.
Jeg har en mistanke om at feilen er fordi internal employments ikke filtreres riktig for en eller annen grunn, men vet ikke om det er pga feil på backend eller frontend. Derfor finner jeg ikke på noe bedre enn et enkelt plaster i denne omgang..

# Checklist

## Required

- [ ] The changes are working as expected
- [ ] The changes are tested OK for both desktop and mobile screens
- [ ] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
- [ ] Interactive elements have data-testids
- [ ] I have done a QA of my own changes

## Optional

- [ ] Solution is verified by PO/designer
