### PR TITLE
Np 46448 updated org api

### DIFF
--- a/src/api/cristinApi.ts
+++ b/src/api/cristinApi.ts
@@ -92,6 +92,7 @@ export const searchForOrganizations = async (params: OrganizationSearchParams) =
   const queryParams = queryContent ? `?${queryContent}` : '';
 
   const fetchOrganizationsResponse = await apiRequest2<SearchResponse<Organization>>({
+    headers: { Accept: 'application/json; version=1' },
     url: `${CristinApiPath.Organization}${queryParams}`,
   });
 

--- a/src/api/cristinApi.ts
+++ b/src/api/cristinApi.ts
@@ -1,3 +1,4 @@
+import { AxiosHeaders } from 'axios';
 import { SearchResponse } from '../types/common.types';
 import { Keywords } from '../types/keywords.types';
 import { Organization } from '../types/organization.types';
@@ -78,13 +79,20 @@ export interface OrganizationSearchParams {
   query?: string;
   page?: number;
   results?: number;
+  includeSubunits?: boolean;
 }
 
 export const searchForOrganizations = async (params: OrganizationSearchParams) => {
   const searchParams = new URLSearchParams();
+  const headers = new AxiosHeaders();
+
   if (params.query) {
     searchParams.set('query', params.query);
   }
+  if (params.includeSubunits) {
+    headers.set('Accept', 'application/json; version=1');
+  }
+
   searchParams.set('results', params.results?.toString() ?? '20');
   searchParams.set('page', params.page?.toString() ?? '1');
 
@@ -92,7 +100,7 @@ export const searchForOrganizations = async (params: OrganizationSearchParams) =
   const queryParams = queryContent ? `?${queryContent}` : '';
 
   const fetchOrganizationsResponse = await apiRequest2<SearchResponse<Organization>>({
-    headers: { Accept: 'application/json; version=1' },
+    headers,
     url: `${CristinApiPath.Organization}${queryParams}`,
   });
 

--- a/src/components/institution/SelectInstitutionForm.tsx
+++ b/src/components/institution/SelectInstitutionForm.tsx
@@ -55,6 +55,7 @@ export const SelectInstitutionForm = ({ onSubmit, onClose, suggestedInstitutions
 
   const organizationQueryParams: OrganizationSearchParams = {
     query: debouncedQuery,
+    includeSubunits: true,
   };
   const organizationSearchQuery = useQuery({
     enabled: !!debouncedQuery,

--- a/src/components/institution/SelectInstitutionForm.tsx
+++ b/src/components/institution/SelectInstitutionForm.tsx
@@ -11,15 +11,14 @@ import {
   RadioGroup,
   TextField,
 } from '@mui/material';
+import { useQuery } from '@tanstack/react-query';
 import { Field, FieldProps, Form, Formik, FormikProps } from 'formik';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { CristinApiPath } from '../../api/apiPaths';
-import { SearchResponse } from '../../types/common.types';
+import { OrganizationSearchParams, searchForOrganizations } from '../../api/cristinApi';
 import { Organization } from '../../types/organization.types';
 import { dataTestId } from '../../utils/dataTestIds';
 import { useDebounce } from '../../utils/hooks/useDebounce';
-import { useFetch } from '../../utils/hooks/useFetch';
 import { getSortedSubUnits } from '../../utils/institutions-helpers';
 import { getLanguageString } from '../../utils/translation-helpers';
 import { OrganizationRenderOption } from '../OrganizationRenderOption';
@@ -53,12 +52,16 @@ export const SelectInstitutionForm = ({ onSubmit, onClose, suggestedInstitutions
   const { t } = useTranslation();
   const [searchTerm, setSearchTerm] = useState('');
   const debouncedQuery = useDebounce(searchTerm);
-  const [institutions, isLoadingInstitutions] = useFetch<SearchResponse<Organization>>({
-    url: debouncedQuery ? `${CristinApiPath.Organization}?query=${debouncedQuery}&results=20` : '',
-    errorMessage: t('feedback.error.get_institutions'),
-  });
 
-  const options = isLoadingInstitutions || !institutions ? [] : institutions.hits;
+  const organizationQueryParams: OrganizationSearchParams = {
+    query: debouncedQuery,
+  };
+  const organizationSearchQuery = useQuery({
+    enabled: !!debouncedQuery,
+    queryKey: ['organization', organizationQueryParams],
+    queryFn: () => searchForOrganizations(organizationQueryParams),
+    meta: { errorMessage: t('feedback.error.get_institutions') },
+  });
 
   return (
     <Formik
@@ -113,7 +116,7 @@ export const SelectInstitutionForm = ({ onSubmit, onClose, suggestedInstitutions
               {({ field }: FieldProps<Organization>) => (
                 <Autocomplete
                   {...field}
-                  options={options}
+                  options={organizationSearchQuery.data?.hits ?? []}
                   inputValue={field.value ? getLanguageString(field.value.labels) : searchTerm}
                   getOptionLabel={(option) => getLanguageString(option.labels)}
                   renderOption={(props, option) => (
@@ -132,7 +135,7 @@ export const SelectInstitutionForm = ({ onSubmit, onClose, suggestedInstitutions
                     resetForm();
                     setFieldValue(field.name, value);
                   }}
-                  loading={isLoadingInstitutions}
+                  loading={organizationSearchQuery.isLoading}
                   renderInput={(params) => (
                     <TextField
                       {...params}

--- a/src/pages/basic_data/app_admin/OrganizationSearchField.tsx
+++ b/src/pages/basic_data/app_admin/OrganizationSearchField.tsx
@@ -1,14 +1,13 @@
 import { Autocomplete, TextFieldProps } from '@mui/material';
+import { useQuery } from '@tanstack/react-query';
 import { FieldInputProps } from 'formik';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { CristinApiPath } from '../../../api/apiPaths';
+import { OrganizationSearchParams, searchForOrganizations } from '../../../api/cristinApi';
 import { AutocompleteTextField } from '../../../components/AutocompleteTextField';
-import { SearchResponse } from '../../../types/common.types';
 import { Organization } from '../../../types/organization.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
-import { useFetch } from '../../../utils/hooks/useFetch';
 import { getLanguageString } from '../../../utils/translation-helpers';
 
 interface OrganizationSearchFieldProps extends Pick<TextFieldProps, 'label'> {
@@ -36,16 +35,22 @@ export const OrganizationSearchField = ({
   const { t } = useTranslation();
   const [searchTerm, setSearchTerm] = useState('');
   const debouncedQuery = useDebounce(searchTerm);
-  const [institutionOptions, isLoadingInstitutionOptions] = useFetch<SearchResponse<Organization>>({
-    url: debouncedQuery ? `${CristinApiPath.Organization}?query=${debouncedQuery}&results=20` : '',
-    errorMessage: t('feedback.error.get_institutions'),
+
+  const organizationQueryParams: OrganizationSearchParams = {
+    query: debouncedQuery,
+  };
+  const organizationSearchQuery = useQuery({
+    enabled: !!debouncedQuery,
+    queryKey: ['organization', organizationQueryParams],
+    queryFn: () => searchForOrganizations(organizationQueryParams),
+    meta: { errorMessage: t('feedback.error.get_institutions') },
   });
-  const isLoading = isLoadingDefaultOptions || isLoadingInstitutionOptions;
-  const options = isLoadingInstitutionOptions || !institutionOptions ? defaultOptions : institutionOptions.hits;
+
+  const isLoading = isLoadingDefaultOptions || organizationSearchQuery.isLoading;
 
   return (
     <Autocomplete
-      options={options}
+      options={organizationSearchQuery.data?.hits ?? defaultOptions}
       inputMode="search"
       disabled={disabled}
       getOptionLabel={(option) => getLanguageString(option.labels)}

--- a/src/pages/basic_data/app_admin/OrganizationSearchField.tsx
+++ b/src/pages/basic_data/app_admin/OrganizationSearchField.tsx
@@ -46,7 +46,7 @@ export const OrganizationSearchField = ({
     meta: { errorMessage: t('feedback.error.get_institutions') },
   });
 
-  const isLoading = isLoadingDefaultOptions || organizationSearchQuery.isLoading;
+  const isLoading = isLoadingDefaultOptions || organizationSearchQuery.isFetching;
 
   return (
     <Autocomplete

--- a/src/pages/registration/description_tab/projects_field/ProjectContributorRow.tsx
+++ b/src/pages/registration/description_tab/projects_field/ProjectContributorRow.tsx
@@ -67,10 +67,13 @@ export const ProjectContributorRow = ({
 
   const [isLoadingDefaultOptions, setIsLoadingDefaultOptions] = useState(false);
   const [defaultInstitutionOptions, setDefaultInstitutionOptions] = useState<Organization[]>([]);
+
   const fetchSuggestedInstitutions = async (affiliationIds: string[]) => {
-    if (affiliationIds.length > 0) {
-      setIsLoadingDefaultOptions(true);
+    if (affiliationIds.length === 0) {
+      return;
     }
+
+    setIsLoadingDefaultOptions(true);
 
     // Find affiliations with distinct top levels
     const distinctInstitutions = affiliationIds.reduce((accumumlator: string[], current) => {

--- a/src/utils/institutions-helpers.ts
+++ b/src/utils/institutions-helpers.ts
@@ -18,7 +18,7 @@ export const getDistinctContributorUnits = (contributors: Contributor[]) => {
 export const getOrganizationHierarchy = (unit?: Organization, result: Organization[] = []): Organization[] => {
   if (!unit) {
     return result;
-  } else if (!unit.partOf) {
+  } else if (!unit.partOf || unit.partOf.length === 0) {
     return [unit, ...result];
   }
 
@@ -40,7 +40,9 @@ export const getAllChildOrganizations = (units: Organization[] = [], result: Org
 };
 
 export const getTopLevelOrganization = (organization: Organization): Organization =>
-  !organization.partOf ? organization : getTopLevelOrganization(organization.partOf[0]);
+  !organization.partOf || organization.partOf.length === 0
+    ? organization
+    : getTopLevelOrganization(organization.partOf[0]);
 
 export const sortCustomerInstitutions = <T extends SimpleCustomerInstitution>(customers: T[] = []) =>
   customers.sort((a, b) => (a.displayName.toLocaleLowerCase() < b.displayName.toLocaleLowerCase() ? -1 : 1));


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46448

Legg til param for om org-søk skal inkludere underenheter eller ikke. Som default vil ikke underenheter (`hasPart`) nå inkluderes i responsen

# Checklist

## Required

- [x] The changes are working as expected
- [x] The changes are tested OK for both desktop and mobile screens
- [x] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

## Optional

- [ ] Solution is verified by PO/designer
