### PR TITLE
NP-46613 Add log entry for archived files

### DIFF
--- a/src/pages/public_registration/LogPanel.tsx
+++ b/src/pages/public_registration/LogPanel.tsx
@@ -111,8 +111,19 @@ export const LogPanel = ({ tickets, registration }: LogPanelProps) => {
     }
   });
 
+  const numberOfArchivedFilesOnRegistration = getAssociatedFiles(registration.associatedArtifacts).filter(
+    (file) => file.type === 'UnpublishableFile'
+  ).length;
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', mt: '0.5rem' }}>
+      {numberOfArchivedFilesOnRegistration > 0 && (
+        <StyledStatusMessageBox sx={{ bgcolor: 'publishingRequest.main' }}>
+          <Typography sx={{ gridColumn: '1/3', fontStyle: 'italic' }}>
+            {t('log.archived_files_on_registration', { count: numberOfArchivedFilesOnRegistration })}
+          </Typography>
+        </StyledStatusMessageBox>
+      )}
       {registration && (
         <StyledStatusMessageBox sx={{ bgcolor: 'publishingRequest.main' }}>
           <Typography>{t('common.created')}</Typography>

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1882,6 +1882,8 @@
   "log": {
     "archived_file_one": "{{count}} fil arkivert i etterkant",
     "archived_file_other": "{{count}} filer arkivert i etterkant",
+    "archived_files_on_registration_one": "Registreringen har {{count}} arkivert fil",
+    "archived_files_on_registration_other": "Registreringen har {{count}} arkiverte filer",
     "deleted_file_one": "{{count}} fil slettet i etterkant",
     "deleted_file_other": "{{count}} filer slettet i etterkant"
   }


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-46613](https://unit.atlassian.net/browse/NP-46613)

Legger til et logginnslag i toppen av logglisten som viser totalt antall arkiverte filer på registreringen. Dersom det ikke er noen arkiverte filer så vises ikke logginnslaget.

<img width="252" alt="image" src="https://github.com/BIBSYSDEV/NVA-Frontend/assets/10809754/1f22abba-455a-41fd-9490-dbf62cce5950">


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-46613]: https://unit.atlassian.net/browse/NP-46613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ