### PR TITLE
Optimize chunking

### DIFF
--- a/src/pages/my_page/user_profile/MyProfile.tsx
+++ b/src/pages/my_page/user_profile/MyProfile.tsx
@@ -8,6 +8,7 @@ import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchPerson, updateCristinPerson } from '../../../api/cristinApi';
+import { NationalIdNumberField } from '../../../components/NationalIdNumberField';
 import { PageSpinner } from '../../../components/PageSpinner';
 import { setNotification } from '../../../redux/notificationSlice';
 import { RootState } from '../../../redux/store';
@@ -198,7 +199,7 @@ export const MyProfile = () => {
                   </Grid>
                   <Grid item xs={14} md={12}>
                     <StyledGridBox>
-                      {/* <NationalIdNumberField nationalId={user.nationalIdNumber} /> */}
+                      <NationalIdNumberField nationalId={user.nationalIdNumber} />
                       <TextField
                         value={getIdentifierFromId(personId ?? '')}
                         disabled

--- a/src/pages/my_page/user_profile/MyProfile.tsx
+++ b/src/pages/my_page/user_profile/MyProfile.tsx
@@ -8,7 +8,6 @@ import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchPerson, updateCristinPerson } from '../../../api/cristinApi';
-import { NationalIdNumberField } from '../../../components/NationalIdNumberField';
 import { PageSpinner } from '../../../components/PageSpinner';
 import { setNotification } from '../../../redux/notificationSlice';
 import { RootState } from '../../../redux/store';
@@ -199,7 +198,7 @@ export const MyProfile = () => {
                   </Grid>
                   <Grid item xs={14} md={12}>
                     <StyledGridBox>
-                      <NationalIdNumberField nationalId={user.nationalIdNumber} />
+                      {/* <NationalIdNumberField nationalId={user.nationalIdNumber} /> */}
                       <TextField
                         value={getIdentifierFromId(personId ?? '')}
                         disabled

--- a/src/pages/registration/DescriptionPanel.tsx
+++ b/src/pages/registration/DescriptionPanel.tsx
@@ -8,7 +8,7 @@ import { InputContainerBox } from '../../components/styled/Wrappers';
 import { DescriptionFieldNames } from '../../types/publicationFieldNames';
 import { Registration } from '../../types/registration.types';
 import { dataTestId } from '../../utils/dataTestIds';
-import { languageOptions } from '../../utils/registration-helpers';
+import { registrationLanguageOptions } from '../../utils/registration-helpers';
 import { DatePickerField } from './description_tab/DatePickerField';
 import { RegistrationFunding } from './description_tab/RegistrationFunding';
 import { ProjectsField } from './description_tab/projects_field/ProjectsField';
@@ -185,13 +185,13 @@ export const DescriptionPanel = () => {
               placeholder={t('registration.description.primary_language')}
               select
               variant="filled">
-              {!languageOptions.some((language) => language.uri === field.value) && (
+              {!registrationLanguageOptions.some((language) => language.uri === field.value) && (
                 // Show if Registration has a language that's currently not supported
                 <MenuItem value={field.value} disabled>
                   {i18n.language === 'nob' ? getLanguageByIso6393Code('und').nob : getLanguageByIso6393Code('und').eng}
                 </MenuItem>
               )}
-              {languageOptions.map(({ uri, nob, eng }) => (
+              {registrationLanguageOptions.map(({ uri, nob, eng }) => (
                 <MenuItem value={uri} key={uri} data-testid={`registration-language-${uri}`}>
                   {i18n.language === 'nob' ? nob : eng}
                 </MenuItem>

--- a/src/pages/registration/DescriptionPanel.tsx
+++ b/src/pages/registration/DescriptionPanel.tsx
@@ -8,29 +8,11 @@ import { InputContainerBox } from '../../components/styled/Wrappers';
 import { DescriptionFieldNames } from '../../types/publicationFieldNames';
 import { Registration } from '../../types/registration.types';
 import { dataTestId } from '../../utils/dataTestIds';
+import { languageOptions } from '../../utils/registration-helpers';
 import { DatePickerField } from './description_tab/DatePickerField';
 import { RegistrationFunding } from './description_tab/RegistrationFunding';
 import { ProjectsField } from './description_tab/projects_field/ProjectsField';
 import { VocabularyBase } from './description_tab/vocabularies/VocabularyBase';
-
-export const languageOptions = [
-  getLanguageByIso6393Code('eng'),
-  getLanguageByIso6393Code('nob'),
-  getLanguageByIso6393Code('nno'),
-  getLanguageByIso6393Code('dan'),
-  getLanguageByIso6393Code('fin'),
-  getLanguageByIso6393Code('fra'),
-  getLanguageByIso6393Code('isl'),
-  getLanguageByIso6393Code('ita'),
-  getLanguageByIso6393Code('nld'),
-  getLanguageByIso6393Code('por'),
-  getLanguageByIso6393Code('rus'),
-  getLanguageByIso6393Code('sme'),
-  getLanguageByIso6393Code('spa'),
-  getLanguageByIso6393Code('swe'),
-  getLanguageByIso6393Code('deu'),
-  getLanguageByIso6393Code('mis'),
-];
 
 export const DescriptionPanel = () => {
   const { t, i18n } = useTranslation();

--- a/src/pages/search/advanced_search/LanguageFilter.tsx
+++ b/src/pages/search/advanced_search/LanguageFilter.tsx
@@ -4,12 +4,11 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router';
 import { ResultParam } from '../../../api/searchApi';
-import i18n from '../../../translations/i18n';
 import { dataTestId } from '../../../utils/dataTestIds';
-import { languageOptions } from '../../registration/DescriptionPanel';
+import { languageOptions } from '../../../utils/registration-helpers';
 
 export const LanguageFilter = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const history = useHistory();
   const searchParams = new URLSearchParams(history.location.search);
   const languageParam = searchParams.get(ResultParam.PublicationLanguageShould)?.split(',') || [];

--- a/src/pages/search/advanced_search/LanguageFilter.tsx
+++ b/src/pages/search/advanced_search/LanguageFilter.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router';
 import { ResultParam } from '../../../api/searchApi';
 import { dataTestId } from '../../../utils/dataTestIds';
-import { languageOptions } from '../../../utils/registration-helpers';
+import { registrationLanguageOptions } from '../../../utils/registration-helpers';
 
 export const LanguageFilter = () => {
   const { t, i18n } = useTranslation();
@@ -21,7 +21,10 @@ export const LanguageFilter = () => {
   const updateSelectedLanguages = (selectedUris: string[]) => {
     if (selectedUris && selectedUris.length > 0) {
       const languages = selectedUris
-        .map((iso6393Code) => languageOptions.find((language) => language.iso6393Code === iso6393Code)?.iso6393Code)
+        .map(
+          (iso6393Code) =>
+            registrationLanguageOptions.find((language) => language.iso6393Code === iso6393Code)?.iso6393Code
+        )
         .filter(Boolean);
 
       if (languages.length > 0) {
@@ -37,7 +40,7 @@ export const LanguageFilter = () => {
   };
 
   const selectedLanguages = languageParam
-    .map((iso6393Code) => languageOptions.find((language) => language.iso6393Code === iso6393Code))
+    .map((iso6393Code) => registrationLanguageOptions.find((language) => language.iso6393Code === iso6393Code))
     .filter(Boolean) as Language[];
 
   return (
@@ -61,7 +64,7 @@ export const LanguageFilter = () => {
           }}
           renderValue={() => t('search.advanced_search.choose_one_or_more')}
           variant="outlined">
-          {languageOptions.map(({ uri, iso6393Code, nob, eng }) => (
+          {registrationLanguageOptions.map(({ uri, iso6393Code, nob, eng }) => (
             <MenuItem value={iso6393Code} key={uri} data-testid={`publication-language-${uri}`}>
               {i18n.language === 'nob' ? nob : eng}
             </MenuItem>

--- a/src/utils/registration-helpers.ts
+++ b/src/utils/registration-helpers.ts
@@ -1,4 +1,5 @@
 import { TFunction } from 'i18next';
+import { getLanguageByIso6393Code } from 'nva-language';
 import { DisabledCategory } from '../components/CategorySelector';
 import { OutputItem } from '../pages/registration/resource_type_tab/sub_type_forms/artistic_types/OutputRow';
 import i18n from '../translations/i18n';
@@ -722,3 +723,22 @@ export const findParentSubject = (disciplines: NpiSubjectDomain[], npiSubjectHea
   );
   return parent ? parent.id : null;
 };
+
+export const languageOptions = [
+  getLanguageByIso6393Code('eng'),
+  getLanguageByIso6393Code('nob'),
+  getLanguageByIso6393Code('nno'),
+  getLanguageByIso6393Code('dan'),
+  getLanguageByIso6393Code('fin'),
+  getLanguageByIso6393Code('fra'),
+  getLanguageByIso6393Code('isl'),
+  getLanguageByIso6393Code('ita'),
+  getLanguageByIso6393Code('nld'),
+  getLanguageByIso6393Code('por'),
+  getLanguageByIso6393Code('rus'),
+  getLanguageByIso6393Code('sme'),
+  getLanguageByIso6393Code('spa'),
+  getLanguageByIso6393Code('swe'),
+  getLanguageByIso6393Code('deu'),
+  getLanguageByIso6393Code('mis'),
+];

--- a/src/utils/registration-helpers.ts
+++ b/src/utils/registration-helpers.ts
@@ -724,7 +724,7 @@ export const findParentSubject = (disciplines: NpiSubjectDomain[], npiSubjectHea
   return parent ? parent.id : null;
 };
 
-export const languageOptions = [
+export const registrationLanguageOptions = [
   getLanguageByIso6393Code('eng'),
   getLanguageByIso6393Code('nob'),
   getLanguageByIso6393Code('nno'),


### PR DESCRIPTION
Unngå at bruker må laste ned noen overflødige chunk. I dette tilfellet fjernes behovet for `DescriptionPanel` når man åpner fremsiden. Vi har nok fortsatt mange plasser hvor vi kan bedre oss her, uten at jeg har oversikt over hvor stort omfanget er. Mulig vi burde vurdere å ha lazy-loading av alle sider per underside også (Min side, Oppgaver, Grunndata) for å minimere enda mer hvor mange chunks som må lastes ned. Men mulig vinninga går opp i spinninga om vi drar det for langt også 🤷 