### PR TITLE
Add sperate mock-scripts for windows and unix

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "pre-commit": "npx lint-staged && npm run unused-i18n-keys",
     "prepare": "husky",
     "start": "react-scripts -r @cypress/instrument-cra start",
-    "start:mock": "set REACT_APP_USE_MOCK=true&& npm start",
+    "start:mock:win": "set REACT_APP_USE_MOCK=true&& npm start",
+    "start:mock:unix": "export REACT_APP_USE_MOCK=true && npm start",
     "test": "cypress run",
-    "test:cypress": "start-server-and-test start:mock http://localhost:3000 test",
+    "test:cypress": "start-server-and-test start:mock:win http://localhost:3000 test",
     "unused-i18n-keys": "i18n-unused display-unused"
   },
   "browserslist": {


### PR DESCRIPTION
# Description

Link to Jira issue: N/A

Update scripts to so we don't have to set USE_MACK_DATA manually, depending on whoch OS you are running.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
