### PR TITLE
NP-46252 Disable file edit when published

### DIFF
--- a/src/pages/registration/FilesAndLicensePanel.tsx
+++ b/src/pages/registration/FilesAndLicensePanel.tsx
@@ -22,7 +22,7 @@ import { BackgroundDiv } from '../../components/styled/Wrappers';
 import { RootState } from '../../redux/store';
 import { alternatingTableRowColor } from '../../themes/mainTheme';
 import { AssociatedFile, AssociatedLink, NullAssociatedArtifact, Uppy } from '../../types/associatedArtifact.types';
-import { LicenseUri, licenses } from '../../types/license.types';
+import { licenses, LicenseUri } from '../../types/license.types';
 import { FileFieldNames, SpecificLinkFieldNames } from '../../types/publicationFieldNames';
 import { Registration } from '../../types/registration.types';
 import { dataTestId } from '../../utils/dataTestIds';
@@ -35,6 +35,7 @@ import {
   isEmbargoed,
   isTypeWithFileVersionField,
   userCanEditRegistration,
+  userCanUnpublishRegistration,
   userIsValidImporter,
 } from '../../utils/registration-helpers';
 import {
@@ -291,8 +292,14 @@ export const FilesAndLicensePanel = ({ uppy }: FilesAndLicensePanelProps) => {
                           return false;
                         });
 
+                        const canEditEmbargoedDegreeFile = !!user?.isEmbargoThesisCurator;
+                        const canEditNonEmbargoedDegreeFile =
+                          file.type === 'PublishedFile' ? userCanUnpublishRegistration(values) : canEditFiles;
+
                         const isEmbargoedDegreeFile = isProtectedDegree && isEmbargoed(file.embargoDate);
-                        const canEditThisFile = isEmbargoedDegreeFile ? !!user?.isEmbargoThesisCurator : canEditFiles;
+                        const canEditThisFile = isEmbargoedDegreeFile
+                          ? canEditEmbargoedDegreeFile
+                          : canEditNonEmbargoedDegreeFile;
 
                         return (
                           <FilesTableRow

--- a/src/pages/registration/FilesAndLicensePanel.tsx
+++ b/src/pages/registration/FilesAndLicensePanel.tsx
@@ -293,13 +293,11 @@ export const FilesAndLicensePanel = ({ uppy }: FilesAndLicensePanelProps) => {
                         });
 
                         const canEditEmbargoedDegreeFile = !!user?.isEmbargoThesisCurator;
-                        const canEditNonEmbargoedDegreeFile =
+                        const canEditFile =
                           file.type === 'PublishedFile' ? userCanUnpublishRegistration(values) : canEditFiles;
 
                         const isEmbargoedDegreeFile = isProtectedDegree && isEmbargoed(file.embargoDate);
-                        const canEditThisFile = isEmbargoedDegreeFile
-                          ? canEditEmbargoedDegreeFile
-                          : canEditNonEmbargoedDegreeFile;
+                        const canEditThisFile = isEmbargoedDegreeFile ? canEditEmbargoedDegreeFile : canEditFile;
 
                         return (
                           <FilesTableRow

--- a/src/pages/registration/FilesAndLicensePanel.tsx
+++ b/src/pages/registration/FilesAndLicensePanel.tsx
@@ -112,6 +112,22 @@ export const FilesAndLicensePanel = ({ uppy }: FilesAndLicensePanelProps) => {
   const isProtectedDegree = isDegreeWithProtectedFiles(publicationInstanceType);
   const canEditFiles = userCanEditRegistration(values) || userIsValidImporter(user, values);
 
+  function canEditFile(file: AssociatedFile) {
+    if (isProtectedDegree && isEmbargoed(file.embargoDate)) {
+      return !!user?.isEmbargoThesisCurator;
+    }
+
+    if (isProtectedDegree) {
+      return !!user?.isThesisCurator;
+    }
+
+    if (file.type === 'PublishedFile') {
+      return userCanUnpublishRegistration(values) ?? false;
+    }
+
+    return true;
+  }
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
       {(publisherIdentifier || seriesIdentifier || journalIdentifier) && (
@@ -292,18 +308,11 @@ export const FilesAndLicensePanel = ({ uppy }: FilesAndLicensePanelProps) => {
                           return false;
                         });
 
-                        const canEditEmbargoedDegreeFile = !!user?.isEmbargoThesisCurator;
-                        const canEditFile =
-                          file.type === 'PublishedFile' ? userCanUnpublishRegistration(values) : canEditFiles;
-
-                        const isEmbargoedDegreeFile = isProtectedDegree && isEmbargoed(file.embargoDate);
-                        const canEditThisFile = isEmbargoedDegreeFile ? canEditEmbargoedDegreeFile : canEditFile;
-
                         return (
                           <FilesTableRow
                             key={file.identifier}
                             file={file}
-                            disabled={!canEditThisFile}
+                            disabled={!canEditFile(file)}
                             removeFile={() => {
                               const associatedArtifactsBeforeRemoval = associatedArtifacts.length;
                               const remainingFiles = uppy

--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -96,7 +96,10 @@ export const FilesTableRow = ({ file, removeFile, baseFieldName, showFileVersion
 
   return (
     <>
-      <TableRow data-testid={dataTestId.registrationWizard.files.fileRow} sx={{ td: { pb: 0, borderBottom: 'unset' } }}>
+      <TableRow
+        data-testid={dataTestId.registrationWizard.files.fileRow}
+        title={disabled ? t('registration.files_and_license.disabled_helper_text') : ''}
+        sx={{ bgcolor: disabled ? 'grey.400' : '', td: { pb: 0, borderBottom: 'unset' } }}>
         <TableCell sx={{ minWidth: '13rem' }}>
           <TruncatableTypography>{file.name}</TruncatableTypography>
         </TableCell>
@@ -300,7 +303,9 @@ export const FilesTableRow = ({ file, removeFile, baseFieldName, showFileVersion
           )}
         </TableCell>
       </TableRow>
-      <TableRow>
+      <TableRow
+        sx={{ bgcolor: disabled ? 'grey.400' : '' }}
+        title={disabled ? t('registration.files_and_license.disabled_helper_text') : ''}>
         <TableCell sx={{ pt: 0, pb: 0 }} colSpan={showFileVersion ? 6 : 5}>
           <Collapse in={openCollapsable}>
             <Box
@@ -347,6 +352,7 @@ export const FilesTableRow = ({ file, removeFile, baseFieldName, showFileVersion
 
                 {canOverrideRrs && (
                   <FormControlLabel
+                    disabled={disabled}
                     label={
                       <Trans t={t} i18nKey="registration.files_and_license.follow_institution_rights_policy">
                         {rrsPolicyLink}

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1252,6 +1252,7 @@
       "administrative_agreement": "Administrativ avtale",
       "administrative_contract": "Intern fil som aldri skal publiseres. F.eks. forfatteravtale eller annen dokumentasjon for det registrerte resultatet",
       "conditions_for_using_file": "Betingelser for bruk",
+      "disabled_helper_text": "Denne filen er allerede publisert med en godkjent lisens. Ta kontakt med kurator om du vil endre eller slette filen",
       "embargo": "Embargo/utsatt publisering",
       "file_and_license_info": "Enhver fil i NVA må ha en lisens, slik at leser er informert om hva som er tillatt å gjøre med innholdet.",
       "file_publish_date_helper_text": "Filen er låst fram til angitt dato",


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-46252](https://unit.atlassian.net/browse/NP-46252)

Disable editering av fil i wizard når filen er publisert, så lenge man ikke kan avpublisere hele registreringen (dvs. er publishing-curator).

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-46252]: https://unit.atlassian.net/browse/NP-46252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ