### PR TITLE
Np 46254 Show helper text for unpublishing registration

### DIFF
--- a/src/pages/public_registration/action_accordions/DeletePublication.tsx
+++ b/src/pages/public_registration/action_accordions/DeletePublication.tsx
@@ -1,4 +1,5 @@
-import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
+import ExpandLess from '@mui/icons-material/ExpandLess';
+import ExpandMore from '@mui/icons-material/ExpandMore';
 import { LoadingButton } from '@mui/lab';
 import { Box, Button, DialogActions, Divider, IconButton, TextField, Typography } from '@mui/material';
 import { useMutation } from '@tanstack/react-query';
@@ -69,27 +70,34 @@ export const DeletePublication = ({ registration }: DeletePublicationProps) => {
 
   return (
     <>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem', mt: '1rem', alignItems: 'center' }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', mt: '1rem' }}>
         <Divider flexItem />
-        {!showDeleteField && (
-          <IconButton
-            data-testid={dataTestId.unpublishActions.showUnpublishButtonButton}
-            title={t('common.show_more_options')}
-            onClick={() => setShowDeleteField(true)}>
-            <MoreHorizIcon />
-          </IconButton>
+        <IconButton
+          sx={{ width: 'fit-content', alignSelf: 'center', p: '0' }}
+          data-testid={dataTestId.unpublishActions.showUnpublishButtonButton}
+          title={t('common.show_more_options')}
+          onClick={() => setShowDeleteField(!showDeleteField)}>
+          {showDeleteField ? <ExpandLess /> : <ExpandMore />}
+        </IconButton>
+        {showDeleteField && (
+          <>
+            <Typography fontWeight="bold">{t('unpublish_actions.unpublish_header')}</Typography>
+            {userCanUnpublish ? (
+              <>
+                <Typography>{t('unpublish_actions.unpublish_info')}</Typography>
+                <Button
+                  data-testid={dataTestId.unpublishActions.openUnpublishModalButton}
+                  variant="outlined"
+                  sx={{ bgcolor: 'white' }}
+                  onClick={() => setShowDeleteModal(true)}>
+                  {t('unpublish_actions.unpublish')}
+                </Button>
+              </>
+            ) : (
+              <Trans t={t} i18nKey="unpublish_actions.unpublish_not_allowed" components={[<Typography paragraph />]} />
+            )}
+          </>
         )}
-        {showDeleteField &&
-          (userCanUnpublish ? (
-            <Button
-              data-testid={dataTestId.unpublishActions.openUnpublishModalButton}
-              variant="outlined"
-              onClick={() => setShowDeleteModal(true)}>
-              {t('unpublish_actions.unpublish')}
-            </Button>
-          ) : (
-            <Trans t={t} i18nKey="unpublish_actions.unpublish_not_allowed" components={[<Typography paragraph />]} />
-          ))}
       </Box>
       <Modal
         headingText={t('registration.delete_registration')}

--- a/src/pages/public_registration/action_accordions/DeletePublication.tsx
+++ b/src/pages/public_registration/action_accordions/DeletePublication.tsx
@@ -4,7 +4,7 @@ import { Box, Button, DialogActions, Divider, IconButton, TextField, Typography 
 import { useMutation } from '@tanstack/react-query';
 import { ErrorMessage, Field, FieldProps, Form, Formik } from 'formik';
 import { useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import * as Yup from 'yup';
@@ -15,6 +15,7 @@ import { setNotification } from '../../../redux/notificationSlice';
 import i18n from '../../../translations/i18n';
 import { Registration } from '../../../types/registration.types';
 import { dataTestId } from '../../../utils/dataTestIds';
+import { userCanUnpublishRegistration } from '../../../utils/registration-helpers';
 import { getRegistrationLandingPagePath } from '../../../utils/urlPaths';
 import { FindRegistration } from './FindRegistration';
 
@@ -27,12 +28,14 @@ interface DeletePublicationProps {
 }
 
 export const DeletePublication = ({ registration }: DeletePublicationProps) => {
-  const [showDeleteButton, setShowDeleteButton] = useState(false);
+  const [showDeleteField, setShowDeleteField] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const [selectedDuplicate, setSelectedDuplicate] = useState<Registration | null>(null);
   const history = useHistory();
+
+  const userCanUnpublish = userCanUnpublishRegistration(registration);
 
   const deleteValidationSchema = Yup.object().shape({
     deleteMessage: Yup.string()
@@ -68,22 +71,25 @@ export const DeletePublication = ({ registration }: DeletePublicationProps) => {
     <>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem', mt: '1rem', alignItems: 'center' }}>
         <Divider flexItem />
-        {!showDeleteButton && (
+        {!showDeleteField && (
           <IconButton
             data-testid={dataTestId.unpublishActions.showUnpublishButtonButton}
             title={t('common.show_more_options')}
-            onClick={() => setShowDeleteButton(true)}>
+            onClick={() => setShowDeleteField(true)}>
             <MoreHorizIcon />
           </IconButton>
         )}
-        {showDeleteButton && (
-          <Button
-            data-testid={dataTestId.unpublishActions.openUnpublishModalButton}
-            variant="outlined"
-            onClick={() => setShowDeleteModal(true)}>
-            {t('unpublish_actions.unpublish')}
-          </Button>
-        )}
+        {showDeleteField &&
+          (userCanUnpublish ? (
+            <Button
+              data-testid={dataTestId.unpublishActions.openUnpublishModalButton}
+              variant="outlined"
+              onClick={() => setShowDeleteModal(true)}>
+              {t('unpublish_actions.unpublish')}
+            </Button>
+          ) : (
+            <Trans t={t} i18nKey="unpublish_actions.unpublish_not_allowed" components={[<Typography paragraph />]} />
+          ))}
       </Box>
       <Modal
         headingText={t('registration.delete_registration')}

--- a/src/pages/public_registration/action_accordions/DeletePublication.tsx
+++ b/src/pages/public_registration/action_accordions/DeletePublication.tsx
@@ -84,7 +84,7 @@ export const DeletePublication = ({ registration }: DeletePublicationProps) => {
             <Typography fontWeight="bold">{t('unpublish_actions.unpublish_header')}</Typography>
             {userCanUnpublish ? (
               <>
-                <Typography>{t('unpublish_actions.unpublish_info')}</Typography>
+                <Typography gutterBottom>{t('unpublish_actions.unpublish_info')}</Typography>
                 <Button
                   data-testid={dataTestId.unpublishActions.openUnpublishModalButton}
                   variant="outlined"

--- a/src/pages/public_registration/action_accordions/DeletePublication.tsx
+++ b/src/pages/public_registration/action_accordions/DeletePublication.tsx
@@ -75,7 +75,7 @@ export const DeletePublication = ({ registration }: DeletePublicationProps) => {
         <IconButton
           sx={{ width: 'fit-content', alignSelf: 'center', p: '0' }}
           data-testid={dataTestId.unpublishActions.showUnpublishButtonButton}
-          title={t('common.show_more_options')}
+          title={showDeleteField ? t('common.show_fewer_options') : t('common.show_more_options')}
           onClick={() => setShowDeleteField(!showDeleteField)}>
           {showDeleteField ? <ExpandLess /> : <ExpandMore />}
         </IconButton>

--- a/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
@@ -21,7 +21,7 @@ import { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link as RouterLink } from 'react-router-dom';
-import { UpdateTicketData, createTicket, updateTicket } from '../../../api/registrationApi';
+import { createTicket, updateTicket, UpdateTicketData } from '../../../api/registrationApi';
 import { MessageForm } from '../../../components/MessageForm';
 import { setNotification } from '../../../redux/notificationSlice';
 import { RootState } from '../../../redux/store';
@@ -29,9 +29,9 @@ import { PublishingTicket } from '../../../types/publication_types/ticket.types'
 import { Registration, RegistrationStatus } from '../../../types/registration.types';
 import { isErrorStatus, isSuccessStatus } from '../../../utils/constants';
 import { dataTestId } from '../../../utils/dataTestIds';
-import { TabErrors, getFirstErrorTab, getTabErrors } from '../../../utils/formik-helpers';
-import { userCanPublishRegistration, userCanUnpublishRegistration } from '../../../utils/registration-helpers';
-import { UrlPathTemplate, getRegistrationWizardPath } from '../../../utils/urlPaths';
+import { getFirstErrorTab, getTabErrors, TabErrors } from '../../../utils/formik-helpers';
+import { userCanPublishRegistration } from '../../../utils/registration-helpers';
+import { getRegistrationWizardPath, UrlPathTemplate } from '../../../utils/urlPaths';
 import { registrationValidationSchema } from '../../../utils/validation/registration/registrationValidation';
 import { TicketMessageList } from '../../messages/components/MessageList';
 import { StyledStatusMessageBox } from '../../messages/components/PublishingRequestMessagesColumn';
@@ -72,7 +72,6 @@ export const PublishingAccordion = ({
   const registrationHasFile = registration.associatedArtifacts.some((artifact) => artifact.type === 'PublishedFile');
   const completedTickets = publishingRequestTickets.filter((ticket) => ticket.status === 'Completed');
   const userCanPublish = userCanPublishRegistration(registration);
-  const userCanUnpublish = userCanUnpublishRegistration(registration);
 
   const lastPublishingRequest = publishingRequestTickets.at(-1);
 
@@ -403,9 +402,7 @@ export const PublishingAccordion = ({
             <MessageForm confirmAction={async (message) => await addMessage(lastPublishingRequest.id, message)} />
           </Box>
         )}
-        {userCanUnpublish && registration.status === RegistrationStatus.Published && (
-          <DeletePublication registration={registration} />
-        )}
+        {registration.status === RegistrationStatus.Published && <DeletePublication registration={registration} />}
       </AccordionDetails>
     </Accordion>
   );

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1886,6 +1886,7 @@
     "search_for_duplicate": "Søk etter forskningsresultat",
     "unpublish": "Avpubliser",
     "unpublish_header": "Avpublisere",
+    "unpublish_info": "Resultatet vil ikke lenger være synlig for andre hvis du velger å avpublisere. Du kan velge å publisere det på nytt senere",
     "unpublish_not_allowed": "<0>Du kan ikke avpublisere dette resultatet, fordi det enten har en opplastet fil med godkjent lisens eller er rapportert til Nasjonal vitenskapsindeks (NVI).</0><0>Har du behov for å avpublisere resultatet, ta kontakt med kurator via kuratorstøtte.</0>",
     "unpublish_registration": "Avpubliser forskningsresultat",
     "unpublish_registration_detail_1": "Etter å ha avpublisert restultatet kan du ikke lengre søke det opp, men det er fortsatt tilgjengelig via direkte oppslag (fra siteringer).",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -251,6 +251,7 @@
     "show_all": "Vis alle",
     "show_details": "Vis detaljer",
     "show_fewer": "Vis færre",
+    "show_fewer_options": "Vis færre valg",
     "show_more": "Vis flere",
     "show_more_options": "Vis flere valg",
     "skip_to_main_content": "Hopp til hovedinnhold",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1885,6 +1885,8 @@
     "search_duplicate_facets": "Søk med DOI, handle eller tittel",
     "search_for_duplicate": "Søk etter forskningsresultat",
     "unpublish": "Avpubliser",
+    "unpublish_header": "Avpublisere",
+    "unpublish_not_allowed": "<0>Du kan ikke avpublisere dette resultatet, fordi det enten har en opplastet fil med godkjent lisens eller er rapportert til Nasjonal vitenskapsindeks (NVI).</0><0>Har du behov for å avpublisere resultatet, ta kontakt med kurator via kuratorstøtte.</0>",
     "unpublish_registration": "Avpubliser forskningsresultat",
     "unpublish_registration_detail_1": "Etter å ha avpublisert restultatet kan du ikke lengre søke det opp, men det er fortsatt tilgjengelig via direkte oppslag (fra siteringer).",
     "unpublish_registration_detail_2": "Kun metadata (ingen filer) vil være synlig ved direkte oppslag.",


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-46254](https://unit.atlassian.net/browse/NP-46254)

Egentlig var det kritiske med denne oppgaven å ta i bruk AllowedOperations for å bestemme om man skal vise avpubliseringsknappen eller ikke. Men det viser seg at vi allerede bruker den, og da må det være en backen issue at denne knappen vises selv om det finnes publiserte filer på registreringen.

Har ellers lagt til hjelpetekst over avpubliseringsknappen, og hjelpetekst dersom bruker ikke har tilgang til å avpublisere.

Har også gjort om de tre prikkene til `<ExpandMore />` og  `<ExpandLess />` ikoner fra mui, og gjort hele feltet toggle-bart, da dette også var i skissene. Gjorde toggle-ikonene ganske små for at det skulle passe designet i skissene, men si ifra om trykkflaten har blitt altfor liten.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-46254]: https://unit.atlassian.net/browse/NP-46254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ