### PR TITLE
Np 46672 show import candidates channel

### DIFF
--- a/src/pages/basic_data/app_admin/central_import/CentralImportResultItem.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportResultItem.tsx
@@ -30,68 +30,72 @@ export const CentralImportResultItem = ({ importCandidate }: CentralImportResult
 
   return (
     <SearchListItem
-      sx={{ borderLeftColor: 'centralImport.main', display: 'flex', gap: '1rem' }}
+      sx={{
+        borderLeftColor: 'centralImport.main',
+        display: 'flex',
+        flexDirection: 'row',
+        gap: '1rem',
+        justifyContent: 'space-between',
+      }}
       data-testid={dataTestId.startPage.searchResultItem}>
-      <Box sx={{ display: 'flex', gap: '1rem', justifyContent: 'space-between', width: '100%' }}>
-        <div>
-          {heading && (
-            <Typography variant="overline" sx={{ color: 'primary.main' }}>
-              {heading}
+      <div>
+        {heading && (
+          <Typography variant="overline" color="primary">
+            {heading}
+          </Typography>
+        )}
+        <Typography gutterBottom sx={{ fontSize: '1rem', fontWeight: '600', wordWrap: 'break-word' }}>
+          <MuiLink component={Link} to={getImportCandidatePath(getIdentifierFromId(importCandidate.id))}>
+            {getTitleString(importCandidate.mainTitle)}
+          </MuiLink>
+        </Typography>
+
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', columnGap: '0.5rem', flexWrap: 'wrap' }}>
+            {importCandidate.contributors.map((contributor, index) => (
+              <Box
+                key={index}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  '&:not(:last-child)': { '&:after': { content: '";"' } },
+                }}>
+                <Typography variant="body2">
+                  {contributor.identity.id ? (
+                    <MuiLink component={Link} to={getResearchProfilePath(contributor.identity.id)}>
+                      {contributor.identity.name}
+                    </MuiLink>
+                  ) : (
+                    contributor.identity.name
+                  )}
+                </Typography>
+                <ContributorIndicators contributor={contributor} />
+              </Box>
+            ))}
+
+            <Typography>
+              {t('basic_data.central_import.verified_contributor_count', {
+                verifiedContributorCount,
+                contributorsCount,
+              })}
+            </Typography>
+          </Box>
+
+          {importCandidate.organizations.length > 0 && (
+            <Typography>
+              {importCandidate.organizations
+                .map((organization) =>
+                  organization.type === 'Organization' ? getLanguageString(organization.labels) : organization.name
+                )
+                .filter(Boolean)
+                .join(', ')}
             </Typography>
           )}
-          <Typography gutterBottom sx={{ fontSize: '1rem', fontWeight: '600', wordWrap: 'break-word' }}>
-            <MuiLink component={Link} to={getImportCandidatePath(getIdentifierFromId(importCandidate.id))}>
-              {getTitleString(importCandidate.mainTitle)}
-            </MuiLink>
-          </Typography>
 
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', columnGap: '0.5rem', flexWrap: 'wrap' }}>
-              {importCandidate.contributors.map((contributor, index) => (
-                <Box
-                  key={index}
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    '&:not(:last-child)': { '&:after': { content: '";"' } },
-                  }}>
-                  <Typography variant="body2">
-                    {contributor.identity.id ? (
-                      <MuiLink component={Link} to={getResearchProfilePath(contributor.identity.id)}>
-                        {contributor.identity.name}
-                      </MuiLink>
-                    ) : (
-                      contributor.identity.name
-                    )}
-                  </Typography>
-                  <ContributorIndicators contributor={contributor} />
-                </Box>
-              ))}
-
-              <Typography>
-                {t('basic_data.central_import.verified_contributor_count', {
-                  verifiedContributorCount,
-                  contributorsCount,
-                })}
-              </Typography>
-            </Box>
-
-            {importCandidate.organizations.length > 0 && (
-              <Typography>
-                {importCandidate.organizations
-                  .map((organization) =>
-                    organization.type === 'Organization' ? getLanguageString(organization.labels) : organization.name
-                  )
-                  .filter(Boolean)
-                  .join(', ')}
-              </Typography>
-            )}
-
-            <ImportCandidateChannelName importCandidate={importCandidate} />
-          </Box>
-        </div>
-        <Typography sx={{ whiteSpace: 'nowrap' }}>{periodString}</Typography>
-      </Box>
+          <ImportCandidateChannelName importCandidate={importCandidate} />
+        </Box>
+      </div>
+      <Typography sx={{ whiteSpace: 'nowrap' }}>{periodString}</Typography>
     </SearchListItem>
   );
 };

--- a/src/pages/basic_data/app_admin/central_import/CentralImportResultItem.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportResultItem.tsx
@@ -6,9 +6,10 @@ import { SearchListItem } from '../../../../components/styled/Wrappers';
 import { ImportCandidateSummary } from '../../../../types/importCandidate.types';
 import { dataTestId } from '../../../../utils/dataTestIds';
 import { getIdentifierFromId, getTimePeriodString } from '../../../../utils/general-helpers';
-import { getTitleString, isJournal } from '../../../../utils/registration-helpers';
+import { getTitleString } from '../../../../utils/registration-helpers';
 import { getLanguageString } from '../../../../utils/translation-helpers';
 import { getImportCandidatePath, getResearchProfilePath } from '../../../../utils/urlPaths';
+import { ImportCandidateChannelName } from './ImportCandidateChannelName';
 
 interface CentralImportResultItemProps {
   importCandidate: ImportCandidateSummary;
@@ -86,32 +87,11 @@ export const CentralImportResultItem = ({ importCandidate }: CentralImportResult
               </Typography>
             )}
 
-            <ImportCandidateChannelInfo importCandidate={importCandidate} />
+            <ImportCandidateChannelName importCandidate={importCandidate} />
           </Box>
         </div>
         <Typography sx={{ whiteSpace: 'nowrap' }}>{periodString}</Typography>
       </Box>
     </SearchListItem>
   );
-};
-
-export const ImportCandidateChannelInfo = ({ importCandidate }: CentralImportResultItemProps) => {
-  const { t } = useTranslation();
-
-  const shouldHaveJournal = isJournal(importCandidate.publicationInstance?.type);
-
-  if (shouldHaveJournal) {
-    const journal = importCandidate.journal?.name ?? importCandidate.journal?.id;
-    if (journal) {
-      return <Typography fontWeight={600}>{journal}</Typography>;
-    } else {
-      return <Typography>{t('basic_data.central_import.missing_journal')}</Typography>;
-    }
-  }
-
-  const publisher = importCandidate.publisher?.name ?? importCandidate.publisher?.id;
-  if (publisher) {
-    return <Typography fontWeight={600}>{publisher}</Typography>;
-  }
-  return <Typography>{t('basic_data.central_import.missing_publisher')}</Typography>;
 };

--- a/src/pages/basic_data/app_admin/central_import/CentralImportResultItem.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportResultItem.tsx
@@ -32,7 +32,6 @@ export const CentralImportResultItem = ({ importCandidate }: CentralImportResult
     <SearchListItem
       sx={{
         borderLeftColor: 'centralImport.main',
-        display: 'flex',
         flexDirection: 'row',
         gap: '1rem',
         justifyContent: 'space-between',

--- a/src/pages/basic_data/app_admin/central_import/ImportCandidateChannelName.tsx
+++ b/src/pages/basic_data/app_admin/central_import/ImportCandidateChannelName.tsx
@@ -1,0 +1,29 @@
+import { Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { ImportCandidateSummary } from '../../../../types/importCandidate.types';
+import { isJournal } from '../../../../utils/registration-helpers';
+
+interface ImportCandidateChannelNameProps {
+  importCandidate: ImportCandidateSummary;
+}
+
+export const ImportCandidateChannelName = ({ importCandidate }: ImportCandidateChannelNameProps) => {
+  const { t } = useTranslation();
+
+  const shouldHaveJournal = isJournal(importCandidate.publicationInstance?.type);
+
+  if (shouldHaveJournal) {
+    const journal = importCandidate.journal?.name ?? importCandidate.journal?.id;
+    if (journal) {
+      return <Typography fontWeight={600}>{journal}</Typography>;
+    } else {
+      return <Typography>{t('basic_data.central_import.missing_journal')}</Typography>;
+    }
+  }
+
+  const publisher = importCandidate.publisher?.name ?? importCandidate.publisher?.id;
+  if (publisher) {
+    return <Typography fontWeight={600}>{publisher}</Typography>;
+  }
+  return <Typography>{t('basic_data.central_import.missing_publisher')}</Typography>;
+};

--- a/src/pages/basic_data/app_admin/central_import/ImportCandidateChannelName.tsx
+++ b/src/pages/basic_data/app_admin/central_import/ImportCandidateChannelName.tsx
@@ -13,7 +13,7 @@ export const ImportCandidateChannelName = ({ importCandidate }: ImportCandidateC
   const shouldHaveJournal = isJournal(importCandidate.publicationInstance?.type);
 
   if (shouldHaveJournal) {
-    const journal = importCandidate.journal?.name ?? importCandidate.journal?.id;
+    const journal = importCandidate.journal?.name;
     if (journal) {
       return <Typography fontWeight={600}>{journal}</Typography>;
     } else {
@@ -21,7 +21,7 @@ export const ImportCandidateChannelName = ({ importCandidate }: ImportCandidateC
     }
   }
 
-  const publisher = importCandidate.publisher?.name ?? importCandidate.publisher?.id;
+  const publisher = importCandidate.publisher?.name;
   if (publisher) {
     return <Typography fontWeight={600}>{publisher}</Typography>;
   }

--- a/src/pages/basic_data/app_admin/central_import/ImportCandidateChannelName.tsx
+++ b/src/pages/basic_data/app_admin/central_import/ImportCandidateChannelName.tsx
@@ -13,17 +13,15 @@ export const ImportCandidateChannelName = ({ importCandidate }: ImportCandidateC
   const shouldHaveJournal = isJournal(importCandidate.publicationInstance?.type);
 
   if (shouldHaveJournal) {
-    const journal = importCandidate.journal?.name;
-    if (journal) {
-      return <Typography fontWeight={600}>{journal}</Typography>;
+    if (importCandidate.journal?.name) {
+      return <Typography fontWeight={600}>{importCandidate.journal.name}</Typography>;
     } else {
       return <Typography>{t('basic_data.central_import.missing_journal')}</Typography>;
     }
   }
 
-  const publisher = importCandidate.publisher?.name;
-  if (publisher) {
-    return <Typography fontWeight={600}>{publisher}</Typography>;
+  if (importCandidate.publisher?.name) {
+    return <Typography fontWeight={600}>{importCandidate.publisher.name}</Typography>;
   }
   return <Typography>{t('basic_data.central_import.missing_publisher')}</Typography>;
 };

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -75,6 +75,8 @@
         "result_in_nva": "Resultat i NVA",
         "update_value": "Oppdater verdi"
       },
+      "missing_journal": "Mangler tidsskrift",
+      "missing_publisher": "Mangler utgiver",
       "not_applicable": "Mangelfull",
       "or_search_with": "eller søk med",
       "reset_search_values": "Tilbakestill verdier",
@@ -87,9 +89,7 @@
         "NOT_APPLICABLE": "Mangelfull",
         "NOT_IMPORTED": "Til import"
       },
-      "verified_contributor_count": "({{verifiedContributorCount}} av {{contributorsCount}} identifisert)",
-      "missing_publisher": "Mangler utgiver",
-      "missing_journal": "Mangler tidsskrift"
+      "verified_contributor_count": "({{verifiedContributorCount}} av {{contributorsCount}} identifisert)"
     },
     "institutions": {
       "add_institution": "Opprett institusjon",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -87,7 +87,9 @@
         "NOT_APPLICABLE": "Mangelfull",
         "NOT_IMPORTED": "Til import"
       },
-      "verified_contributor_count": "({{verifiedContributorCount}} av {{contributorsCount}} identifisert)"
+      "verified_contributor_count": "({{verifiedContributorCount}} av {{contributorsCount}} identifisert)",
+      "missing_publisher": "Mangler utgiver",
+      "missing_journal": "Mangler tidsskrift"
     },
     "institutions": {
       "add_institution": "Opprett institusjon",

--- a/src/types/importCandidate.types.ts
+++ b/src/types/importCandidate.types.ts
@@ -12,7 +12,7 @@ import { MapPublicationInstance } from './publication_types/otherRegistration.ty
 import { PresentationPublicationInstance } from './publication_types/presentationRegistration.types';
 import { ReportPublicationInstance } from './publication_types/reportRegistration.types';
 import { ResearchDataPublicationInstance } from './publication_types/researchDataRegistration.types';
-import { Journal, Publisher, Registration, RegistrationAggregations } from './registration.types';
+import { Journal, Publisher, Registration, RegistrationAggregations, Series } from './registration.types';
 
 export type ImportCandidateStatus = 'IMPORTED' | 'NOT_IMPORTED' | 'NOT_APPLICABLE';
 
@@ -49,8 +49,9 @@ export interface ImportCandidateSummary {
   totalContributors: number;
   totalVerifiedContributors: number;
   organizations: (Pick<Organization, 'type' | 'id' | 'labels'> | UnconfirmedOrganization)[];
-  publisher: Pick<Publisher, 'id' | 'name'>;
-  journal: Pick<Journal, 'id'>;
+  publisher?: Partial<Publisher>;
+  journal?: Partial<Journal>;
+  series?: Partial<Series>;
   publicationInstance: PublicationInstance;
   contributors: Contributor[];
   printIssn?: string;

--- a/src/types/importCandidate.types.ts
+++ b/src/types/importCandidate.types.ts
@@ -12,7 +12,7 @@ import { MapPublicationInstance } from './publication_types/otherRegistration.ty
 import { PresentationPublicationInstance } from './publication_types/presentationRegistration.types';
 import { ReportPublicationInstance } from './publication_types/reportRegistration.types';
 import { ResearchDataPublicationInstance } from './publication_types/researchDataRegistration.types';
-import { Journal, Publisher, Registration, RegistrationAggregations, Series } from './registration.types';
+import { Journal, Publisher, Registration, RegistrationAggregations } from './registration.types';
 
 export type ImportCandidateStatus = 'IMPORTED' | 'NOT_IMPORTED' | 'NOT_APPLICABLE';
 
@@ -51,7 +51,6 @@ export interface ImportCandidateSummary {
   organizations: (Pick<Organization, 'type' | 'id' | 'labels'> | UnconfirmedOrganization)[];
   publisher?: Partial<Publisher>;
   journal?: Partial<Journal>;
-  series?: Partial<Series>;
   publicationInstance: PublicationInstance;
   contributors: Contributor[];
   printIssn?: string;


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46672

Vis tidsskrift og kanal for hvor en importkandidat er publisert. Avhenger av en oppdatering i backend for at alle kanaler skal ha navn, men har foreløpig lagt inn `id` som en fallback, så vi ser at det virker. Skal automatisk bli rett når APIet returnerer riktig data.
EDIT: Dette førte til problemer med mobilvisning igjen, så jeg dropper det istedet, og viser `Tidsskrift/Utgiver mangler` når APIet ikke oppgir noe navn. Da vil mange av kandidatene si at de mangler kanal inntil dette løses i backend, men tenker det er bedre.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
