### PR TITLE
NP-46387 Reset unit selection only when needed

### DIFF
--- a/src/pages/editor/OrganizationOverview.tsx
+++ b/src/pages/editor/OrganizationOverview.tsx
@@ -124,7 +124,10 @@ const OrganizationAccordion = ({
       data-testid={dataTestId.editor.organizationAccordion(organization.id)}
       elevation={2}
       disableGutters
-      sx={{ bgcolor: level % 2 === 0 ? 'secondary.main' : 'secondary.light', ml: { xs: undefined, md: `${level}rem` } }}
+      sx={{
+        bgcolor: level % 2 === 0 ? 'secondary.main' : 'secondary.light',
+        ml: { xs: undefined, md: level > 0 ? '1rem' : 0 },
+      }}
       expanded={expanded}
       onChange={() => setExpandedState(!expanded)}>
       <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ visibility: subunitsCount > 0 ? null : 'hidden' }} />}>

--- a/src/pages/search/advanced_search/OrganizationHierarchyFilter.tsx
+++ b/src/pages/search/advanced_search/OrganizationHierarchyFilter.tsx
@@ -173,7 +173,10 @@ const OrganizationAccordion = ({
       data-testid={dataTestId.editor.organizationAccordion(organization.id)}
       elevation={2}
       disableGutters
-      sx={{ bgcolor: level % 2 === 0 ? 'secondary.main' : 'secondary.light', ml: { xs: undefined, md: `${level}rem` } }}
+      sx={{
+        bgcolor: level % 2 === 0 ? 'secondary.main' : 'secondary.light',
+        ml: { xs: undefined, md: level > 0 ? '1rem' : 0 },
+      }}
       expanded={expanded}
       onChange={() => {
         setExpandedState(!expandedState);

--- a/src/pages/search/advanced_search/OrganizationHierarchyFilter.tsx
+++ b/src/pages/search/advanced_search/OrganizationHierarchyFilter.tsx
@@ -172,14 +172,13 @@ const OrganizationAccordion = ({
     <Accordion
       data-testid={dataTestId.editor.organizationAccordion(organization.id)}
       elevation={2}
-      onClick={(event) => {
-        event.stopPropagation();
-        setSelectedId(organization.id);
-      }}
       disableGutters
       sx={{ bgcolor: level % 2 === 0 ? 'secondary.main' : 'secondary.light', ml: { xs: undefined, md: `${level}rem` } }}
       expanded={expanded}
-      onChange={() => setExpandedState(!expandedState)}>
+      onChange={() => {
+        setExpandedState(!expandedState);
+        setSelectedId(organization.id);
+      }}>
       <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ visibility: subunitsCount > 0 ? null : 'hidden' }} />}>
         <Box
           sx={{

--- a/src/pages/search/advanced_search/OrganizationHierarchyFilter.tsx
+++ b/src/pages/search/advanced_search/OrganizationHierarchyFilter.tsx
@@ -52,13 +52,19 @@ export const OrganizationHierarchyFilter = ({ organization, open, onClose }: Org
   const closeDialog = () => {
     onClose();
     setSearchId('');
-    setSelectedId(unitFromParams);
   };
 
   const allSubUnits = getSortedSubUnits(organization.hasPart);
 
   return (
-    <Dialog open={open} onClose={closeDialog} maxWidth="lg" transitionDuration={0}>
+    <Dialog
+      open={open}
+      onClose={() => {
+        closeDialog();
+        setSelectedId(unitFromParams);
+      }}
+      maxWidth="lg"
+      transitionDuration={0}>
       <DialogTitle>{t('common.select_unit')}</DialogTitle>
       <DialogContent>
         <Typography sx={{ mb: '2rem' }}>
@@ -102,7 +108,13 @@ export const OrganizationHierarchyFilter = ({ organization, open, onClose }: Org
       </DialogContent>
 
       <DialogActions>
-        <Button onClick={closeDialog}>{t('common.cancel')}</Button>
+        <Button
+          onClick={() => {
+            closeDialog();
+            setSelectedId(unitFromParams);
+          }}>
+          {t('common.cancel')}
+        </Button>
         <Button
           variant="contained"
           disabled={!selectedId}
@@ -111,6 +123,7 @@ export const OrganizationHierarchyFilter = ({ organization, open, onClose }: Org
             params.set(ResultParam.Unit, selectedId);
             history.push({ search: params.toString() });
             closeDialog();
+            setSelectedId(selectedId);
           }}>
           {t('common.select')}
         </Button>

--- a/src/pages/search/advanced_search/OrganizationHierarchyFilter.tsx
+++ b/src/pages/search/advanced_search/OrganizationHierarchyFilter.tsx
@@ -123,7 +123,6 @@ export const OrganizationHierarchyFilter = ({ organization, open, onClose }: Org
             params.set(ResultParam.Unit, selectedId);
             history.push({ search: params.toString() });
             closeDialog();
-            setSelectedId(selectedId);
           }}>
           {t('common.select')}
         </Button>


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46387

Løser 3 småfeil:
- Løs bug hvor valgt enhet ikke ble vist som valgt om man åpnet dialogen på nytt. Pass samtidig på at valgt verdi blir nullstilt om bruker ikke lagrer sitt valg.
- Gi alle enhetsnivåer samme indenteringsstørrelse, i stedet for at innrykket blir større for hvert nivå
- La bruker velge en enhet med tastatur (tab og enter)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
