### PR TITLE
NP-46187 Add file names to log entries

### DIFF
--- a/src/pages/public_registration/LogPanel.tsx
+++ b/src/pages/public_registration/LogPanel.tsx
@@ -13,7 +13,7 @@ import { StyledStatusMessageBox } from '../messages/components/PublishingRequest
 interface LogItem {
   modifiedDate: string;
   description: string;
-  descriptionAppendage?: string[];
+  fileNames?: string[];
   type: TicketType;
 }
 
@@ -77,7 +77,7 @@ export const LogPanel = ({ tickets, registration }: LogPanelProps) => {
             description: t('my_page.messages.files_published', {
               count: publishingTicket.approvedFiles.length,
             }),
-            descriptionAppendage: getFileNamesForTicket(publishingTicket, registration, t),
+            fileNames: getFileNamesForTicket(publishingTicket, registration, t),
             type: 'PublishingRequest',
           });
         } else if (ticket.status === 'Closed') {
@@ -115,20 +115,18 @@ export const LogPanel = ({ tickets, registration }: LogPanelProps) => {
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', mt: '0.5rem' }}>
       {registration && (
         <StyledStatusMessageBox sx={{ bgcolor: 'publishingRequest.main' }}>
-          <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-            <Typography>{t('common.created')}:</Typography>
-            {organizationQuery.isLoading || userQuery.isLoading ? (
-              <Skeleton sx={{ width: '4rem' }} />
-            ) : (
-              <Typography>
-                {organizationQuery.data ? organizationQuery.data?.acronym : t('common.unknown')}
-                {userQuery.data ? `, ${getFullName(userQuery.data.givenName, userQuery.data.familyName)}` : ''}
-              </Typography>
-            )}
-          </Box>
+          <Typography>{t('common.created')}</Typography>
           <Tooltip title={new Date(registration.createdDate).toLocaleTimeString()} enterDelay={tooltipDelay}>
             <Typography>{new Date(registration.createdDate).toLocaleDateString()}</Typography>
           </Tooltip>
+          {organizationQuery.isLoading || userQuery.isLoading ? (
+            <Skeleton sx={{ width: '4rem' }} />
+          ) : (
+            <Typography>
+              {organizationQuery.data ? organizationQuery.data?.acronym : t('common.unknown')}
+              {userQuery.data ? `, ${getFullName(userQuery.data.givenName, userQuery.data.familyName)}` : ''}
+            </Typography>
+          )}
         </StyledStatusMessageBox>
       )}
       {logs
@@ -142,7 +140,7 @@ export const LogPanel = ({ tickets, registration }: LogPanelProps) => {
               <Tooltip title={modifiedDate.toLocaleTimeString()} enterDelay={tooltipDelay}>
                 <Typography>{modifiedDate.toLocaleDateString()}</Typography>
               </Tooltip>
-              {logItem.descriptionAppendage && logItem.descriptionAppendage?.length > 0 && (
+              {logItem.fileNames && logItem.fileNames.length > 0 && (
                 <Box
                   component="ul"
                   sx={{
@@ -151,7 +149,7 @@ export const LogPanel = ({ tickets, registration }: LogPanelProps) => {
                     p: 'inherit',
                     color: 'black',
                   }}>
-                  {logItem.descriptionAppendage.map((desc, index) => (
+                  {logItem.fileNames.map((desc, index) => (
                     <li key={index}>
                       <Tooltip title={desc === t('common.deleted') ? '' : desc} enterDelay={tooltipDelay}>
                         <Typography
@@ -159,6 +157,9 @@ export const LogPanel = ({ tickets, registration }: LogPanelProps) => {
                             whiteSpace: 'nowrap',
                             overflow: 'hidden',
                             textOverflow: 'ellipsis',
+                            fontStyle: desc === t('common.deleted') ? 'italic' : 'normal',
+                            width: 'fit-content',
+                            maxWidth: '100%',
                           }}>
                           {desc}
                         </Typography>

--- a/src/pages/public_registration/LogPanel.tsx
+++ b/src/pages/public_registration/LogPanel.tsx
@@ -1,14 +1,14 @@
-import { PublishingTicket, Ticket, TicketType } from '../../types/publication_types/ticket.types';
 import { Box, Skeleton, Tooltip, Typography } from '@mui/material';
-import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
+import { TFunction } from 'i18next';
+import { useTranslation } from 'react-i18next';
 import { fetchOrganization } from '../../api/cristinApi';
 import { fetchUser } from '../../api/roleApi';
+import { PublishingTicket, Ticket, TicketType } from '../../types/publication_types/ticket.types';
 import { Registration } from '../../types/registration.types';
 import { getAssociatedFiles } from '../../utils/registration-helpers';
 import { getFullName } from '../../utils/user-helpers';
 import { StyledStatusMessageBox } from '../messages/components/PublishingRequestMessagesColumn';
-import { TFunction } from 'i18next';
 
 interface LogItem {
   modifiedDate: string;

--- a/src/pages/public_registration/LogPanel.tsx
+++ b/src/pages/public_registration/LogPanel.tsx
@@ -8,6 +8,7 @@ import { Registration } from '../../types/registration.types';
 import { getAssociatedFiles } from '../../utils/registration-helpers';
 import { getFullName } from '../../utils/user-helpers';
 import { StyledStatusMessageBox } from '../messages/components/PublishingRequestMessagesColumn';
+import { ticketColor } from '../messages/components/TicketListItem';
 
 interface LogItem {
   modifiedDate: string;
@@ -131,43 +132,40 @@ export const LogPanel = ({ tickets, registration }: LogPanelProps) => {
       {logs
         .sort((a, b) => new Date(a.modifiedDate).getTime() - new Date(b.modifiedDate).getTime())
         .map((logItem, index) => {
-          const bgColor = logItem.type === 'PublishingRequest' ? 'publishingRequest.main' : 'doiRequest.main';
           const modifiedDate = new Date(logItem.modifiedDate);
           return (
-            <StyledStatusMessageBox key={index} sx={{ bgcolor: `${bgColor}` }}>
+            <StyledStatusMessageBox key={index} sx={{ bgcolor: ticketColor[logItem.type] }}>
               <Typography>{logItem.description}</Typography>
               <Tooltip title={modifiedDate.toLocaleTimeString()} enterDelay={tooltipDelay}>
                 <Typography>{modifiedDate.toLocaleDateString()}</Typography>
               </Tooltip>
-              {logItem.filesInfo &&
-                logItem.filesInfo.approvedFileNames &&
-                logItem.filesInfo.approvedFileNames.length > 0 && (
-                  <Box
-                    component="ul"
-                    sx={{
-                      gridColumn: '1/3',
-                      m: '0',
-                      p: 'inherit',
-                      color: 'black',
-                    }}>
-                    {logItem.filesInfo.approvedFileNames.map((fileName, index) => (
-                      <li key={index}>
-                        <Tooltip title={fileName} enterDelay={tooltipDelay}>
-                          <Typography
-                            sx={{
-                              whiteSpace: 'nowrap',
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                              width: 'fit-content',
-                              maxWidth: '100%',
-                            }}>
-                            {fileName}
-                          </Typography>
-                        </Tooltip>
-                      </li>
-                    ))}
-                  </Box>
-                )}
+              {logItem.filesInfo?.approvedFileNames && logItem.filesInfo.approvedFileNames.length > 0 && (
+                <Box
+                  component="ul"
+                  sx={{
+                    gridColumn: '1/3',
+                    m: '0',
+                    p: 'inherit',
+                    color: 'black',
+                  }}>
+                  {logItem.filesInfo.approvedFileNames.map((fileName, index) => (
+                    <li key={index}>
+                      <Tooltip title={fileName} enterDelay={tooltipDelay}>
+                        <Typography
+                          sx={{
+                            whiteSpace: 'nowrap',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            width: 'fit-content',
+                            maxWidth: '100%',
+                          }}>
+                          {fileName}
+                        </Typography>
+                      </Tooltip>
+                    </li>
+                  ))}
+                </Box>
+              )}
               {logItem.filesInfo && logItem.filesInfo.numberOfUnpublishableFiles > 0 && (
                 <Typography sx={{ gridColumn: '1/3', fontStyle: 'italic' }}>
                   {t('log.archived_file', { count: logItem.filesInfo.numberOfUnpublishableFiles })}

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1870,9 +1870,9 @@
     "unpublish_registration_reason": "Legg inn en kort begrunnelse for at dette forskningsresultatet ikke lenger skal være publisert. Begrunnelsen vil vises på forskningsresultatet ved oppslag av referanse til forskningsresultet."
   },
   "log": {
-    "archived_file_one": "{{count}} fil arkivert siden",
-    "archived_file_other": "{{count}} filer arkivert siden",
-    "deleted_file_one": "{{count}} fil slettet siden",
-    "deleted_file_other": "{{count}} filer slettet siden"
+    "archived_file_one": "{{count}} fil arkivert i etterkant",
+    "archived_file_other": "{{count}} filer arkivert i etterkant",
+    "deleted_file_one": "{{count}} fil slettet i etterkant",
+    "deleted_file_other": "{{count}} filer slettet i etterkant"
   }
 }

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -163,6 +163,7 @@
     "created": "Opprettet",
     "date": "Dato",
     "delete": "Slett",
+    "deleted": "Slettet",
     "description": "Beskrivelse",
     "dialogue": "Dialog",
     "doi": "DOI",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -163,7 +163,6 @@
     "created": "Opprettet",
     "date": "Dato",
     "delete": "Slett",
-    "deleted": "Slettet",
     "description": "Beskrivelse",
     "dialogue": "Dialog",
     "doi": "DOI",
@@ -1869,5 +1868,11 @@
     "unpublish_registration_duplicate_citation_information": "Da kan du legge inn en lenke til det andre forskningsresultatet. Alle oppslag på det avpubliserte forskningsresultatet vil da føre til det andre, publiserte forskningsresultatet.",
     "unpublish_registration_duplicate_question": "Finnes det en annen publisert versjon av samme forskningsresultat?",
     "unpublish_registration_reason": "Legg inn en kort begrunnelse for at dette forskningsresultatet ikke lenger skal være publisert. Begrunnelsen vil vises på forskningsresultatet ved oppslag av referanse til forskningsresultet."
+  },
+  "log": {
+    "archived_file_one": "{{count}} fil arkivert siden",
+    "archived_file_other": "{{count}} filer arkivert siden",
+    "deleted_file_one": "{{count}} fil slettet siden",
+    "deleted_file_other": "{{count}} filer slettet siden"
   }
 }

--- a/src/types/publication_types/ticket.types.ts
+++ b/src/types/publication_types/ticket.types.ts
@@ -59,7 +59,7 @@ type TicketPublication = Pick<
   };
 
 export interface PublishingTicket extends Ticket {
-  approvedFiles: AssociatedFile[];
+  approvedFiles: string[];
   filesForApproval: AssociatedFile[];
   workflow: PublishStrategy;
 }


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-46187](https://unit.atlassian.net/browse/NP-46187)

Legger til filnavn i logginnslag for publiserte filer. Dersom filen er slettet vil teksten "slettet" stå istedenfor. Når filnavn er for lange kortes de med "..." (ellipsis). Legger på tooltip på filnavn, slik at man ser hele navnet dersom det er for langt (med mindre filen er slettet, da er det ingen tooltip-tekst).

Har også sneket inn tooltip med klokkelsett på dato for logginnslag. 

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-46187]: https://unit.atlassian.net/browse/NP-46187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ