### PR TITLE
NP-46388 Prefill users institution in dropdown on advanced search

### DIFF
--- a/src/pages/search/advanced_search/OrganizationFilters.tsx
+++ b/src/pages/search/advanced_search/OrganizationFilters.tsx
@@ -34,7 +34,7 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
   const organizationQuery = useQuery({
     enabled: !!user?.topOrgCristinId,
     queryKey: ['organization', user?.topOrgCristinId],
-    queryFn: user?.topOrgCristinId ? () => fetchOrganization(user?.topOrgCristinId ?? '') : undefined,
+    queryFn: user ? () => fetchOrganization(user.topOrgCristinId ?? '') : undefined,
     meta: { errorMessage: t('feedback.error.get_institution') },
     staleTime: Infinity,
     cacheTime: 1_800_000, // 30 minutes
@@ -69,7 +69,7 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
     meta: { errorMessage: t('feedback.error.get_institutions') },
   });
 
-  const defaultOptions = userOrganization !== undefined ? [userOrganization] : [];
+  const defaultOptions = userOrganization ? [userOrganization] : [];
   const options = organizationSearchQuery.data?.hits ?? defaultOptions;
 
   const isLoading = topLevelOrganizationQuery.isFetching || organizationSearchQuery.isFetching;

--- a/src/pages/search/advanced_search/OrganizationFilters.tsx
+++ b/src/pages/search/advanced_search/OrganizationFilters.tsx
@@ -2,11 +2,13 @@ import { Autocomplete, Box, Checkbox, Chip, FormControlLabel, Skeleton } from '@
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { fetchOrganization, OrganizationSearchParams, searchForOrganizations } from '../../../api/cristinApi';
 import { ResultParam } from '../../../api/searchApi';
 import { AutocompleteTextField } from '../../../components/AutocompleteTextField';
 import { OrganizationRenderOption } from '../../../components/OrganizationRenderOption';
+import { RootState } from '../../../redux/store';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
 import { getLanguageString } from '../../../utils/translation-helpers';
@@ -22,11 +24,22 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
   const history = useHistory();
   const [searchTerm, setSearchTerm] = useState('');
   const debouncedQuery = useDebounce(searchTerm);
+  const user = useSelector((store: RootState) => store.user);
   const params = new URLSearchParams(history.location.search);
   const excludeSubunits = params.get(ResultParam.ExcludeSubunits) === 'true';
   const topLevelOrgParam = params.get(ResultParam.TopLevelOrganization);
   const [showUnitSelection, setShowUnitSelection] = useState(false);
   const toggleShowUnitSelection = () => setShowUnitSelection(!showUnitSelection);
+
+  const organizationQuery = useQuery({
+    enabled: !!user?.topOrgCristinId,
+    queryKey: ['organization', user?.topOrgCristinId],
+    queryFn: user?.topOrgCristinId ? () => fetchOrganization(user?.topOrgCristinId ?? '') : undefined,
+    meta: { errorMessage: t('feedback.error.get_institution') },
+    staleTime: Infinity,
+    cacheTime: 1_800_000, // 30 minutes
+  });
+  const userOrganization = organizationQuery.data;
 
   const topLevelOrganizationQuery = useQuery({
     queryKey: [topLevelOrganizationId],
@@ -56,7 +69,8 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
     meta: { errorMessage: t('feedback.error.get_institutions') },
   });
 
-  const options = organizationSearchQuery.data?.hits ?? [];
+  const defaultOptions = userOrganization !== undefined ? [userOrganization] : [];
+  const options = organizationSearchQuery.data?.hits ?? defaultOptions;
 
   const isLoading = topLevelOrganizationQuery.isFetching || organizationSearchQuery.isFetching;
 


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-46388](https://unit.atlassian.net/browse/NP-46388)

I avansert søk, legger inn brukers institusjon som default dropdown-opsjon før man gjør et spesifikt søk. Dette fordi bruker i de fleste tilfeller ønsker å filterer på sin institusjon.
NB: Hvis man har søkt og valgt en annen institusjon, så vil brukers institusjon fortsatt vises som opsjon i dropdown. Litt usikker på om dette er ønsket eller ikke, så tenker å la PO teste selv.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-46388]: https://unit.atlassian.net/browse/NP-46388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ