### PR TITLE
NP-46748 Unlock file edit for import candidates

### DIFF
--- a/src/pages/registration/FilesAndLicensePanel.tsx
+++ b/src/pages/registration/FilesAndLicensePanel.tsx
@@ -121,6 +121,10 @@ export const FilesAndLicensePanel = ({ uppy }: FilesAndLicensePanelProps) => {
       return !!user?.isThesisCurator;
     }
 
+    if (values.type === 'ImportCandidate') {
+      return !!user?.isInternalImporter;
+    }
+
     if (file.type === 'PublishedFile') {
       return userCanUnpublishRegistration(values) ?? false;
     }


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-46748](https://unit.atlassian.net/browse/NP-46748)

Etter nedlåsning av publiserte filer, viser det seg at også importkanditater bruker samme filkomponent. Ettersom importkanditater ikke har allowedOperations, feilet hele rettighetssjekken. Gjør nå heller en sjekk på om man er import-curator dersom det er en importkandidat man holder på med.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-46748]: https://unit.atlassian.net/browse/NP-46748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ