### PR TITLE
NP-46483 Use OrganizationRendrOption

### DIFF
--- a/src/components/institution/SelectInstitutionForm.tsx
+++ b/src/components/institution/SelectInstitutionForm.tsx
@@ -64,8 +64,6 @@ export const SelectInstitutionForm = ({ onSubmit, onClose, suggestedInstitutions
     meta: { errorMessage: t('feedback.error.get_institutions') },
   });
 
-  console.log(organizationSearchQuery.data?.hits);
-
   return (
     <Formik
       initialValues={initialValuesOrganizationForm}

--- a/src/components/institution/SelectInstitutionForm.tsx
+++ b/src/components/institution/SelectInstitutionForm.tsx
@@ -64,6 +64,8 @@ export const SelectInstitutionForm = ({ onSubmit, onClose, suggestedInstitutions
     meta: { errorMessage: t('feedback.error.get_institutions') },
   });
 
+  console.log(organizationSearchQuery.data?.hits);
+
   return (
     <Formik
       initialValues={initialValuesOrganizationForm}

--- a/src/pages/basic_data/institution_admin/edit_user/AreaOfResponsibility.tsx
+++ b/src/pages/basic_data/institution_admin/edit_user/AreaOfResponsibility.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { fetchOrganization } from '../../../../api/cristinApi';
+import { OrganizationRenderOption } from '../../../../components/OrganizationRenderOption';
 import { RootState } from '../../../../redux/store';
 import { dataTestId } from '../../../../utils/dataTestIds';
 import { getSortedSubUnits } from '../../../../utils/institutions-helpers';
@@ -63,11 +64,7 @@ export const AreaOfResponsibility = ({ viewingScopes, updateViewingScopes }: Are
           data-testid={dataTestId.myInstitutionUsersPage.areaOfResponsibilityField}
           options={options}
           getOptionLabel={(option) => getLanguageString(option.labels)}
-          renderOption={(props, option) => (
-            <li {...props} key={option.id}>
-              {getLanguageString(option.labels)}
-            </li>
-          )}
+          renderOption={(props, option) => <OrganizationRenderOption props={props} option={option} />}
           disabled={isSubmitting}
           onChange={(_, value) => {
             if (value) {

--- a/src/pages/basic_data/institution_admin/edit_user/AreaOfResponsibility.tsx
+++ b/src/pages/basic_data/institution_admin/edit_user/AreaOfResponsibility.tsx
@@ -64,7 +64,7 @@ export const AreaOfResponsibility = ({ viewingScopes, updateViewingScopes }: Are
           data-testid={dataTestId.myInstitutionUsersPage.areaOfResponsibilityField}
           options={options}
           getOptionLabel={(option) => getLanguageString(option.labels)}
-          renderOption={(props, option) => <OrganizationRenderOption props={props} option={option} />}
+          renderOption={(props, option) => <OrganizationRenderOption key={option.id} props={props} option={option} />}
           disabled={isSubmitting}
           onChange={(_, value) => {
             if (value) {

--- a/src/pages/search/advanced_search/OrganizationFilters.tsx
+++ b/src/pages/search/advanced_search/OrganizationFilters.tsx
@@ -3,9 +3,10 @@ import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
-import { OrganizationSearchParams, fetchOrganization, searchForOrganizations } from '../../../api/cristinApi';
+import { fetchOrganization, OrganizationSearchParams, searchForOrganizations } from '../../../api/cristinApi';
 import { ResultParam } from '../../../api/searchApi';
 import { AutocompleteTextField } from '../../../components/AutocompleteTextField';
+import { OrganizationRenderOption } from '../../../components/OrganizationRenderOption';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
 import { getSortedSubUnits } from '../../../utils/institutions-helpers';
@@ -45,6 +46,8 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
   });
 
   const options = organizationSearchQuery.data?.hits ?? [];
+
+  console.log(options);
 
   const subUnits = getSortedSubUnits(topLevelOrganizationQuery.data?.hasPart);
   const selectedSubUnit = subUnits.find((unit) => unit.id === unitId) ?? null;
@@ -105,6 +108,7 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
         disabled={topLevelOrganizationQuery.isFetching}
         value={topLevelOrganizationQuery.data ?? null}
         loading={isLoading}
+        renderOption={(props, option) => <OrganizationRenderOption key={option.id} props={props} option={option} />}
         renderInput={(params) => (
           <AutocompleteTextField
             {...params}
@@ -138,6 +142,7 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
           params.set(ResultParam.From, '0');
           history.push({ search: params.toString() });
         }}
+        renderOption={(props, option) => <OrganizationRenderOption key={option.id} props={props} option={option} />}
         renderInput={(params) => (
           <TextField
             {...params}
@@ -156,7 +161,7 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
           <Checkbox
             disabled={!topLevelOrganizationId}
             onChange={handleCheckedExcludeSubunits}
-            checked={!!topLevelOrganizationId && !!excludeSubunits}
+            checked={!!topLevelOrganizationId && excludeSubunits}
           />
         }
         label={t('tasks.nvi.exclude_subunits')}

--- a/src/pages/search/advanced_search/OrganizationFilters.tsx
+++ b/src/pages/search/advanced_search/OrganizationFilters.tsx
@@ -47,8 +47,6 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
 
   const options = organizationSearchQuery.data?.hits ?? [];
 
-  console.log(options);
-
   const subUnits = getSortedSubUnits(topLevelOrganizationQuery.data?.hasPart);
   const selectedSubUnit = subUnits.find((unit) => unit.id === unitId) ?? null;
 


### PR DESCRIPTION
# Description

Use `<OrganizationRenderOption />` on several Autocompletes. As of now, searh does not return the country of the organization, but BE has been notified.

Link to Jira issue: https://unit.atlassian.net/browse/NP-46483

# Checklist

## Required

- [x] The changes are working as expected
- [x] The changes are tested OK for both desktop and mobile screens
- [x] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

## Optional

- [ ] Solution is verified by PO/designer
