### PR TITLE
Np 46739 use norwegian date formats

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ import { RootState } from './redux/store';
 import { setUser } from './redux/userSlice';
 import { authOptions } from './utils/aws-config';
 import { USE_MOCK_DATA } from './utils/constants';
-import { getDateFnsLocale } from './utils/date-helpers';
+import { getDateFnsLocale, getDatePickerLocaleText } from './utils/date-helpers';
 import { mockUser } from './utils/testfiles/mock_feide_user';
 import { UrlPathTemplate } from './utils/urlPaths';
 
@@ -107,7 +107,11 @@ export const App = () => {
                 mb: '0.5rem',
               }}>
               <ErrorBoundary>
-                <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={getDateFnsLocale(i18n.language)}>
+                <LocalizationProvider
+                  dateAdapter={AdapterDateFns}
+                  adapterLocale={getDateFnsLocale(i18n.language)}
+                  dateFormats={{ keyboardDate: 'dd.MM.yyyy' }}
+                  localeText={getDatePickerLocaleText(i18n.language)}>
                   <AppRoutes />
                 </LocalizationProvider>
               </ErrorBoundary>

--- a/src/pages/basic_data/app_admin/InstitutionList.tsx
+++ b/src/pages/basic_data/app_admin/InstitutionList.tsx
@@ -16,6 +16,7 @@ import { Link as RouterLink } from 'react-router-dom';
 import { alternatingTableRowColor } from '../../../themes/mainTheme';
 import { SimpleCustomerInstitution } from '../../../types/customerInstitution.types';
 import { dataTestId } from '../../../utils/dataTestIds';
+import { toDateString } from '../../../utils/date-helpers';
 import { getAdminInstitutionPath } from '../../../utils/urlPaths';
 
 interface InstitutionListProps {
@@ -47,7 +48,7 @@ export const InstitutionList = ({ institutions }: InstitutionListProps) => {
                 <Typography>{institution.doiPrefix}</Typography>
               </TableCell>
               <TableCell>
-                <Typography>{new Date(institution.createdDate).toLocaleDateString()}</Typography>
+                <Typography>{toDateString(institution.createdDate)}</Typography>
               </TableCell>
               <TableCell>
                 <Button

--- a/src/pages/basic_data/app_admin/NviPeriodsPage.tsx
+++ b/src/pages/basic_data/app_admin/NviPeriodsPage.tsx
@@ -7,6 +7,7 @@ import { ErrorBoundary } from '../../../components/ErrorBoundary';
 import { ListSkeleton } from '../../../components/ListSkeleton';
 import { SearchListItem } from '../../../components/styled/Wrappers';
 import { NviPeriod } from '../../../types/nvi.types';
+import { toDateString } from '../../../utils/date-helpers';
 import { UpsertNviPeriodDialog } from './UpsertNviPeriodDialog';
 
 export const NviPeriodsPage = () => {
@@ -32,14 +33,10 @@ export const NviPeriodsPage = () => {
         <List disablePadding>
           {sortedPeriods.map((nviPeriod) => {
             const startDateString = nviPeriod.startDate
-              ? `${new Date(nviPeriod.startDate).toLocaleDateString()} (${new Date(
-                  nviPeriod.startDate
-                ).toLocaleTimeString()})`
+              ? `${toDateString(nviPeriod.startDate)} (${new Date(nviPeriod.startDate).toLocaleTimeString()})`
               : '?';
             const endDateString = nviPeriod.reportingDate
-              ? `${new Date(nviPeriod.reportingDate).toLocaleDateString()} (${new Date(
-                  nviPeriod.reportingDate
-                ).toLocaleTimeString()})`
+              ? `${toDateString(nviPeriod.reportingDate)} (${new Date(nviPeriod.reportingDate).toLocaleTimeString()})`
               : '?';
 
             return (

--- a/src/pages/basic_data/fields/StartDateField.tsx
+++ b/src/pages/basic_data/fields/StartDateField.tsx
@@ -23,7 +23,6 @@ export const StartDateField = ({ fieldName, maxDate, disabled = false, dataTestI
             !touched && setFieldTouched(field.name, true, false);
             setFieldValue(field.name, date ?? '');
           }}
-          format="dd.MM.yyyy"
           views={['year', 'month', 'day']}
           maxDate={maxDate}
           slotProps={{

--- a/src/pages/basic_data/institution_admin/AddAffiliationSection.tsx
+++ b/src/pages/basic_data/institution_admin/AddAffiliationSection.tsx
@@ -100,7 +100,6 @@ export const AddAffiliationSection = () => {
                   !touched && setFieldTouched(field.name, true, false);
                   setFieldValue(field.name, date ?? '');
                 }}
-                format="dd.MM.yyyy"
                 views={['year', 'month', 'day']}
                 minDate={values.affiliation.startDate ? new Date(values.affiliation.startDate) : undefined}
                 slotProps={{

--- a/src/pages/basic_data/institution_admin/edit_user/AffiliationFormSection.tsx
+++ b/src/pages/basic_data/institution_admin/edit_user/AffiliationFormSection.tsx
@@ -94,7 +94,6 @@ export const AffiliationFormSection = () => {
                   label={t('common.end_date')}
                   value={field.value ? new Date(field.value) : null}
                   onChange={(date: any) => setFieldValue(field.name, date ?? '')}
-                  format="dd.MM.yyyy"
                   views={['year', 'month', 'day']}
                   minDate={
                     employments[employmentIndex].startDate

--- a/src/pages/messages/components/DoiRequestMessagesColumn.tsx
+++ b/src/pages/messages/components/DoiRequestMessagesColumn.tsx
@@ -1,6 +1,7 @@
 import { Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { ExpandedTicket, Ticket } from '../../../types/publication_types/ticket.types';
+import { toDateString } from '../../../utils/date-helpers';
 import { StyledMessagesContainer, StyledStatusMessageBox } from './PublishingRequestMessagesColumn';
 
 interface DoiRequestMessagesColumnProps {
@@ -23,7 +24,7 @@ export const DoiRequestMessagesColumn = ({ ticket }: DoiRequestMessagesColumnPro
           ) : ticket.status === 'Closed' ? (
             <Typography>{t('my_page.messages.doi_closed')}</Typography>
           ) : null}
-          {ticket.modifiedDate && <Typography>{new Date(ticket.modifiedDate).toLocaleDateString()}</Typography>}
+          {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}
         </StyledStatusMessageBox>
       )}
     </StyledMessagesContainer>

--- a/src/pages/messages/components/MessageList.tsx
+++ b/src/pages/messages/components/MessageList.tsx
@@ -7,6 +7,7 @@ import { ConfirmDialog } from '../../../components/ConfirmDialog';
 import { ErrorBoundary } from '../../../components/ErrorBoundary';
 import { Ticket } from '../../../types/publication_types/ticket.types';
 import { dataTestId } from '../../../utils/dataTestIds';
+import { toDateString } from '../../../utils/date-helpers';
 import { getFullName } from '../../../utils/user-helpers';
 import { ticketColor } from './TicketListItem';
 
@@ -87,9 +88,7 @@ export const MessageItem = ({ text, date, username, backgroundColor, onDelete, i
             </b>
           )}
         </span>
-        <span data-testid={dataTestId.registrationLandingPage.tasksPanel.messageTimestamp}>
-          {new Date(date).toLocaleDateString()}
-        </span>
+        <span data-testid={dataTestId.registrationLandingPage.tasksPanel.messageTimestamp}>{toDateString(date)}</span>
       </Typography>
 
       <Divider sx={{ mb: '0.5rem', bgcolor: 'primary.main' }} />

--- a/src/pages/messages/components/PublishingRequestMessagesColumn.tsx
+++ b/src/pages/messages/components/PublishingRequestMessagesColumn.tsx
@@ -1,6 +1,7 @@
 import { Box, styled, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { ExpandedPublishingTicket, PublishingTicket } from '../../../types/publication_types/ticket.types';
+import { toDateString } from '../../../utils/date-helpers';
 
 export const StyledMessagesContainer = styled(Box)({
   display: 'flex',
@@ -44,7 +45,7 @@ export const PublishingRequestMessagesColumn = ({ ticket }: PublishingRequestMes
           ) : (
             ticket.status === 'Closed' && <Typography>{t('my_page.messages.files_rejected')}</Typography>
           )}
-          {ticket.modifiedDate && <Typography>{new Date(ticket.modifiedDate).toLocaleDateString()}</Typography>}
+          {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}
         </StyledStatusMessageBox>
       )}
     </StyledMessagesContainer>

--- a/src/pages/messages/components/SupportMessagesColumn.tsx
+++ b/src/pages/messages/components/SupportMessagesColumn.tsx
@@ -2,6 +2,7 @@ import { Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { TruncatableTypography } from '../../../components/TruncatableTypography';
 import { ExpandedTicket } from '../../../types/publication_types/ticket.types';
+import { toDateString } from '../../../utils/date-helpers';
 import { StyledMessagesContainer, StyledStatusMessageBox } from './PublishingRequestMessagesColumn';
 
 interface SupportMessagesColumnProps {
@@ -37,7 +38,7 @@ export const SupportMessagesColumn = ({ ticket }: SupportMessagesColumnProps) =>
         lastMessage && (
           <StyledStatusMessageBox sx={{ bgcolor: 'generalSupportCase.main' }}>
             <Typography>{lastSender}</Typography>
-            <Typography>{new Date(lastMessage.createdDate).toLocaleDateString()}</Typography>
+            <Typography>{toDateString(lastMessage.createdDate)}</Typography>
             <TruncatableTypography lines={5} sx={{ gridColumn: '1/3' }}>
               {lastMessage.text}
             </TruncatableTypography>

--- a/src/pages/messages/components/TicketDateIntervalFilter.tsx
+++ b/src/pages/messages/components/TicketDateIntervalFilter.tsx
@@ -7,7 +7,6 @@ import { dataTestId } from '../../../utils/dataTestIds';
 import { formatDateStringToISO } from '../../../utils/date-helpers';
 
 const commonDatepickerProps: Partial<DatePickerProps<Date>> = {
-  format: 'dd.MM.yyyy',
   views: ['year', 'month', 'day'],
   disableHighlightToday: true,
   slotProps: {

--- a/src/pages/projects/form/ProjectFormPanel1.tsx
+++ b/src/pages/projects/form/ProjectFormPanel1.tsx
@@ -87,7 +87,6 @@ export const ProjectFormPanel1 = ({ currentProject, suggestedProjectManager }: P
                 }}
                 value={field.value ? new Date(field.value) : null}
                 maxDate={values.endDate ? new Date(values.endDate) : undefined}
-                format="dd.MM.yyyy"
                 slotProps={{
                   textField: {
                     inputProps: { 'data-testid': dataTestId.registrationWizard.description.projectForm.startDateField },
@@ -113,7 +112,6 @@ export const ProjectFormPanel1 = ({ currentProject, suggestedProjectManager }: P
                 }}
                 value={field.value ? new Date(field.value) : null}
                 minDate={values.startDate ? new Date(values.startDate) : undefined}
-                format="dd.MM.yyyy"
                 slotProps={{
                   textField: {
                     inputProps: { 'data-testid': dataTestId.registrationWizard.description.projectForm.endDateField },

--- a/src/pages/public_registration/LogPanel.tsx
+++ b/src/pages/public_registration/LogPanel.tsx
@@ -6,6 +6,7 @@ import { fetchUser } from '../../api/roleApi';
 import { AssociatedFile } from '../../types/associatedArtifact.types';
 import { PublishingTicket, Ticket, TicketType } from '../../types/publication_types/ticket.types';
 import { Registration } from '../../types/registration.types';
+import { toDateString } from '../../utils/date-helpers';
 import { getAssociatedFiles } from '../../utils/registration-helpers';
 import { getFullName } from '../../utils/user-helpers';
 import { StyledStatusMessageBox } from '../messages/components/PublishingRequestMessagesColumn';
@@ -130,7 +131,7 @@ export const LogPanel = ({ tickets, registration }: LogPanelProps) => {
         <StyledStatusMessageBox sx={{ bgcolor: 'publishingRequest.main' }}>
           <Typography>{t('common.created')}</Typography>
           <Tooltip title={new Date(registration.createdDate).toLocaleTimeString()} enterDelay={tooltipDelay}>
-            <Typography>{new Date(registration.createdDate).toLocaleDateString()}</Typography>
+            <Typography>{toDateString(registration.createdDate)}</Typography>
           </Tooltip>
           {organizationQuery.isPending || userQuery.isPending ? (
             <Skeleton sx={{ width: '4rem' }} />
@@ -150,7 +151,7 @@ export const LogPanel = ({ tickets, registration }: LogPanelProps) => {
             <StyledStatusMessageBox key={index} sx={{ bgcolor: ticketColor[logItem.type] }}>
               <Typography>{logItem.description}</Typography>
               <Tooltip title={modifiedDate.toLocaleTimeString()} enterDelay={tooltipDelay}>
-                <Typography>{modifiedDate.toLocaleDateString()}</Typography>
+                <Typography>{toDateString(modifiedDate)}</Typography>
               </Tooltip>
               {logItem.filesInfo?.approvedFileNames && logItem.filesInfo.approvedFileNames.length > 0 && (
                 <Box

--- a/src/pages/public_registration/PublicPublicationContext.tsx
+++ b/src/pages/public_registration/PublicPublicationContext.tsx
@@ -63,6 +63,7 @@ import {
 import { PresentationPublicationContext } from '../../types/publication_types/presentationRegistration.types';
 import { ReportPublicationContext } from '../../types/publication_types/reportRegistration.types';
 import { ContextPublisher, Journal, Publisher, Series } from '../../types/registration.types';
+import { toDateString } from '../../utils/date-helpers';
 import { getIdentifierFromId, getPeriodString } from '../../utils/general-helpers';
 import { useFetchResource } from '../../utils/hooks/useFetchResource';
 import { getOutputName, hyphenateIsrc } from '../../utils/registration-helpers';
@@ -445,9 +446,7 @@ const PublicExhibitionMentionInPublicationDialogContent = ({
         {t('common.date')}
       </Typography>
       <Typography paragraph>
-        {exhibitionMentionInPublication.date?.value
-          ? new Date(exhibitionMentionInPublication.date.value).toLocaleDateString()
-          : '-'}
+        {exhibitionMentionInPublication.date?.value ? toDateString(exhibitionMentionInPublication.date.value) : '-'}
       </Typography>
       <Typography variant="h3" gutterBottom>
         {t('registration.resource_type.other_publisher_isbn_etc')}
@@ -496,9 +495,7 @@ const PublicExhibitionOtherPresentationDialogContent = ({
         {t('common.date')}
       </Typography>
       <Typography paragraph>
-        {exhibitionOtherPresentation.date?.value
-          ? new Date(exhibitionOtherPresentation.date.value).toLocaleDateString()
-          : '-'}
+        {exhibitionOtherPresentation.date?.value ? toDateString(exhibitionOtherPresentation.date.value) : '-'}
       </Typography>
     </DialogContent>
   );
@@ -525,7 +522,7 @@ const PublicCompetitionDialogContent = ({ competition }: { competition: Competit
       <Typography variant="h3">{t('registration.resource_type.artistic.competition_rank')}</Typography>
       <Typography paragraph>{competition.description}</Typography>
       <Typography variant="h3">{t('common.date')}</Typography>
-      <Typography>{new Date(competition.date.value).toLocaleDateString()}</Typography>
+      <Typography>{toDateString(competition.date.value)}</Typography>
     </DialogContent>
   );
 };
@@ -557,7 +554,7 @@ const PublicMentionDialogContent = ({ mention }: { mention: MentionInPublication
       <Typography variant="h3">{t('registration.resource_type.issue')}</Typography>
       <Typography paragraph>{mention.issue}</Typography>
       <Typography variant="h3">{t('common.date')}</Typography>
-      <Typography>{new Date(mention.date.value).toLocaleDateString()}</Typography>
+      <Typography>{toDateString(mention.date.value)}</Typography>
       <Typography variant="h3">{t('registration.resource_type.other_publisher_isbn_etc')}</Typography>
       <Typography paragraph>{mention.otherInformation}</Typography>
     </DialogContent>
@@ -589,7 +586,7 @@ const PublicBroadcastDialogContent = ({ broadcast }: { broadcast: Broadcast }) =
       <Typography variant="h3">{t('common.publisher')}</Typography>
       <Typography paragraph>{broadcast.publisher.name}</Typography>
       <Typography variant="h3">{t('common.date')}</Typography>
-      <Typography>{new Date(broadcast.date.value).toLocaleDateString()}</Typography>
+      <Typography>{toDateString(broadcast.date.value)}</Typography>
     </DialogContent>
   );
 };
@@ -603,7 +600,7 @@ const PublicCinematicReleaseDialogContent = ({ cinematicRelease }: { cinematicRe
       <Typography variant="h3">{t('common.place')}</Typography>
       <Typography paragraph>{cinematicRelease.place.label}</Typography>
       <Typography variant="h3">{t('registration.resource_type.artistic.premiere_date')}</Typography>
-      <Typography>{new Date(cinematicRelease.date.value).toLocaleDateString()}</Typography>
+      <Typography>{toDateString(cinematicRelease.date.value)}</Typography>
     </DialogContent>
   );
 };
@@ -625,7 +622,7 @@ const PublicOtherReleaseDialogContent = ({ otherRelease }: { otherRelease: Other
         </>
       )}
       <Typography variant="h3">{t('registration.resource_type.artistic.premiere_date')}</Typography>
-      <Typography>{new Date(otherRelease.date.value).toLocaleDateString()}</Typography>
+      <Typography>{toDateString(otherRelease.date.value)}</Typography>
     </DialogContent>
   );
 };
@@ -732,7 +729,7 @@ const PublicConcertDialogContent = ({ concert }: { concert: Concert }) => {
 
       <Typography variant="h3">{t('common.date')}</Typography>
       {time.type === 'Instant' ? (
-        <Typography paragraph>{new Date(time.value).toLocaleDateString()}</Typography>
+        <Typography paragraph>{toDateString(time.value)}</Typography>
       ) : (
         <Typography paragraph>{getPeriodString(time.from, time.to)}</Typography>
       )}
@@ -881,11 +878,13 @@ const PublicLiteraryArtsPerformanceDialogContent = ({ performance }: { performan
       <Typography paragraph>{performance.place.label}</Typography>
       <Typography variant="h3">{t('common.date')}</Typography>
       <Typography paragraph>
-        {new Date(
-          +performance.publicationDate.year,
-          +performance.publicationDate.month,
-          +performance.publicationDate.day
-        ).toLocaleDateString()}
+        {toDateString(
+          new Date(
+            +performance.publicationDate.year,
+            +performance.publicationDate.month,
+            +performance.publicationDate.day
+          )
+        )}
       </Typography>
     </DialogContent>
   );

--- a/src/pages/public_registration/action_accordions/CompletedPublishingRequestStatusBox.tsx
+++ b/src/pages/public_registration/action_accordions/CompletedPublishingRequestStatusBox.tsx
@@ -1,6 +1,7 @@
 import { Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { PublishingTicket } from '../../../types/publication_types/ticket.types';
+import { toDateString } from '../../../utils/date-helpers';
 import { StyledStatusMessageBox } from '../../messages/components/PublishingRequestMessagesColumn';
 
 interface CompletedPublishingRequestStatusBoxProps {
@@ -17,7 +18,7 @@ export const CompletedPublishingRequestStatusBox = ({ ticket }: CompletedPublish
   return (
     <StyledStatusMessageBox sx={{ bgcolor: 'publishingRequest.main' }}>
       <Typography>{t('my_page.messages.files_published', { count: ticket.approvedFiles.length })}</Typography>
-      <Typography>{new Date(ticket.modifiedDate).toLocaleDateString()}</Typography>
+      <Typography>{toDateString(ticket.modifiedDate)}</Typography>
     </StyledStatusMessageBox>
   );
 };

--- a/src/pages/public_registration/action_accordions/DeletedRegistrationInformation.tsx
+++ b/src/pages/public_registration/action_accordions/DeletedRegistrationInformation.tsx
@@ -5,6 +5,7 @@ import { fetchRegistration } from '../../../api/registrationApi';
 import { fetchUser } from '../../../api/roleApi';
 import { ProfilePicture } from '../../../components/ProfilePicture';
 import { PublicationNote, Registration } from '../../../types/registration.types';
+import { toDateString } from '../../../utils/date-helpers';
 import { getIdentifierFromId } from '../../../utils/general-helpers';
 import { getFullName } from '../../../utils/user-helpers';
 import { StyledStatusMessageBox } from '../../messages/components/PublishingRequestMessagesColumn';
@@ -48,9 +49,7 @@ export const DeletedRegistrationInformation = ({
       }}>
       <Typography>{t(`registration.status.${registration.status}`)}</Typography>
       <Box sx={{ display: 'flex', minWidth: '6rem', gap: '0.5rem', alignItems: 'center' }}>
-        {unpublishingNote.createdDate && (
-          <Typography>{new Date(unpublishingNote.createdDate).toLocaleDateString()}</Typography>
-        )}
+        {unpublishingNote.createdDate && <Typography>{toDateString(unpublishingNote.createdDate)}</Typography>}
         {senderQuery.isFetching ? (
           <Skeleton variant="circular" sx={{ width: '1.5rem', height: '1.5rem' }} />
         ) : (

--- a/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
@@ -20,7 +20,7 @@ import { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link as RouterLink } from 'react-router-dom';
-import { createTicket, updateTicket, UpdateTicketData } from '../../../api/registrationApi';
+import { UpdateTicketData, createTicket, updateTicket } from '../../../api/registrationApi';
 import { MessageForm } from '../../../components/MessageForm';
 import { setNotification } from '../../../redux/notificationSlice';
 import { RootState } from '../../../redux/store';
@@ -28,9 +28,10 @@ import { PublishingTicket } from '../../../types/publication_types/ticket.types'
 import { Registration, RegistrationStatus } from '../../../types/registration.types';
 import { isErrorStatus, isSuccessStatus } from '../../../utils/constants';
 import { dataTestId } from '../../../utils/dataTestIds';
+import { toDateString } from '../../../utils/date-helpers';
 import { getFirstErrorTab, getTabErrors, validateRegistrationForm } from '../../../utils/formik-helpers';
 import { userCanPublishRegistration } from '../../../utils/registration-helpers';
-import { getRegistrationWizardPath, UrlPathTemplate } from '../../../utils/urlPaths';
+import { UrlPathTemplate, getRegistrationWizardPath } from '../../../utils/urlPaths';
 import { TicketMessageList } from '../../messages/components/MessageList';
 import { StyledStatusMessageBox } from '../../messages/components/PublishingRequestMessagesColumn';
 import { ErrorList } from '../../registration/ErrorList';
@@ -226,9 +227,7 @@ export const PublishingAccordion = ({
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', mb: '0.5rem' }}>
             <StyledStatusMessageBox sx={{ bgcolor: 'publishingRequest.main' }}>
               <Typography>{t('registration.status.PUBLISHED_METADATA')}</Typography>
-              {registration.publishedDate && (
-                <Typography>{new Date(registration.publishedDate).toLocaleDateString()}</Typography>
-              )}
+              {registration.publishedDate && <Typography>{toDateString(registration.publishedDate)}</Typography>}
             </StyledStatusMessageBox>
             {completedTickets.map((ticket) => (
               <CompletedPublishingRequestStatusBox key={ticket.id} ticket={ticket} />

--- a/src/pages/public_registration/public_files/FileRow.tsx
+++ b/src/pages/public_registration/public_files/FileRow.tsx
@@ -21,6 +21,7 @@ import { RootState } from '../../../redux/store';
 import { AssociatedFile, FileVersion } from '../../../types/associatedArtifact.types';
 import { licenses } from '../../../types/license.types';
 import { dataTestId } from '../../../utils/dataTestIds';
+import { toDateString } from '../../../utils/date-helpers';
 import { equalUris } from '../../../utils/general-helpers';
 import { isEmbargoed, openFileInNewTab } from '../../../utils/registration-helpers';
 import { PreviewFile } from './preview_file/PreviewFile';
@@ -129,7 +130,7 @@ export const FileRow = ({
         {file.embargoDate && fileIsEmbargoed ? (
           <Typography data-testid={dataTestId.registrationLandingPage.fileEmbargoDate}>
             <LockIcon />
-            {t('common.will_be_available')} {new Date(file.embargoDate).toLocaleDateString()}
+            {t('common.will_be_available')} {toDateString(file.embargoDate)}
           </Typography>
         ) : (
           <Button

--- a/src/pages/registration/description_tab/DatePickerField.tsx
+++ b/src/pages/registration/description_tab/DatePickerField.tsx
@@ -63,7 +63,6 @@ export const DatePickerField = () => {
           updateDateValues(newDate, yearOnly);
           setDate(newDate);
         }}
-        format={yearOnly ? 'yyyy' : 'dd.MM.yyyy'}
         views={yearOnly ? ['year'] : ['year', 'month', 'day']}
         maxDate={new Date(new Date().getFullYear() + 5, 11, 31)}
         slotProps={{

--- a/src/pages/registration/description_tab/projects_field/projectHelpers.ts
+++ b/src/pages/registration/description_tab/projects_field/projectHelpers.ts
@@ -1,5 +1,6 @@
 import { CristinProject, ProjectContributor, ProjectContributorIdentity } from '../../../../types/project.types';
 import { CristinPerson, User } from '../../../../types/user.types';
+import { toDateString } from '../../../../utils/date-helpers';
 import { getLanguageString } from '../../../../utils/translation-helpers';
 
 export const getProjectCoordinatingInstitutionName = (project?: CristinProject) =>
@@ -20,8 +21,8 @@ export const getProjectPeriod = (project?: CristinProject) => {
   const startDate = new Date(project.startDate);
   const endDate = project.endDate && new Date(project.endDate);
   const dateInterval = [
-    startDate.toLocaleDateString(),
-    endDate && !isNaN(endDate.valueOf()) ? endDate.toLocaleDateString() : '?',
+    toDateString(startDate),
+    endDate && !isNaN(endDate.valueOf()) ? toDateString(endDate) : '?',
   ].join(' - ');
 
   return dateInterval;

--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -411,7 +411,6 @@ export const FilesTableRow = ({ file, removeFile, baseFieldName, showFileVersion
                       label={t('registration.files_and_license.embargo')}
                       value={field.value ? new Date(field.value) : null}
                       onChange={(date) => setFieldValue(field.name, date ?? '')}
-                      format="dd.MM.yyyy"
                       maxDate={new Date(new Date().getFullYear() + 5, 11, 31)}
                       disabled={file.administrativeAgreement || disabled}
                       sx={{ minWidth: '15rem' }}

--- a/src/pages/registration/resource_type_tab/components/PeriodFields.tsx
+++ b/src/pages/registration/resource_type_tab/components/PeriodFields.tsx
@@ -27,7 +27,6 @@ export const PeriodFields = ({ fromFieldName, toFieldName }: PeriodFieldsProps) 
               !touched && setFieldTouched(field.name, true, false);
               setFieldValue(field.name, date ?? '');
             }}
-            format="dd.MM.yyyy"
             views={['year', 'month', 'day']}
             maxDate={toValue ? new Date(toValue) : maxDate}
             slotProps={{
@@ -52,7 +51,6 @@ export const PeriodFields = ({ fromFieldName, toFieldName }: PeriodFieldsProps) 
               !touched && setFieldTouched(field.name, true, false);
               setFieldValue(field.name, date ?? '');
             }}
-            format="dd.MM.yyyy"
             views={['year', 'month', 'day']}
             minDate={fromValue ? new Date(fromValue) : undefined}
             maxDate={maxDate}

--- a/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/architecture/AwardModal.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/architecture/AwardModal.tsx
@@ -110,7 +110,6 @@ export const AwardModal = ({ award, onSubmit, open, closeModal }: AwardModalProp
                       !touched && setFieldTouched(field.name, true, false);
                       setFieldValue(field.name, date ?? '');
                     }}
-                    format="yyyy"
                     views={['year']}
                     slotProps={{
                       textField: {

--- a/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/architecture/CompetitionModal.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/architecture/CompetitionModal.tsx
@@ -120,7 +120,6 @@ export const CompetitionModal = ({ competition, onSubmit, open, closeModal }: Co
                       !touched && setFieldTouched(field.name, true, false);
                       setFieldValue(field.name, date ?? '');
                     }}
-                    format="dd.MM.yyyy"
                     views={['year', 'month', 'day']}
                     slotProps={{
                       textField: {

--- a/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/architecture/PublicationMentionModal.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/architecture/PublicationMentionModal.tsx
@@ -115,7 +115,6 @@ export const PublicationMentionModal = ({
                         !touched && setFieldTouched(field.name, true, false);
                         setFieldValue(field.name, date ?? '');
                       }}
-                      format="dd.MM.yyyy"
                       views={['year', 'month', 'day']}
                       slotProps={{
                         textField: {

--- a/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/literary_art/LiteraryArtsPerformanceModal.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/literary_art/LiteraryArtsPerformanceModal.tsx
@@ -159,7 +159,6 @@ export const LiteraryArtsPerformanceModal = ({
                         setFieldValue('publicationDate', emptyRegistrationDate);
                       }
                     }}
-                    format="dd.MM.yyyy"
                     views={['year', 'month', 'day']}
                     slotProps={{
                       textField: {

--- a/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/moving_picture/BroadcastModal.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/moving_picture/BroadcastModal.tsx
@@ -97,7 +97,6 @@ export const BroadcastModal = ({ broadcast, onSubmit, open, closeModal }: Broadc
                       !touched && setFieldTouched(field.name, true, false);
                       setFieldValue(field.name, date ?? '');
                     }}
-                    format="dd.MM.yyyy"
                     slotProps={{
                       textField: {
                         inputProps: {

--- a/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/moving_picture/CinematicReleaseModal.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/moving_picture/CinematicReleaseModal.tsx
@@ -87,7 +87,6 @@ export const CinematicReleaseModal = ({ cinematicRelease, onSubmit, open, closeM
                       !touched && setFieldTouched(field.name, true, false);
                       setFieldValue(field.name, date);
                     }}
-                    format="dd.MM.yyyy"
                     slotProps={{
                       textField: {
                         inputProps: {

--- a/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/moving_picture/OtherReleaseModal.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/moving_picture/OtherReleaseModal.tsx
@@ -133,7 +133,6 @@ export const OtherReleaseModal = ({ otherRelease, onSubmit, open, closeModal }: 
                       !touched && setFieldTouched(field.name, true, false);
                       setFieldValue(field.name, date ?? '');
                     }}
-                    format="dd.MM.yyyy"
                     slotProps={{
                       textField: {
                         inputProps: {

--- a/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/music_performance/ConcertModal.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/music_performance/ConcertModal.tsx
@@ -233,7 +233,6 @@ export const ConcertModal = ({ concert, onSubmit, open, closeModal }: ConcertMod
                         !touched && setFieldTouched(field.name, true, false);
                         setFieldValue(field.name, date ?? '');
                       }}
-                      format="dd.MM.yyyy"
                       slotProps={{
                         textField: {
                           inputProps: {

--- a/src/pages/registration/resource_type_tab/sub_type_forms/exhibition_types/ExhibitionMentionInPublication.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/exhibition_types/ExhibitionMentionInPublication.tsx
@@ -108,7 +108,6 @@ export const ExhibitionMentionInPublicationModal = ({
                         !touched && setFieldTouched(field.name, true, false);
                         setFieldValue(field.name, date);
                       }}
-                      format="dd.MM.yyyy"
                       slotProps={{
                         textField: {
                           inputProps: {

--- a/src/pages/registration/resource_type_tab/sub_type_forms/exhibition_types/ExhibitionOtherPresentationModal.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/exhibition_types/ExhibitionOtherPresentationModal.tsx
@@ -146,7 +146,6 @@ export const ExhibitionOtherPresentationModal = ({
                       !touched && setFieldTouched(field.name, true, false);
                       setFieldValue(field.name, date);
                     }}
-                    format="dd.MM.yyyy"
                     slotProps={{
                       textField: {
                         inputProps: {

--- a/src/themes/mainTheme.ts
+++ b/src/themes/mainTheme.ts
@@ -1,6 +1,5 @@
 import { PaletteColorOptions, SxProps, createTheme } from '@mui/material';
 import { enUS as coreEnUs, nbNO as coreNbNo, nnNO as coreNnNo } from '@mui/material/locale';
-import { enUS as pickersEnUs, nbNO as pickersNbNo } from '@mui/x-date-pickers/locales';
 import i18n from '../translations/i18n';
 
 // Colors: https://www.figma.com/file/3hggk6SX2ca81U8kwaZKFs/Farger-NVA
@@ -32,7 +31,6 @@ enum Color {
 }
 
 const coreLocale = i18n.language === 'eng' ? coreEnUs : i18n.language === 'nno' ? coreNnNo : coreNbNo;
-const pickersLocale = i18n.language === 'eng' ? pickersEnUs : pickersNbNo;
 
 declare module '@mui/material/styles' {
   interface Palette {
@@ -332,7 +330,6 @@ export const mainTheme = createTheme(
       },
     },
   },
-  pickersLocale,
   coreLocale
 );
 

--- a/src/utils/date-helpers.ts
+++ b/src/utils/date-helpers.ts
@@ -3,7 +3,7 @@ import { RegistrationDate } from '../types/registration.types';
 
 export const displayDate = (date: Omit<RegistrationDate, 'type'> | undefined) => {
   if (date?.month && date?.day) {
-    return new Date(+date.year, +date.month - 1, +date.day).toLocaleDateString();
+    return toDateString(new Date(+date.year, +date.month - 1, +date.day));
   } else if (date?.year) {
     return date.year;
   } else {
@@ -20,4 +20,14 @@ export const getDateFnsLocale = (language: string) => {
 
 export const formatDateStringToISO = (date: Date) => {
   return `${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')}`;
+};
+
+export const toDateString = (date: Date | string | number) => {
+  if (!date) {
+    return '';
+  }
+
+  const dateObject = date instanceof Date ? date : new Date(date);
+
+  return dateObject.toLocaleDateString('nb-NO', { year: 'numeric', month: '2-digit', day: '2-digit' });
 };

--- a/src/utils/date-helpers.ts
+++ b/src/utils/date-helpers.ts
@@ -1,4 +1,5 @@
-import { enUS as englishLocale, nb as norwegianLocale } from 'date-fns/locale';
+import { enUS as englishPickerLocale, nbNO as norwegianPickerLocale } from '@mui/x-date-pickers/locales';
+import { enGB as englishDateLocale, nb as norwegianDateLocale } from 'date-fns/locale';
 import { RegistrationDate } from '../types/registration.types';
 
 export const displayDate = (date: Omit<RegistrationDate, 'type'> | undefined) => {
@@ -13,9 +14,16 @@ export const displayDate = (date: Omit<RegistrationDate, 'type'> | undefined) =>
 
 export const getDateFnsLocale = (language: string) => {
   if (language === 'nob' || language === 'nno') {
-    return norwegianLocale;
+    return norwegianDateLocale;
   }
-  return englishLocale;
+  return englishDateLocale;
+};
+
+export const getDatePickerLocaleText = (language: string) => {
+  if (language === 'nob' || language === 'nno') {
+    return norwegianPickerLocale.components.MuiLocalizationProvider.defaultProps.localeText;
+  }
+  return englishPickerLocale.components.MuiLocalizationProvider.defaultProps.localeText;
 };
 
 export const formatDateStringToISO = (date: Date) => {

--- a/src/utils/general-helpers.ts
+++ b/src/utils/general-helpers.ts
@@ -1,16 +1,17 @@
 import { TFunction } from 'i18next';
 import * as Yup from 'yup';
+import { toDateString } from './date-helpers';
 
 export const isValidUrl = (value: string) => Yup.string().url().isValidSync(value);
 
 export const getPeriodString = (from: string | undefined, to: string | undefined) => {
-  const fromDate = from ? new Date(from).toLocaleDateString() : '';
-  const toDate = to ? new Date(to).toLocaleDateString() : '';
+  const fromDate = from ? toDateString(from) : '';
+  const toDate = to ? toDateString(to) : '';
 
   if (!fromDate && !toDate) {
     return '';
   } else {
-    return fromDate === toDate ? fromDate : `${fromDate ?? '?'} - ${toDate ?? '?'}`;
+    return fromDate === toDate ? fromDate : `${fromDate || '?'} - ${toDate || '?'}`;
   }
 };
 


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46739

Sikre at alle datoer vises på samme format (`DD.MM.YYYY`). VI må nå bruke den nye `toDateString()` i stedet for `Date.toLocaleDateString()` der hvor vi vil vise dato til sluttbruker.
Prøvde å sette opp ESLint regler for å gi warning om man bruker `Date.toLocaleDateString()`, men fant ikke en måte å få det til å virke uten å måtte dra inn en ny pakke. Men det er kanskje like greit uten, for det er forsåvidt fortsatt legitimt å bruke `Date.toLocaleDateString()` om vi ønsker å vise dato på annet format en plass , feks om vi vil vise `24. mai 2024` i stedet for `24.05.2025`.
Fjerner her også alle `format` props til `<DatePicker>` som nå blir overflødig med en default verdi i stedet.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
