### PR TITLE
Ensure all search hits has same color

### DIFF
--- a/src/api/apiPaths.ts
+++ b/src/api/apiPaths.ts
@@ -47,7 +47,6 @@ export enum RoleApiPath {
 
 export enum SearchApiPath {
   Registrations = '/search/resources',
-  Tickets = '/search/tickets',
   CustomerTickets = '/search/customer/tickets',
   ImportCandidates = '/search/import-candidates',
   NviCandidate = '/scientific-index/candidate',

--- a/src/api/mock-interceptor.ts
+++ b/src/api/mock-interceptor.ts
@@ -58,7 +58,7 @@ export const interceptRequestsOnMock = () => {
   mock.onGet(new RegExp(PublicationsApiPath.RegistrationsByOwner)).reply(200, mockMyRegistrations);
 
   //MY MESSAGES
-  mock.onGet(new RegExp(SearchApiPath.Tickets)).reply(200, mockSearchTasks);
+  mock.onGet(new RegExp(SearchApiPath.CustomerTickets)).reply(200, mockSearchTasks);
   mock.onGet(new RegExp('/tickets')).reply(200, mockTicketCollection);
 
   // PUBLICATION CHANNEL

--- a/src/components/RegistrationList.tsx
+++ b/src/components/RegistrationList.tsx
@@ -2,7 +2,7 @@ import CloseOutlinedIcon from '@mui/icons-material/CloseOutlined';
 import EditIcon from '@mui/icons-material/Edit';
 import StarIcon from '@mui/icons-material/Star';
 import StarOutlineIcon from '@mui/icons-material/StarOutline';
-import { Box, IconButton, Link as MuiLink, LinkProps, List, ListItemText, Tooltip, Typography } from '@mui/material';
+import { Box, IconButton, LinkProps, List, ListItemText, Link as MuiLink, Tooltip, Typography } from '@mui/material';
 import { useIsMutating, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
@@ -16,15 +16,15 @@ import { dataTestId } from '../utils/dataTestIds';
 import { displayDate } from '../utils/date-helpers';
 import { getTitleString, userCanDeleteRegistration } from '../utils/registration-helpers';
 import {
+  UrlPathTemplate,
   getRegistrationLandingPagePath,
   getRegistrationWizardPath,
   getResearchProfilePath,
-  UrlPathTemplate,
 } from '../utils/urlPaths';
 import { ContributorIndicators } from './ContributorIndicators';
 import { ErrorBoundary } from './ErrorBoundary';
-import { SearchListItem } from './styled/Wrappers';
 import { TruncatableTypography } from './TruncatableTypography';
+import { SearchListItem } from './styled/Wrappers';
 
 interface RegistrationListProps extends Pick<LinkProps, 'target'> {
   registrations: Registration[];
@@ -37,7 +37,7 @@ export const RegistrationList = ({ registrations, ...rest }: RegistrationListPro
   <List data-testid="search-results">
     {registrations.map((registration) => (
       <ErrorBoundary key={registration.id}>
-        <SearchListItem sx={{ borderLeftColor: 'registration.main', bgcolor: 'white' }}>
+        <SearchListItem sx={{ borderLeftColor: 'registration.main' }}>
           <RegistrationListItemContent registration={registration} {...rest} />
         </SearchListItem>
       </ErrorBoundary>

--- a/src/components/styled/Wrappers.tsx
+++ b/src/components/styled/Wrappers.tsx
@@ -63,6 +63,7 @@ export const SearchListItem = styled(ListItem)(({ theme }) => ({
   borderLeft: '1.25rem solid',
   flexDirection: 'column',
   alignItems: 'start',
+  background: 'white',
 }));
 
 export const StyledStatusCheckbox = styled(Checkbox)({

--- a/src/pages/basic_data/app_admin/InstitutionList.tsx
+++ b/src/pages/basic_data/app_admin/InstitutionList.tsx
@@ -41,7 +41,7 @@ export const InstitutionList = ({ institutions }: InstitutionListProps) => {
           {institutions.map((institution) => (
             <TableRow key={institution.id}>
               <TableCell>
-                <Typography>{institution.displayName}</Typography>
+                <Typography>{institution.displayName ?? institution.id}</Typography>
               </TableCell>
               <TableCell>
                 <Typography>{institution.doiPrefix}</Typography>
@@ -54,7 +54,7 @@ export const InstitutionList = ({ institutions }: InstitutionListProps) => {
                   variant="outlined"
                   startIcon={<EditIcon />}
                   component={RouterLink}
-                  data-testid={dataTestId.basicData.customers.editInstitutionButton(institution.displayName)}
+                  data-testid={dataTestId.basicData.customers.editInstitutionButton(institution.id)}
                   to={getAdminInstitutionPath(institution.id)}>
                   <Typography>{t('common.edit')}</Typography>
                 </Button>

--- a/src/pages/search/project_search/ProjectListItem.tsx
+++ b/src/pages/search/project_search/ProjectListItem.tsx
@@ -27,10 +27,7 @@ export const ProjectListItem = ({ project, refetchProjects, showEdit = false }: 
   const projectParticipantsLength = getProjectParticipants(project.contributors).length;
 
   return (
-    <SearchListItem
-      sx={{
-        borderLeftColor: 'project.main',
-      }}>
+    <SearchListItem sx={{ borderLeftColor: 'project.main' }}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
         <Typography sx={{ fontSize: '1rem', fontWeight: '600' }} gutterBottom>
           <MuiLink component={Link} to={getProjectPath(project.id)}>

--- a/src/utils/dataTestIds.ts
+++ b/src/utils/dataTestIds.ts
@@ -29,7 +29,7 @@ export const dataTestId = {
     centralImportAccordion: 'central-import-accordion',
     customers: {
       customerList: 'customer-institutions-list',
-      editInstitutionButton: (name: string) => `edit-institution-button-${name.toLowerCase().replaceAll(' ', '-')}`,
+      editInstitutionButton: (id: string) => `edit-institution-button-${id}`,
     },
     institutionsAccordion: 'institutions-accordion',
     institutionAdmin: {

--- a/src/utils/institutions-helpers.ts
+++ b/src/utils/institutions-helpers.ts
@@ -45,7 +45,7 @@ export const getTopLevelOrganization = (organization: Organization): Organizatio
     : getTopLevelOrganization(organization.partOf[0]);
 
 export const sortCustomerInstitutions = <T extends SimpleCustomerInstitution>(customers: T[] = []) =>
-  customers.sort((a, b) => (a.displayName.toLocaleLowerCase() < b.displayName.toLocaleLowerCase() ? -1 : 1));
+  customers.sort((a, b) => (a.displayName?.toLocaleLowerCase() < b.displayName?.toLocaleLowerCase() ? -1 : 1));
 
 export const getUnitTopLevelCode = (id = '') => {
   const identifier = id.split('/').pop() ?? '';

--- a/src/utils/testfiles/mock_feide_user.ts
+++ b/src/utils/testfiles/mock_feide_user.ts
@@ -10,7 +10,7 @@ export const mockUser: FeideUser = {
   'custom:topOrgCristinId': 'https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0',
   'custom:nvaUsername': '1@20754.0.0.0',
   'custom:roles':
-    'Creator@https://api.dev.nva.aws.unit.no/customer/a-a-a-a-a,Curator@https://api.dev.nva.aws.unit.no/customer/a-a-a-a-a,Curator-thesis@https://api.dev.nva.aws.unit.no/customer/a-a-a-a-a,Curator-thesis-embargo@https://api.dev.nva.aws.unit.no/customer/a-a-a-a-a,App-admin@https://api.dev.nva.aws.unit.no/customer/a-a-a-a-a,Institution-admin@https://api.dev.nva.aws.unit.no/customer/a-a-a-a-a,Editor@https://api.dev.nva.aws.unit.no/customer/a-a-a-a-a',
+    'Creator,Doi-Curator,Support-Curator,Publishing-Curator,Curator-thesis,Curator-thesis-embargo,App-admin,Institution-admin,Editor',
   'custom:accessRights': '',
   'custom:allowedCustomers': 'https://api.dev.nva.aws.unit.no/customer/a-a-a-a-a',
 };


### PR DESCRIPTION
# Description

Blander 3 småting i denne PRen:
1. Fjern gammel, ubrukt, API-path for ticket søk
2. Liten fiks for å håndtere at customer mangler navn, som ikke skal skje, men som har skjedd i sandbox. Mest for å ikke blokkere andre.
3. Fiks farge på søketreff, da det ble rart på forskerprofilen når resultat og projsjekt fikk ulik bakgrunnsfarge.

Før:
![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/5c47e675-ea35-4db9-b6fa-db829380fc40)

Etter:
![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/3a2608e4-b10a-4e75-84c9-e4c6950ba878)



# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
