### PR TITLE
NP-46628: Fixed line break on long words on registration landing page

### DIFF
--- a/src/pages/public_registration/PublicSummaryContent.tsx
+++ b/src/pages/public_registration/PublicSummaryContent.tsx
@@ -10,7 +10,7 @@ export const PublicSummaryContent = ({ registration }: PublicRegistrationContent
   return !entityDescription ? null : (
     <>
       {entityDescription.abstract && (
-        <Typography style={{ whiteSpace: 'pre-line' }} paragraph>
+        <Typography style={{ whiteSpace: 'pre-line', overflowWrap: 'anywhere' }} paragraph>
           {entityDescription.abstract}
         </Typography>
       )}
@@ -19,7 +19,7 @@ export const PublicSummaryContent = ({ registration }: PublicRegistrationContent
           <Typography variant="h3" color="primary" gutterBottom>
             {t('registration.description.alternative_abstract')}
           </Typography>
-          <Typography style={{ whiteSpace: 'pre-line' }} paragraph>
+          <Typography style={{ whiteSpace: 'pre-line', overflowWrap: 'anywhere' }} paragraph>
             {entityDescription.alternativeAbstracts.und}
           </Typography>
         </>
@@ -29,7 +29,7 @@ export const PublicSummaryContent = ({ registration }: PublicRegistrationContent
           <Typography variant="h3" color="primary" gutterBottom>
             {t('common.description')}
           </Typography>
-          <Typography style={{ whiteSpace: 'pre-line' }} paragraph>
+          <Typography style={{ whiteSpace: 'pre-line', overflowWrap: 'anywhere' }} paragraph>
             {entityDescription.description}
           </Typography>
         </>


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46628

The issue describes a case where the summary on the registration consists on one long word that needs to be broken into smaller parts to fit on the page. 

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [ ] The changes are working as expected
- [ ] The changes are tested OK for different screen sizes
- [ ] The changes are tested OK for a11y
- [ ] Interactive elements have data-testids
- [ ] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
