### PR TITLE
map returned keywords from person to new model

### DIFF
--- a/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
+++ b/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
@@ -51,31 +51,26 @@ export const MyFieldAndBackground = () => {
       no: personBackground.no ?? '',
       en: personBackground.en ?? '',
     },
-    keywords: personKeywords
-      ? personKeywords.map((keyword) => {
-          return {
-            type: 'Keyword',
-            id: '',
-            identifier: keyword.type,
-            labels: keyword.label,
-          };
-        })
-      : [],
+    keywords: personKeywords.map((keyword) => {
+      return {
+        type: 'Keyword',
+        id: '',
+        identifier: keyword.type,
+        labels: keyword.label,
+      };
+    }),
   };
 
   const updatePerson = useMutation({
     mutationFn: async (values: PersonBackgroundFormData) => {
       if (personId) {
         const keywords = values.keywords as Keywords[];
-        const mappedKeywords: KeywordsOld[] = keywords
-          ? keywords.map((keyword) => {
-              return {
-                type: keyword.identifier,
-                label: keyword.labels,
-              };
-            })
-          : [];
-
+        const mappedKeywords: KeywordsOld[] = keywords.map((keyword) => {
+          return {
+            type: keyword.identifier,
+            label: keyword.labels,
+          };
+        });
         const payload: PersonBackgroundFormData = {
           background: {
             no: values.background.no === '' ? null : values.background.no,

--- a/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
+++ b/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
@@ -16,16 +16,6 @@ import { getLanguageString } from '../../../utils/translation-helpers';
 
 type PersonBackgroundFormData = Pick<FlatCristinPerson, 'background' | 'keywords'>;
 
-const castKeywords = (data: any): Keywords[] =>
-  data.map((keyword: any) => {
-    return {
-      type: 'Keyword',
-      id: '',
-      identifier: keyword.type,
-      labels: keyword.label,
-    };
-  });
-
 export const MyFieldAndBackground = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
@@ -61,7 +51,16 @@ export const MyFieldAndBackground = () => {
       no: personBackground.no ?? '',
       en: personBackground.en ?? '',
     },
-    keywords: personKeywords ? castKeywords(personKeywords) : [],
+    keywords: personKeywords
+      ? personKeywords.map((keyword: any) => {
+          return {
+            type: 'Keyword',
+            id: '',
+            identifier: keyword.type,
+            labels: keyword.label,
+          };
+        })
+      : [],
   };
 
   const updatePerson = useMutation({

--- a/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
+++ b/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
@@ -52,7 +52,7 @@ export const MyFieldAndBackground = () => {
       en: personBackground.en ?? '',
     },
     keywords: personKeywords
-      ? personKeywords.map((keyword: any) => {
+      ? personKeywords.map((keyword) => {
           return {
             type: 'Keyword',
             id: '',

--- a/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
+++ b/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
@@ -9,12 +9,22 @@ import { fetchPerson, searchForKeywords, updateCristinPerson } from '../../../ap
 import { AutocompleteTextField } from '../../../components/AutocompleteTextField';
 import { setNotification } from '../../../redux/notificationSlice';
 import { RootState } from '../../../redux/store';
-import { Keywords } from '../../../types/keywords.types';
+import { Keywords, KeywordsOld } from '../../../types/keywords.types';
 import { FlatCristinPerson } from '../../../types/user.types';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
 import { getLanguageString } from '../../../utils/translation-helpers';
 
 type PersonBackgroundFormData = Pick<FlatCristinPerson, 'background' | 'keywords'>;
+
+const castKeywords = (data: any): Keywords[] =>
+  data.map((keyword: any) => {
+    return {
+      type: 'Keyword',
+      id: '',
+      identifier: keyword.type,
+      labels: keyword.label,
+    };
+  });
 
 export const MyFieldAndBackground = () => {
   const { t } = useTranslation();
@@ -51,18 +61,28 @@ export const MyFieldAndBackground = () => {
       no: personBackground.no ?? '',
       en: personBackground.en ?? '',
     },
-    keywords: personKeywords ?? [],
+    keywords: personKeywords ? castKeywords(personKeywords) : [],
   };
 
   const updatePerson = useMutation({
     mutationFn: async (values: PersonBackgroundFormData) => {
       if (personId) {
+        const keywords = values.keywords as Keywords[];
+        const mappedKeywords: KeywordsOld[] = keywords
+          ? keywords.map((keyword) => {
+              return {
+                type: keyword.identifier,
+                label: keyword.labels,
+              };
+            })
+          : [];
+
         const payload: PersonBackgroundFormData = {
           background: {
             no: values.background.no === '' ? null : values.background.no,
             en: values.background.en === '' ? null : values.background.en,
           },
-          keywords: values.keywords,
+          keywords: mappedKeywords,
         };
         await updateCristinPerson(personId, payload);
       }

--- a/src/pages/research_profile/ResearchProfile.tsx
+++ b/src/pages/research_profile/ResearchProfile.tsx
@@ -8,8 +8,8 @@ import {
   Divider,
   Grid,
   IconButton,
-  List,
   Link as MuiLink,
+  List,
   Typography,
 } from '@mui/material';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
@@ -20,11 +20,11 @@ import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { fetchPerson, searchForProjects } from '../../api/cristinApi';
 import { fetchPromotedPublicationsById } from '../../api/preferencesApi';
-import { FetchResultsParams, fetchResults } from '../../api/searchApi';
+import { fetchResults, FetchResultsParams } from '../../api/searchApi';
+import { AffiliationHierarchy } from '../../components/institution/AffiliationHierarchy';
 import { ListPagination } from '../../components/ListPagination';
 import { PageSpinner } from '../../components/PageSpinner';
 import { ProfilePicture } from '../../components/ProfilePicture';
-import { AffiliationHierarchy } from '../../components/institution/AffiliationHierarchy';
 import { BackgroundDiv } from '../../components/styled/Wrappers';
 import { RootState } from '../../redux/store';
 import orcidIcon from '../../resources/images/orcid_logo.svg';
@@ -247,7 +247,7 @@ const ResearchProfile = () => {
             {personKeywords.length > 0 && (
               <Box sx={{ display: 'flex', gap: '0.5rem', mb: '1rem', flexWrap: 'wrap' }}>
                 {personKeywords.map((keyword) => (
-                  <Chip color="primary" key={keyword.identifier} label={getLanguageString(keyword.labels)} />
+                  <Chip color="primary" key={keyword.type} label={getLanguageString(keyword.label)} />
                 ))}
               </Box>
             )}

--- a/src/types/keywords.types.ts
+++ b/src/types/keywords.types.ts
@@ -7,3 +7,11 @@ export interface Keywords {
     nb?: string;
   };
 }
+
+export interface KeywordsOld {
+  type: string;
+  label: {
+    en?: string;
+    nb?: string;
+  };
+}

--- a/src/types/user.types.ts
+++ b/src/types/user.types.ts
@@ -1,5 +1,5 @@
 import { AggregationValue, LanguageString } from './common.types';
-import { Keywords } from './keywords.types';
+import { Keywords, KeywordsOld } from './keywords.types';
 
 export enum RoleName {
   AppAdmin = 'App-admin',
@@ -150,7 +150,7 @@ export interface FlatCristinPerson {
     no?: string | null;
     en?: string | null;
   };
-  keywords?: Keywords[];
+  keywords?: (Keywords | KeywordsOld)[];
   nvi?: NviVerification;
   contactDetails?: CristinPersonContactDetails;
 }

--- a/src/types/user.types.ts
+++ b/src/types/user.types.ts
@@ -127,7 +127,7 @@ export interface CristinPerson extends CreateCristinPerson {
     no?: string;
     en?: string;
   };
-  keywords?: Keywords[];
+  keywords?: KeywordsOld[];
 }
 
 export interface PersonAggregations {


### PR DESCRIPTION
# Description

Link to Jira issue: N/A

After implementing the new changes to `Keywords`, there was a mismatch between the types used in the registry for keywords and the model of `CristinPerson`. This has been adressed by mapping the values that are returned from `person` to the new type.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
