### PR TITLE
Add i18n ally settings in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,6 @@ yarn-error.log*
 .idea
 *.iml
 
-# vscode
-.vscode
-
 # cypress
 cypress/screenshots
 cypress/videos

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "i18n-ally.sourceLanguage": "nb",
+  "i18n-ally.displayLanguage": "nb",
+  "i18n-ally.localesPaths": ["src/translations"],
+  "i18n-ally.pathMatcher": "{locale}Translations.json",
+  "i18n-ally.keystyle": "nested"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "always"
+  },
   "i18n-ally.sourceLanguage": "nb",
   "i18n-ally.displayLanguage": "nb",
   "i18n-ally.localesPaths": ["src/translations"],


### PR DESCRIPTION
Foreslår at vi tester dette som utgangspunkt. Om det er noe her noen ikke vil ha som default kan vi ta det vekk. Om man ikke ønsker i18n inline er det feks bare å ikke innstallere plugin.

1. Vis oversettelser og tillat endring inline i vscode om man har extension `i18n-ally`.
![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/c0b2dee4-d75c-4d95-9976-053c56bd6a0f)

2. Organiser imports (sorter og fjern ubrukte) automatisk ved lagring.