### PR TITLE
NP-46442 Send user to top when clicking navigation accordion

### DIFF
--- a/src/components/NavigationListAccordion.tsx
+++ b/src/components/NavigationListAccordion.tsx
@@ -36,7 +36,8 @@ export const NavigationListAccordion = ({
       sx={{
         mb: '0.5rem',
         bgcolor: 'secondary.dark',
-      }}>
+      }}
+      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}>
       <AccordionSummary
         sx={{ paddingX: '0.75rem' }}
         expandIcon={!isExpanded ? <ExpandMoreIcon /> : null}

--- a/src/components/NavigationListAccordion.tsx
+++ b/src/components/NavigationListAccordion.tsx
@@ -1,5 +1,14 @@
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { Accordion, AccordionDetails, AccordionProps, AccordionSummary, Box, Typography } from '@mui/material';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionProps,
+  AccordionSummary,
+  Box,
+  Theme,
+  Typography,
+  useMediaQuery,
+} from '@mui/material';
 import { ReactNode } from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -23,6 +32,7 @@ export const NavigationListAccordion = ({
   ...props
 }: NavigationListAccordionProps) => {
   const history = useHistory();
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('md'));
   const currentPath = history.location.pathname.replace(/\/$/, ''); // Remove trailing slash
   const isExpanded = expanded !== undefined ? expanded : currentPath.startsWith(accordionPath);
 
@@ -37,7 +47,11 @@ export const NavigationListAccordion = ({
         mb: '0.5rem',
         bgcolor: 'secondary.dark',
       }}
-      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}>
+      onClick={() => {
+        if (!isMobile) {
+          window.scrollTo({ top: 0, behavior: 'smooth' });
+        }
+      }}>
       <AccordionSummary
         sx={{ paddingX: '0.75rem' }}
         expandIcon={!isExpanded ? <ExpandMoreIcon /> : null}


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46442

Prøvde på en løsning som bare scroller til `<main>`, men syns ikke det ble helt bra heller da den noen ganger ville scrolle nedover, så da går jeg heller for en dum løsning som bare scroller til topps hver gang. Untatt på mobil, der vi har en annen visning.

# Checklist

## Required

- [x] The changes are working as expected
- [x] The changes are tested OK for both desktop and mobile screens
- [x] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

## Optional

- [ ] Solution is verified by PO/designer
