### PR TITLE
NP-46609: Fixed too large click area on remove funding-icon

### DIFF
--- a/src/pages/registration/description_tab/RegistrationFunding.tsx
+++ b/src/pages/registration/description_tab/RegistrationFunding.tsx
@@ -190,7 +190,10 @@ export const RegistrationFunding = ({ currentFundings }: FundingsFieldProps) => 
                   <IconButton
                     onClick={() => remove(index)}
                     data-testid={dataTestId.registrationWizard.description.fundingRemoveButton}
-                    title={t('registration.description.funding.remove_funding')}>
+                    title={t('registration.description.funding.remove_funding')}
+                    sx={{
+                      width: 'fit-content',
+                    }}>
                     <CancelIcon color="primary" />
                   </IconButton>
                 </Box>


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46609

Fixed problem where the click area for the remove-button for funding was too big.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
