### PR TITLE
Np 46538 await fetching registration before tickets

### DIFF
--- a/src/pages/dashboard/HomePage.tsx
+++ b/src/pages/dashboard/HomePage.tsx
@@ -13,7 +13,7 @@ import {
   searchForPerson,
   searchForProjects,
 } from '../../api/cristinApi';
-import { fetchResults, FetchResultsParams, ResultParam, ResultSearchOrder, SortOrder } from '../../api/searchApi';
+import { FetchResultsParams, ResultParam, ResultSearchOrder, SortOrder, fetchResults } from '../../api/searchApi';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
 import { NavigationListAccordion } from '../../components/NavigationListAccordion';
 import { LinkButton, NavigationList, SideNavHeader, StyledPageWithSideMenu } from '../../components/PageWithSideMenu';
@@ -48,9 +48,10 @@ const HomePage = () => {
 
   const currentPath = location.pathname.replace(/\/$/, ''); // Remove trailing slash
 
-  const resultIsSelected = !paramsSearchType || paramsSearchType === SearchTypeValue.Result;
-  const personIsSeleced = paramsSearchType === SearchTypeValue.Person;
-  const projectIsSelected = paramsSearchType === SearchTypeValue.Project;
+  const isOnFilterPage = location.pathname === UrlPathTemplate.Home;
+  const resultIsSelected = isOnFilterPage && (!paramsSearchType || paramsSearchType === SearchTypeValue.Result);
+  const personIsSeleced = isOnFilterPage && paramsSearchType === SearchTypeValue.Person;
+  const projectIsSelected = isOnFilterPage && paramsSearchType === SearchTypeValue.Project;
 
   const rowsPerPage = Number(params.get(SearchParam.Results) ?? ROWS_PER_PAGE_OPTIONS[0]);
   const page = Number(params.get(SearchParam.Page) ?? 1);

--- a/src/pages/public_registration/RegistrationLandingPage.tsx
+++ b/src/pages/public_registration/RegistrationLandingPage.tsx
@@ -50,7 +50,7 @@ export const RegistrationLandingPage = () => {
   });
 
   const registration = registrationQuery.data;
-  const registrationId = registration?.id ?? '';
+  const registrationId = registration?.id;
 
   if (identifier !== registration?.identifier && !!registration?.identifier) {
     const newPath = history.location.pathname.replace(identifier, registration.identifier);
@@ -67,9 +67,9 @@ export const RegistrationLandingPage = () => {
     registration?.status === RegistrationStatus.Unpublished;
 
   const ticketsQuery = useQuery({
-    enabled: canEditRegistration,
+    enabled: canEditRegistration && !!registrationId,
     queryKey: ['registrationTickets', registrationId],
-    queryFn: () => fetchRegistrationTickets(registrationId),
+    queryFn: () => (registrationId ? fetchRegistrationTickets(registrationId) : null),
     meta: { errorMessage: t('feedback.error.get_tickets') },
   });
 


### PR DESCRIPTION
# Description

Løser to feil:
- Blokker henting av tickets til registration er hentet (introdusert [her](https://github.com/BIBSYSDEV/NVA-Frontend/pull/5472))
- Unngå kall for søk som brukes på Filter-siden når man er på siden for avansert søk.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [ ] The changes are working as expected
- [ ] The changes are tested OK for different screen sizes
- [ ] The changes are tested OK for a11y
- [ ] Interactive elements have data-testids
- [ ] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
