### PR TITLE
NP-46758 Gjør NPI fagfelt obligatorisk kun for NVI-kategorier

### DIFF
--- a/src/pages/registration/resource_type_tab/components/NpiDisciplineField.tsx
+++ b/src/pages/registration/resource_type_tab/components/NpiDisciplineField.tsx
@@ -16,7 +16,11 @@ const disciplineOptions = disciplines
   )
   .flat();
 
-export const NpiDisciplineField = () => {
+interface NpiDisciplineFieldProps {
+  required: boolean;
+}
+
+export const NpiDisciplineField = ({ required }: NpiDisciplineFieldProps) => {
   const { t } = useTranslation();
 
   return (
@@ -45,7 +49,7 @@ export const NpiDisciplineField = () => {
                 {...params}
                 onBlur={() => (!touched ? setFieldTouched(name, true, false) : null)}
                 label={t('registration.description.npi_disciplines')}
-                required
+                required={required}
                 fullWidth
                 variant="filled"
                 placeholder={!value ? t('registration.description.search_for_npi_discipline') : ''}

--- a/src/pages/registration/resource_type_tab/sub_type_forms/BookForm.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/BookForm.tsx
@@ -1,5 +1,6 @@
 import { useFormikContext } from 'formik';
 import { BookRegistration } from '../../../../types/publication_types/bookRegistration.types';
+import { PublicationInstanceType } from '../../../../types/registration.types';
 import { nviApplicableTypes } from '../../../../utils/registration-helpers';
 import { IsbnAndPages } from '../components/isbn_and_pages/IsbnAndPages';
 import { NpiDisciplineField } from '../components/NpiDisciplineField';
@@ -11,19 +12,20 @@ import { SeriesFields } from '../components/SeriesFields';
 export const BookForm = () => {
   const { values } = useFormikContext<BookRegistration>();
   const instanceType = values.entityDescription.reference?.publicationInstance.type;
+  const isNviApplicable = nviApplicableTypes.includes(instanceType as PublicationInstanceType);
 
   return (
     <>
       <PublisherField />
 
-      <NpiDisciplineField />
+      <NpiDisciplineField required={isNviApplicable} />
 
       <IsbnAndPages />
       <RevisionField />
 
       <SeriesFields />
 
-      {instanceType && nviApplicableTypes.includes(instanceType) ? <NviValidation registration={values} /> : null}
+      {instanceType && isNviApplicable ? <NviValidation registration={values} /> : null}
     </>
   );
 };

--- a/src/pages/registration/resource_type_tab/sub_type_forms/ChapterForm.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/ChapterForm.tsx
@@ -5,7 +5,9 @@ import { ErrorMessage, Field, FieldProps, useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
 import { BookType, ChapterType, ReportType, ResourceFieldNames } from '../../../../types/publicationFieldNames';
 import { ChapterRegistration } from '../../../../types/publication_types/chapterRegistration.types';
+import { PublicationInstanceType } from '../../../../types/registration.types';
 import { dataTestId } from '../../../../utils/dataTestIds';
+import { nviApplicableTypes } from '../../../../utils/registration-helpers';
 import { NpiDisciplineField } from '../components/NpiDisciplineField';
 import { NviValidation } from '../components/NviValidation';
 import { SearchContainerField } from '../components/SearchContainerField';
@@ -25,6 +27,7 @@ export const ChapterForm = () => {
 
   const { values } = useFormikContext<ChapterRegistration>();
   const instanceType = values.entityDescription.reference?.publicationInstance.type ?? '';
+  const isNviApplicable = nviApplicableTypes.includes(instanceType as PublicationInstanceType);
 
   return (
     <>
@@ -75,7 +78,7 @@ export const ChapterForm = () => {
         ) : null}
       </div>
 
-      <NpiDisciplineField />
+      <NpiDisciplineField required={isNviApplicable} />
 
       <Box sx={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
         <Field name={ResourceFieldNames.PagesFrom}>
@@ -111,7 +114,7 @@ export const ChapterForm = () => {
         </Field>
       </Box>
 
-      {instanceType === ChapterType.AcademicChapter ? <NviValidation registration={values} /> : null}
+      {isNviApplicable ? <NviValidation registration={values} /> : null}
     </>
   );
 };

--- a/src/utils/validation/registration/registrationValidation.ts
+++ b/src/utils/validation/registration/registrationValidation.ts
@@ -2,7 +2,7 @@ import * as Yup from 'yup';
 import i18n from '../../../translations/i18n';
 import { PublicationType } from '../../../types/publicationFieldNames';
 import { EntityDescription, Registration, RegistrationDate } from '../../../types/registration.types';
-import { getMainRegistrationType, isBook, isChapter } from '../../registration-helpers';
+import { getMainRegistrationType, isBook, isChapter, nviApplicableTypes } from '../../registration-helpers';
 import { YupShape } from '../validationHelpers';
 import { associatedFileValidationSchema } from './associatedArtifactValidation';
 import { contributorsValidationSchema } from './contributorValidation';
@@ -45,7 +45,8 @@ export const registrationValidationSchema = Yup.object<YupShape<Registration>>({
     npiSubjectHeading: Yup.string()
       .nullable()
       .when('$publicationInstanceType', ([publicationInstanceType], schema) =>
-        isBook(publicationInstanceType) || isChapter(publicationInstanceType)
+        nviApplicableTypes.includes(publicationInstanceType) &&
+        (isBook(publicationInstanceType) || isChapter(publicationInstanceType))
           ? schema.required(registrationErrorMessage.npiSubjectRequired)
           : schema
       ),


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-46758](https://unit.atlassian.net/browse/NP-46758)

Gjør NPI fagfelt obligatorisk kun for NVI-kategorier. Dette betyr at det kun er obligatorisk for "Vitenskapelig monografi" og "Vitenskapelig kapittel".

![image](https://github.com/BIBSYSDEV/NVA-Frontend/assets/10809754/3d9bb73a-7205-43d0-af00-e9895e8283aa)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-46758]: https://unit.atlassian.net/browse/NP-46758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ