### PR TITLE
Avoid excessive scrolling for accordion clicks

### DIFF
--- a/src/components/NavigationListAccordion.tsx
+++ b/src/components/NavigationListAccordion.tsx
@@ -46,16 +46,19 @@ export const NavigationListAccordion = ({
       sx={{
         mb: '0.5rem',
         bgcolor: 'secondary.dark',
-      }}
-      onClick={() => {
-        if (!isMobile) {
-          window.scrollTo({ top: 0, behavior: 'smooth' });
-        }
       }}>
       <AccordionSummary
         sx={{ paddingX: '0.75rem' }}
         expandIcon={!isExpanded ? <ExpandMoreIcon /> : null}
-        onClick={() => !isExpanded && history.push(defaultPath)}>
+        onClick={() => {
+          if (!isExpanded) {
+            history.push(defaultPath);
+
+            if (!isMobile) {
+              window.scrollTo({ top: 0, behavior: 'smooth' });
+            }
+          }
+        }}>
         <Box
           sx={{
             display: 'flex',


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46442

Fiks bug hvor bruker ble scrollet til toppen når man trykket på noe inni en accordion. Man skal bare sendes til toppen når man trykker på toppen av accordion
Introdusert i https://github.com/BIBSYSDEV/NVA-Frontend/pull/5381

# Checklist

## Required

- [x] The changes are working as expected
- [x] The changes are tested OK for both desktop and mobile screens
- [x] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

## Optional

- [ ] Solution is verified by PO/designer
