### PR TITLE
NP-46437 Fix validation of funding

### DIFF
--- a/src/components/NfrProjectSearch.tsx
+++ b/src/components/NfrProjectSearch.tsx
@@ -11,7 +11,7 @@ import { useFetch } from '../utils/hooks/useFetch';
 import { getLanguageString } from '../utils/translation-helpers';
 import { AutocompleteTextField } from './AutocompleteTextField';
 
-interface NfrProjectSearchProps extends Pick<TextFieldProps, 'onBlur' | 'required' | 'name'> {
+interface NfrProjectSearchProps extends Pick<TextFieldProps, 'onBlur' | 'required' | 'name' | 'sx'> {
   onSelectProject: (selectedProject: NfrProject | null) => void;
   errorMessage?: string;
 }

--- a/src/pages/registration/description_tab/RegistrationFunding.tsx
+++ b/src/pages/registration/description_tab/RegistrationFunding.tsx
@@ -1,8 +1,8 @@
 import AddIcon from '@mui/icons-material/AddCircleOutlineSharp';
 import CancelIcon from '@mui/icons-material/Cancel';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import { Box, Button, IconButton, InputAdornment, TextField, Typography } from '@mui/material';
-import { Field, FieldArray, FieldArrayRenderProps, FieldProps } from 'formik';
+import { Box, Button, IconButton, InputAdornment, SxProps, TextField, Typography } from '@mui/material';
+import { ErrorMessage, Field, FieldArray, FieldArrayRenderProps, FieldProps } from 'formik';
 import { Trans, useTranslation } from 'react-i18next';
 import { VerifiedFundingApiPath } from '../../../api/apiPaths';
 import { FundingSourceField } from '../../../components/FundingSourceField';
@@ -18,6 +18,10 @@ import { fundingSourceIsNfr, getNfrProjectUrl } from './projects_field/projectHe
 interface FundingsFieldProps {
   currentFundings: Funding[];
 }
+
+const getTextFieldMargin = (isError: boolean): SxProps => ({
+  mt: isError ? '1.5rem' : 0,
+});
 
 export const RegistrationFunding = ({ currentFundings }: FundingsFieldProps) => {
   const { t } = useTranslation();
@@ -65,15 +69,22 @@ export const RegistrationFunding = ({ currentFundings }: FundingsFieldProps) => 
                   {hasSelectedNfrSource &&
                     (hasSelectedNfrProject ? (
                       <>
-                        <TextField
-                          value={getLanguageString(funding.labels)}
-                          disabled
-                          label={t('registration.description.funding.funding_name')}
-                          fullWidth
-                          variant="filled"
-                          multiline
-                          data-testid={dataTestId.registrationWizard.description.fundingProjectField}
-                        />
+                        <Field name={`${baseFieldName}.${SpecificFundingFieldNames.NorwegianLabel}`}>
+                          {({ field, meta: { touched, error } }: FieldProps<string>) => (
+                            <TextField
+                              value={getLanguageString(funding.labels)}
+                              disabled
+                              label={t('registration.description.funding.funding_name')}
+                              fullWidth
+                              variant="filled"
+                              multiline
+                              sx={getTextFieldMargin(touched && !!error)}
+                              error={touched && !!error}
+                              helperText={<ErrorMessage name={field.name} />}
+                              data-testid={dataTestId.registrationWizard.description.fundingProjectField}
+                            />
+                          )}
+                        </Field>
                         <TextField
                           value={funding.identifier}
                           disabled={hasSelectedNfrSource}
@@ -111,6 +122,7 @@ export const RegistrationFunding = ({ currentFundings }: FundingsFieldProps) => 
                             required
                             name={name}
                             onBlur={onBlur}
+                            sx={getTextFieldMargin(touched && !!error)}
                             errorMessage={touched && !!error ? error : undefined}
                             data-testid={dataTestId.registrationWizard.description.fundingNfrProjectSearchField}
                           />
@@ -131,6 +143,7 @@ export const RegistrationFunding = ({ currentFundings }: FundingsFieldProps) => 
                             variant="filled"
                             multiline
                             required={!hasSelectedNfrSource}
+                            sx={getTextFieldMargin(touched && !!error)}
                             error={touched && !!error}
                             helperText={touched && !!error ? error : undefined}
                             data-testid={dataTestId.registrationWizard.description.fundingProjectField}
@@ -165,6 +178,7 @@ export const RegistrationFunding = ({ currentFundings }: FundingsFieldProps) => 
                                 <InputAdornment position="start">{funding.fundingAmount?.currency}</InputAdornment>
                               ),
                             }}
+                            sx={getTextFieldMargin(touched && !!error)}
                             error={touched && !!error}
                             helperText={touched && !!error ? error : undefined}
                             data-testid={dataTestId.registrationWizard.description.fundingSumField}


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46437

Vis feilmelding når har et NFR-prosjekt som mangler navn.
Tok også med en forsøk på en fiks for å unngå at felter ikke blir på linje. Finner ikke noen god løsning på det, men har lagt inn forsøk på bøting i hvert fall, som bare setter inn ekstra `margin-top` for felter som har en feilmelding :/

Før:
![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/0fdb2e9f-d86a-44f2-a487-afacc1ed6a76)

Etter:
![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/c39d491e-c5e9-4563-bd1a-a05137ce5aae)


# Checklist

## Required

- [x] The changes are working as expected
- [x] The changes are tested OK for both desktop and mobile screens
- [x] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

## Optional

- [ ] Solution is verified by PO/designer
