### PR TITLE
Set generalSupportEnabled for customers

### DIFF
--- a/src/types/customerInstitution.types.ts
+++ b/src/types/customerInstitution.types.ts
@@ -40,6 +40,7 @@ export interface CustomerInstitution extends Pick<SimpleCustomerInstitution, 'id
     type: CustomerRrsType;
     id: string;
   };
+  generalSupportEnabled: boolean;
   allowFileUploadForTypes: PublicationInstanceType[];
 }
 
@@ -113,6 +114,7 @@ export const emptyCustomerInstitution: Omit<CustomerInstitution, 'doiAgent'> = {
   rboInstitution: false,
   rightsRetentionStrategy: { type: CustomerRrsType.NullRightsRetentionStrategy, id: '' },
   allowFileUploadForTypes: allPublicationInstanceTypes,
+  generalSupportEnabled: true,
 };
 
 export const emptyProtectedDoiAgent: ProtectedDoiAgent = {

--- a/src/utils/testfiles/mockCustomerInstitutions.ts
+++ b/src/utils/testfiles/mockCustomerInstitutions.ts
@@ -49,6 +49,7 @@ export const mockCustomerInstitution: CustomerInstitution = {
   rboInstitution: false,
   rightsRetentionStrategy: { type: CustomerRrsType.NullRightsRetentionStrategy, id: '' },
   allowFileUploadForTypes: allPublicationInstanceTypes,
+  generalSupportEnabled: true,
 };
 
 export const mockCustomerInstitutions: CustomerList = {


### PR DESCRIPTION
# Description

Avhenger av https://github.com/BIBSYSDEV/nva-identity-service/pull/360

Disse endringene virker som før inntil APIet støtter dette via create. Så om det legges til i frontend først slipper vi å samkjøre noe utrulling. Foreløpig skal alle ha støtte for support requests som default, så vil det komme muligheter for å justere dette senere for admin.


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
