### PR TITLE
Reset pagination when updating year filter

### DIFF
--- a/src/pages/search/PublicationDateIntervalFilter.tsx
+++ b/src/pages/search/PublicationDateIntervalFilter.tsx
@@ -34,10 +34,12 @@ export const PublicationDateIntervalFilter = ({ datePickerProps, boxProps }: Pub
       const year = newDate.getFullYear();
       if (year.toString().length === 4) {
         searchParams.set(param, year.toString());
+        searchParams.delete(ResultParam.From);
         history.push({ search: searchParams.toString() });
       }
     } else {
       searchParams.delete(param);
+      searchParams.delete(ResultParam.From);
       history.push({ search: searchParams.toString() });
     }
   };


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46487

Nullstill paginering når man endrer årstall i søk

# Checklist

## Required

- [x] The changes are working as expected
- [x] The changes are tested OK for both desktop and mobile screens
- [x] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

## Optional

- [ ] Solution is verified by PO/designer
