### PR TITLE
NP-46839 Fix date-picker on tasks page

### DIFF
--- a/src/pages/messages/components/TicketDateIntervalFilter.tsx
+++ b/src/pages/messages/components/TicketDateIntervalFilter.tsx
@@ -14,8 +14,8 @@ const commonDatepickerProps: Partial<DatePickerProps<Date>> = {
   },
 };
 
-const isEmptyOrStartsWithFourDigitYear = (date: string) => {
-  return date === '' || date.match(/^\d{4}-/);
+const startsWithFourDigitYear = (date: string) => {
+  return date.match(/^\d{4}-/);
 };
 
 export const TicketDateIntervalFilter = () => {
@@ -46,9 +46,8 @@ export const TicketDateIntervalFilter = () => {
         maxDate={selectedToDate ? new Date(selectedToDate) : maxDate}
         onChange={(date, context) => {
           if (context.validationError !== 'invalidDate') {
-            if (isEmptyOrStartsWithFourDigitYear(date ? formatDateStringToISO(date) : '')) {
-              updateSearchParams(date ? formatDateStringToISO(date) : '', selectedToDate);
-            }
+            const isoDate = date ? formatDateStringToISO(date) : '';
+            updateSearchParams(isoDate && startsWithFourDigitYear(isoDate) ? isoDate : '', selectedToDate);
           }
         }}
       />
@@ -61,9 +60,8 @@ export const TicketDateIntervalFilter = () => {
         minDate={selectedFromDate ? new Date(selectedFromDate) : undefined}
         onChange={(date, context) => {
           if (context.validationError !== 'invalidDate') {
-            if (isEmptyOrStartsWithFourDigitYear(date ? formatDateStringToISO(date) : '')) {
-              updateSearchParams(selectedFromDate, date ? formatDateStringToISO(date) : '');
-            }
+            const isoDate = date ? formatDateStringToISO(date) : '';
+            updateSearchParams(selectedFromDate, isoDate && startsWithFourDigitYear(isoDate) ? isoDate : '');
           }
         }}
       />

--- a/src/pages/messages/components/TicketDateIntervalFilter.tsx
+++ b/src/pages/messages/components/TicketDateIntervalFilter.tsx
@@ -24,30 +24,31 @@ export const TicketDateIntervalFilter = () => {
   const [selectedFromDate, selectedToDate] = selectedDatesParam ? selectedDatesParam.split(',') : ['', ''];
 
   const hasValidYear = (date: string) => {
-    return date === '' || date.match(/^\d{4}-/); // Check if year has 4 digits or date is erased
+    return date === '' || date.match(/^\d{4}-/);
+  };
+
+  const updateSearchParams = (newDate: string, otherDate: string, isFromDate: boolean) => {
+    const dateParam = isFromDate ? `${newDate},${otherDate}` : `${otherDate},${newDate}`;
+
+    if (!newDate && !otherDate) {
+      searchParams.delete(TicketSearchParam.CreatedDate);
+    } else {
+      searchParams.set(TicketSearchParam.CreatedDate, dateParam);
+    }
+    history.push({ search: searchParams.toString() });
   };
 
   const onChangeFromDate = (newDate: Date | null) => {
     const newFromDate = newDate ? formatDateStringToISO(newDate) : '';
     if (hasValidYear(newFromDate)) {
-      if (!newFromDate && !selectedToDate) {
-        searchParams.delete(TicketSearchParam.CreatedDate);
-      } else {
-        searchParams.set(TicketSearchParam.CreatedDate, `${newFromDate},${selectedToDate}`);
-      }
-      history.push({ search: searchParams.toString() });
+      updateSearchParams(newFromDate, selectedToDate, true);
     }
   };
 
   const onChangeToDate = (newDate: Date | null) => {
     const newToDate = newDate ? formatDateStringToISO(newDate) : '';
     if (hasValidYear(newToDate)) {
-      if (!selectedFromDate && !newToDate) {
-        searchParams.delete(TicketSearchParam.CreatedDate);
-      } else {
-        searchParams.set(TicketSearchParam.CreatedDate, `${selectedFromDate},${newToDate}`);
-      }
-      history.push({ search: searchParams.toString() });
+      updateSearchParams(newToDate, selectedFromDate, false);
     }
   };
 

--- a/src/pages/messages/components/TicketDateIntervalFilter.tsx
+++ b/src/pages/messages/components/TicketDateIntervalFilter.tsx
@@ -25,22 +25,27 @@ export const TicketDateIntervalFilter = () => {
 
   const onChangeFromDate = (newDate: Date | null) => {
     const newFromDate = newDate ? formatDateStringToISO(newDate) : '';
-    if (!newFromDate && !selectedToDate) {
-      searchParams.delete(TicketSearchParam.CreatedDate);
-    } else {
-      searchParams.set(TicketSearchParam.CreatedDate, `${newFromDate},${selectedToDate}`);
+    // check if year has 4 digits
+    if (newFromDate.match(/^\d{4}-/)) {
+      if (!newFromDate && !selectedToDate) {
+        searchParams.delete(TicketSearchParam.CreatedDate);
+      } else {
+        searchParams.set(TicketSearchParam.CreatedDate, `${newFromDate},${selectedToDate}`);
+      }
+      history.push({ search: searchParams.toString() });
     }
-    history.push({ search: searchParams.toString() });
   };
 
   const onChangeToDate = (newDate: Date | null) => {
     const newToDate = newDate ? formatDateStringToISO(newDate) : '';
-    if (!selectedFromDate && !newToDate) {
-      searchParams.delete(TicketSearchParam.CreatedDate);
-    } else {
-      searchParams.set(TicketSearchParam.CreatedDate, `${selectedFromDate},${newToDate}`);
+    if (newToDate.match(/^\d{4}-/)) {
+      if (!selectedFromDate && !newToDate) {
+        searchParams.delete(TicketSearchParam.CreatedDate);
+      } else {
+        searchParams.set(TicketSearchParam.CreatedDate, `${selectedFromDate},${newToDate}`);
+      }
+      history.push({ search: searchParams.toString() });
     }
-    history.push({ search: searchParams.toString() });
   };
 
   return (

--- a/src/pages/messages/components/TicketDateIntervalFilter.tsx
+++ b/src/pages/messages/components/TicketDateIntervalFilter.tsx
@@ -23,10 +23,13 @@ export const TicketDateIntervalFilter = () => {
   const selectedDatesParam = searchParams.get(TicketSearchParam.CreatedDate);
   const [selectedFromDate, selectedToDate] = selectedDatesParam ? selectedDatesParam.split(',') : ['', ''];
 
+  const hasValidYear = (date: string) => {
+    return date === '' || date.match(/^\d{4}-/); // Check if year has 4 digits or date is erased
+  };
+
   const onChangeFromDate = (newDate: Date | null) => {
     const newFromDate = newDate ? formatDateStringToISO(newDate) : '';
-    // check if year has 4 digits
-    if (newFromDate.match(/^\d{4}-/)) {
+    if (hasValidYear(newFromDate)) {
       if (!newFromDate && !selectedToDate) {
         searchParams.delete(TicketSearchParam.CreatedDate);
       } else {
@@ -38,7 +41,7 @@ export const TicketDateIntervalFilter = () => {
 
   const onChangeToDate = (newDate: Date | null) => {
     const newToDate = newDate ? formatDateStringToISO(newDate) : '';
-    if (newToDate.match(/^\d{4}-/)) {
+    if (hasValidYear(newToDate)) {
       if (!selectedFromDate && !newToDate) {
         searchParams.delete(TicketSearchParam.CreatedDate);
       } else {

--- a/src/pages/messages/components/TicketDateIntervalFilter.tsx
+++ b/src/pages/messages/components/TicketDateIntervalFilter.tsx
@@ -14,6 +14,10 @@ const commonDatepickerProps: Partial<DatePickerProps<Date>> = {
   },
 };
 
+const isEmptyOrStartsWithFourDigitYear = (date: string) => {
+  return date === '' || date.match(/^\d{4}-/);
+};
+
 export const TicketDateIntervalFilter = () => {
   const { t } = useTranslation();
   const history = useHistory();
@@ -23,33 +27,13 @@ export const TicketDateIntervalFilter = () => {
   const selectedDatesParam = searchParams.get(TicketSearchParam.CreatedDate);
   const [selectedFromDate, selectedToDate] = selectedDatesParam ? selectedDatesParam.split(',') : ['', ''];
 
-  const hasValidYear = (date: string) => {
-    return date === '' || date.match(/^\d{4}-/);
-  };
-
-  const updateSearchParams = (newDate: string, otherDate: string, isFromDate: boolean) => {
-    const dateParam = isFromDate ? `${newDate},${otherDate}` : `${otherDate},${newDate}`;
-
-    if (!newDate && !otherDate) {
-      searchParams.delete(TicketSearchParam.CreatedDate);
+  const updateSearchParams = (newFromDate: string, newToDate: string) => {
+    if (newFromDate || newToDate) {
+      searchParams.set(TicketSearchParam.CreatedDate, `${newFromDate},${newToDate}`);
     } else {
-      searchParams.set(TicketSearchParam.CreatedDate, dateParam);
+      searchParams.delete(TicketSearchParam.CreatedDate);
     }
     history.push({ search: searchParams.toString() });
-  };
-
-  const onChangeFromDate = (newDate: Date | null) => {
-    const newFromDate = newDate ? formatDateStringToISO(newDate) : '';
-    if (hasValidYear(newFromDate)) {
-      updateSearchParams(newFromDate, selectedToDate, true);
-    }
-  };
-
-  const onChangeToDate = (newDate: Date | null) => {
-    const newToDate = newDate ? formatDateStringToISO(newDate) : '';
-    if (hasValidYear(newToDate)) {
-      updateSearchParams(newToDate, selectedFromDate, false);
-    }
   };
 
   return (
@@ -62,7 +46,9 @@ export const TicketDateIntervalFilter = () => {
         maxDate={selectedToDate ? new Date(selectedToDate) : maxDate}
         onChange={(date, context) => {
           if (context.validationError !== 'invalidDate') {
-            onChangeFromDate(date);
+            if (isEmptyOrStartsWithFourDigitYear(date ? formatDateStringToISO(date) : '')) {
+              updateSearchParams(date ? formatDateStringToISO(date) : '', selectedToDate);
+            }
           }
         }}
       />
@@ -75,7 +61,9 @@ export const TicketDateIntervalFilter = () => {
         minDate={selectedFromDate ? new Date(selectedFromDate) : undefined}
         onChange={(date, context) => {
           if (context.validationError !== 'invalidDate') {
-            onChangeToDate(date);
+            if (isEmptyOrStartsWithFourDigitYear(date ? formatDateStringToISO(date) : '')) {
+              updateSearchParams(selectedFromDate, date ? formatDateStringToISO(date) : '');
+            }
           }
         }}
       />


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46839

Previously, when entering a date manually in the Date Range filter on TasksPage, the query triggered straight away. Fixed the issue by adding a regex to check if the year in the date has 4 digits before triggering.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
