### PR TITLE
NP-46467 Style input element directly instead of mui-class

### DIFF
--- a/src/components/AreaOfResponsibiltySelector.tsx
+++ b/src/components/AreaOfResponsibiltySelector.tsx
@@ -64,8 +64,8 @@ export const AreaOfResponsibilitySelector = () => {
       title={getLanguageString(organizationOptions[0].labels)}
       label={t('editor.curators.area_of_responsibility')}
       InputLabelProps={{ shrink: true }}
-      sx={{
-        '& .MuiInputBase-input': {
+      inputProps={{
+        style: {
           overflow: 'hidden',
           textOverflow: 'ellipsis',
         },


### PR DESCRIPTION
# Description

Link to Jira issue:

# Checklist

## Required

- [x] The changes are working as expected
- [x] The changes are tested OK for both desktop and mobile screens
- [x] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

## Optional

- [x] Solution is verified by PO/designer
