### PR TITLE
NP-46472 Handle roles without attached customer

### DIFF
--- a/src/redux/userSlice.ts
+++ b/src/redux/userSlice.ts
@@ -22,7 +22,11 @@ const userSlice = createSlice({
       const allowedCustomersString = getStringValue(action.payload['custom:allowedCustomers']);
 
       const roleItems = rolesString.split(',').map((roleItem) => roleItem.split('@') as [RoleName, string]);
-      const roles = roleItems.filter(([_, thisCustomerId]) => thisCustomerId === customerId).map(([role]) => role);
+
+      const roles = roleItems.flatMap(([role, thisCustomerId]) =>
+        !thisCustomerId || thisCustomerId === customerId ? [role] : []
+      );
+
       const allowedCustomers = allowedCustomersString.split(',').filter((customer) => customer);
 
       const user: User = {

--- a/src/redux/userSlice.ts
+++ b/src/redux/userSlice.ts
@@ -22,7 +22,6 @@ const userSlice = createSlice({
       const allowedCustomersString = getStringValue(action.payload['custom:allowedCustomers']);
 
       const roleItems = rolesString.split(',').map((roleItem) => roleItem.split('@') as [RoleName, string]);
-
       const roles = roleItems.flatMap(([role, thisCustomerId]) =>
         !thisCustomerId || thisCustomerId === customerId ? [role] : []
       );


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46472

I dag kommer `custom:roles` tilknyttet en customer id, som dette: `<ROLE>@<CUSTOMER>`. For noen brukere blir dette en veldig lang streng, så vi ønsker å ta vekk `@<CUSTOMER>`, da man bare skal få rollene for den kunden man har valgt uansett. Denne PRen vil gjøre at frontend støtter begge formatene: `<ROLE1>@<CUSTOMER>,<ROLE2>@<CUSTOMER>` og `<ROLE1>,<ROLE2>`

# Checklist

## Required

- [x] The changes are working as expected
- [x] The changes are tested OK for both desktop and mobile screens
- [x] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

## Optional

- [ ] Solution is verified by PO/designer
