### PR TITLE
NP-46637 Added new status check for setting NVI candidate assignee

### DIFF
--- a/src/pages/messages/components/NviCandidateActions.tsx
+++ b/src/pages/messages/components/NviCandidateActions.tsx
@@ -5,12 +5,12 @@ import { ReactNode, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import {
-  CreateNoteData,
-  SetNviCandidateStatusData,
   createNote,
+  CreateNoteData,
   deleteCandidateNote,
   setCandidateAssignee,
   setCandidateStatus,
+  SetNviCandidateStatusData,
 } from '../../../api/scientificIndexApi';
 import { AssigneeSelector } from '../../../components/AssigneeSelector';
 import { ErrorBoundary } from '../../../components/ErrorBoundary';
@@ -144,7 +144,7 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
       <Box sx={{ m: '1rem' }}>
         <AssigneeSelector
           assignee={myApproval?.assignee}
-          canSetAssignee={myApproval?.status === 'Pending'}
+          canSetAssignee={myApproval?.status === 'New' || myApproval?.status === 'Pending'}
           onSelectAssignee={async (assigee) => await assigneeMutation.mutateAsync(assigee)}
           isUpdating={assigneeMutation.isLoading}
           roleFilter={RoleName.NviCurator}


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46637

Ble en del frem og tilbake med denne oppgaven, men til slutt ble det en veldig enkel løsning. Ble litt forvirring rundt duplikater av kuratorer/brukere etter en tildigere migrering hvor gamle cristin-id'er har blitt tildelt nye brukere, noe som har ført til opplistede kuratorer med feil navn som ikke har tilgang. Eller var det bare å oppdatere en status-sjekk på NVI-kandidat....

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [ ] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
