### PR TITLE
Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,6 @@ Also ensure that the following criterias are met:
 - [ ] The changes are tested OK for different screen sizes
 - [ ] The changes are tested OK for a11y
 - [ ] Interactive elements have data-testids
-- [ ] I have described what this PR solves
 - [ ] I have done a QA of my own changes
 
 _Note: some of these criterias may not always be relevant, and can simply be marked as completed._

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
 # Description
 
-Link to Jira issue:
+Link to Jira issue: TODO
 
-[TODO: Describe your changes here]
+[TODO: Describe what this PR solves]
 
 # Checklist
 
@@ -14,6 +14,7 @@ Also ensure that the following criterias are met:
 - [ ] The changes are tested OK for different screen sizes
 - [ ] The changes are tested OK for a11y
 - [ ] Interactive elements have data-testids
+- [ ] I have described what this PR solves
 - [ ] I have done a QA of my own changes
 
 _Note: some of these criterias may not always be relevant, and can simply be marked as completed._

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,16 +2,18 @@
 
 Link to Jira issue:
 
+[TODO: Describe your changes here]
+
 # Checklist
 
-## Required
+Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.
+
+Also ensure that the following criterias are met:
 
 - [ ] The changes are working as expected
-- [ ] The changes are tested OK for both desktop and mobile screens
-- [ ] The changes are tested OK for a11y (with [axe](https://www.deque.com/axe/devtools/), [lighthouse](https://developer.chrome.com/docs/lighthouse/), or similar)
+- [ ] The changes are tested OK for different screen sizes
+- [ ] The changes are tested OK for a11y
 - [ ] Interactive elements have data-testids
 - [ ] I have done a QA of my own changes
 
-## Optional
-
-- [ ] Solution is verified by PO/designer
+_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


### PR DESCRIPTION
Noen ting som ikke har fungert optimalt med den PR-templaten, IMO. 
bl.a. var det rart med en optional checkbox med å kontrollere at ting var sjekket med PO/designer. Så at den ofte ble huket av også på oppgaver hvor det ikke var relevant, for å unngå at det sto "5 of 6 tasks" i oversikten. Har derfor lagt inn en tekst-samtykke med at man har gjort den avsjekken nå.

Åpen for innspill, både til endringene, og om det er noe jeg har glemt!