### PR TITLE
NP-46466 Handle max hits limit

### DIFF
--- a/src/components/ListPagination.tsx
+++ b/src/components/ListPagination.tsx
@@ -19,6 +19,7 @@ export const ListPagination = ({
   showPaginationTop,
   sortingComponent,
   maxHits,
+  rowsPerPageOptions,
 }: ListPaginationProps) => {
   const itemsStart = count > 0 ? (page - 1) * rowsPerPage + 1 : 0;
   const itemsEnd = Math.min(page * rowsPerPage, count);
@@ -38,6 +39,7 @@ export const ListPagination = ({
         onPageChange={onPageChange}
         onRowsPerPageChange={onRowsPerPageChange}
         pageCounterComponent={pageCounter}
+        rowsPerPageOptions={rowsPerPageOptions}
       />
     </>
   );

--- a/src/components/ListPagination.tsx
+++ b/src/components/ListPagination.tsx
@@ -1,17 +1,10 @@
 import { ReactNode } from 'react';
-import { ListPaginationBottom } from './ListPaginationBottom';
+import { ListPaginationBottom, ListPaginationBottomProps } from './ListPaginationBottom';
 import { ListPaginationCounter } from './ListPaginationCounter';
 import { ListPaginationTop } from './ListPaginationTop';
 
-interface ListPaginationProps {
+interface ListPaginationProps extends Omit<ListPaginationBottomProps, 'pageCounterComponent'> {
   children: ReactNode;
-  count: number;
-  rowsPerPage: number;
-  page: number;
-  onPageChange: (newPage: number) => void;
-  onRowsPerPageChange: (newRowsPerPage: number) => void;
-  rowsPerPageOptions?: number[];
-  maxHits?: number; // Default limit of 10_000 hits in ElasticSearch
   showPaginationTop?: boolean;
   sortingComponent?: ReactNode;
 }
@@ -25,6 +18,7 @@ export const ListPagination = ({
   onRowsPerPageChange,
   showPaginationTop,
   sortingComponent,
+  maxHits,
 }: ListPaginationProps) => {
   const itemsStart = count > 0 ? (page - 1) * rowsPerPage + 1 : 0;
   const itemsEnd = Math.min(page * rowsPerPage, count);
@@ -40,6 +34,7 @@ export const ListPagination = ({
         count={count}
         rowsPerPage={rowsPerPage}
         page={page}
+        maxHits={maxHits}
         onPageChange={onPageChange}
         onRowsPerPageChange={onRowsPerPageChange}
         pageCounterComponent={pageCounter}

--- a/src/components/ListPaginationBottom.tsx
+++ b/src/components/ListPaginationBottom.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { ROWS_PER_PAGE_OPTIONS } from '../utils/constants';
 import { dataTestId } from '../utils/dataTestIds';
 
-interface ListPaginationBottomProps {
+export interface ListPaginationBottomProps {
   count: number;
   rowsPerPage: number;
   page: number;


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46466

Blokker paginering over 10k treff for resultatsøk, da APIet ikke støtter dette for øyeblikket.
Forenklet props-definering litt også, for å unngå duplisering.

# Checklist

## Required

- [x] The changes are working as expected
- [x] The changes are tested OK for both desktop and mobile screens
- [x] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

## Optional

- [ ] Solution is verified by PO/designer
