### PR TITLE
NP-46662: NotFound-view when trying to load non-existing NVI-candidate

### DIFF
--- a/src/pages/messages/components/NviCandidatePage.tsx
+++ b/src/pages/messages/components/NviCandidatePage.tsx
@@ -13,6 +13,7 @@ import { dataTestId } from '../../../utils/dataTestIds';
 import { getIdentifierFromId } from '../../../utils/general-helpers';
 import { getNviCandidatePath, IdentifierParams } from '../../../utils/urlPaths';
 import { Forbidden } from '../../errorpages/Forbidden';
+import NotFound from '../../errorpages/NotFound';
 import { PublicRegistrationContent } from '../../public_registration/PublicRegistrationContent';
 import { NavigationIconButton } from './NavigationIconButton';
 import { NviApprovals } from './NviApprovals';
@@ -89,9 +90,15 @@ export const NviCandidatePage = () => {
         }
       : undefined;
 
-  return nviCandidateQuery.error?.response?.status === 401 ? (
-    <Forbidden />
-  ) : registrationQuery.isLoading || nviCandidateQuery.isLoading ? (
+  if (nviCandidateQuery.error?.response?.status === 401) {
+    return <Forbidden />;
+  }
+
+  if (nviCandidateQuery.error?.response?.status === 404) {
+    return <NotFound />;
+  }
+
+  return registrationQuery.isLoading || nviCandidateQuery.isLoading ? (
     <PageSpinner aria-label={t('common.result')} />
   ) : (
     <Box


### PR DESCRIPTION
# Description

Link to Jira issue: [Frontend, nvi candidate: Non-terminating loader](https://unit.atlassian.net/browse/NP-46662)

Earlier, when trying to load an NVI-canditate that no longer exists (if the registration was changed so that it is no longer a candidate) we wound get an eternal spinner. Now, instead, we get a Not Found-view.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [ ] The changes are working as expected
- [ ] The changes are tested OK for different screen sizes
- [ ] The changes are tested OK for a11y
- [ ] Interactive elements have data-testids
- [ ] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
