### PR TITLE
Exclude topLevelOrg from search when subUnnit is selected

### DIFF
--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -397,7 +397,6 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
   }
   if (params.unit) {
     searchParams.set(ResultParam.Unit, params.unit);
-    searchParams.delete(ResultParam.TopLevelOrganization);
   }
 
   searchParams.set(ResultParam.From, typeof params.from === 'number' ? params.from.toString() : '0');

--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -397,6 +397,7 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
   }
   if (params.unit) {
     searchParams.set(ResultParam.Unit, params.unit);
+    searchParams.delete(ResultParam.TopLevelOrganization);
   }
 
   searchParams.set(ResultParam.From, typeof params.from === 'number' ? params.from.toString() : '0');

--- a/src/pages/search/advanced_search/AdvancedSearchPage.tsx
+++ b/src/pages/search/advanced_search/AdvancedSearchPage.tsx
@@ -85,8 +85,7 @@ export const AdvancedSearchPage = () => {
     sort: params.get(ResultParam.Sort) as SortOrder | null,
     title: params.get(ResultParam.Title),
     excludeSubunits,
-    topLevelOrganization: topLevelOrganizationId,
-    unit: unitId,
+    unit: unitId ?? topLevelOrganizationId,
   };
 
   const resultSearchQuery = useQuery({

--- a/src/pages/search/advanced_search/AdvancedSearchPage.tsx
+++ b/src/pages/search/advanced_search/AdvancedSearchPage.tsx
@@ -85,7 +85,7 @@ export const AdvancedSearchPage = () => {
     sort: params.get(ResultParam.Sort) as SortOrder | null,
     title: params.get(ResultParam.Title),
     excludeSubunits,
-    topLevelOrganization: (excludeSubunits && !!unitId) || !!unitId ? null : topLevelOrganizationId,
+    topLevelOrganization: topLevelOrganizationId,
     unit: unitId,
   };
 

--- a/src/pages/search/advanced_search/AdvancedSearchPage.tsx
+++ b/src/pages/search/advanced_search/AdvancedSearchPage.tsx
@@ -15,7 +15,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
-import { FetchResultsParams, ResultParam, ResultSearchOrder, SortOrder, fetchResults } from '../../../api/searchApi';
+import { fetchResults, FetchResultsParams, ResultParam, ResultSearchOrder, SortOrder } from '../../../api/searchApi';
 import { CategoryChip } from '../../../components/CategorySelector';
 import { SearchForm } from '../../../components/SearchForm';
 import { ScientificIndexStatuses } from '../../../types/nvi.types';
@@ -85,7 +85,7 @@ export const AdvancedSearchPage = () => {
     sort: params.get(ResultParam.Sort) as SortOrder | null,
     title: params.get(ResultParam.Title),
     excludeSubunits,
-    topLevelOrganization: excludeSubunits && !!unitId ? null : topLevelOrganizationId,
+    topLevelOrganization: (excludeSubunits && !!unitId) || !!unitId ? null : topLevelOrganizationId,
     unit: unitId,
   };
 


### PR DESCRIPTION
# Description

Link to Jira issue:

# Checklist

## Required

- [x] The changes are working as expected
- [x] The changes are tested OK for both desktop and mobile screens
- [x] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

## Optional

- [ ] Solution is verified by PO/designer
