### PR TITLE
NP-46404 Avoid missing employments due to caching

### DIFF
--- a/src/pages/basic_data/institution_admin/edit_user/UserFormDialog.tsx
+++ b/src/pages/basic_data/institution_admin/edit_user/UserFormDialog.tsx
@@ -66,9 +66,9 @@ export const UserFormDialog = ({ open, onClose, existingUser, existingPerson }: 
     queryKey: [personId],
     queryFn: () => getById<CristinPerson>(personId),
     meta: { errorMessage: t('feedback.error.get_person') },
-    initialData: existingPersonObject,
   });
-  const personEmployments = personQuery.data?.employments ?? [];
+  const person = existingPersonObject ?? personQuery.data;
+  const personEmployments = person?.employments ?? [];
 
   const topOrgCristinIdentifier = topOrgCristinId ? getIdentifierFromId(topOrgCristinId) : '';
   const internalEmployments: Employment[] = [];
@@ -84,7 +84,7 @@ export const UserFormDialog = ({ open, onClose, existingUser, existingPerson }: 
     }
   });
 
-  const personCristinIdentifier = getValueByKey('CristinIdentifier', personQuery.data?.identifiers);
+  const personCristinIdentifier = getValueByKey('CristinIdentifier', person?.identifiers);
   const username =
     personCristinIdentifier && topOrgCristinIdentifier ? `${personCristinIdentifier}@${topOrgCristinIdentifier}` : '';
 
@@ -122,7 +122,7 @@ export const UserFormDialog = ({ open, onClose, existingUser, existingPerson }: 
         return await createUser({
           customerId,
           roles: user.roles,
-          nationalIdentityNumber: getValueByKey('NationalIdentificationNumber', personQuery.data?.identifiers),
+          nationalIdentityNumber: getValueByKey('NationalIdentificationNumber', person?.identifiers),
           viewingScope: user.viewingScope,
         });
       }
@@ -134,12 +134,7 @@ export const UserFormDialog = ({ open, onClose, existingUser, existingPerson }: 
   });
 
   const initialValues: UserFormData = {
-    person: personQuery.data
-      ? {
-          ...personQuery.data,
-          employments: internalEmployments,
-        }
-      : personQuery.data,
+    person: person ? { ...person, employments: internalEmployments } : person,
     user: institutionUserQuery.isError
       ? {
           institution: customerId,


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46404

Pga caching ble det noen ganger vist frem person-respons til kall uten token, som gjorde at brukere kunne fjerne alle sine ansettelser med et uhell.

# Checklist

## Required

- [x] The changes are working as expected
- [x] The changes are tested OK for both desktop and mobile screens
- [x] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

## Optional

- [ ] Solution is verified by PO/designer
