### PR TITLE
NP-46467 Disable area of responsibility dropdown when only one option

### DIFF
--- a/src/components/AreaOfResponsibiltySelector.tsx
+++ b/src/components/AreaOfResponsibiltySelector.tsx
@@ -53,7 +53,25 @@ export const AreaOfResponsibilitySelector = () => {
   const selectedAreaIdsFromUrl = searchParams.get(TicketSearchParam.ViewingScope)?.split(',');
   const selectedOrganizations = organizationOptions.filter((org) => selectedAreaIdsFromUrl?.includes(org.id));
 
-  return (
+  const onlyOneAreaOfResponsibilitySelectable = organizationOptions.length === 1;
+
+  return onlyOneAreaOfResponsibilitySelectable ? (
+    <TextField
+      size="small"
+      fullWidth
+      disabled
+      defaultValue={getLanguageString(organizationOptions[0].labels)}
+      title={getLanguageString(organizationOptions[0].labels)}
+      label={t('editor.curators.area_of_responsibility')}
+      InputLabelProps={{ shrink: true }}
+      sx={{
+        '& .MuiInputBase-input': {
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        },
+      }}
+    />
+  ) : (
     <Autocomplete
       multiple
       autoHighlight


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46467

# Checklist

## Required

- [x] The changes are working as expected
- [x] The changes are tested OK for both desktop and mobile screens
- [x] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

## Optional

- [x] Solution is verified by PO/designer
