### PR TITLE
NP-46650 Added year to NPI-value on LandingPage

### DIFF
--- a/src/components/NpiLevelTypography.tsx
+++ b/src/components/NpiLevelTypography.tsx
@@ -22,8 +22,12 @@ export const NpiLevelTypography = ({ scientificValue, publisherId, ...typography
   const { t } = useTranslation();
 
   const levelString = scientificValue ? ScientificValueMapper[scientificValue] : null;
-  let year = publisherId ? publisherId.split('/').pop() : '';
-  year = year && year.match(/^\d{4}$/) ? ` (${year}) ` : '';
+  const year = publisherId
+    ?.split('/')
+    .pop()
+    ?.match(/^\d{4}$/)
+    ? ` (${publisherId.split('/').pop()}) `
+    : '';
 
   return (
     <Typography {...typographyProps}>

--- a/src/components/NpiLevelTypography.tsx
+++ b/src/components/NpiLevelTypography.tsx
@@ -15,24 +15,20 @@ const ScientificValueMapper: ScientificValueMapperType = {
 
 interface NpiLevelTypographyProps extends TypographyProps {
   scientificValue?: ScientificValue;
-  publisherId?: string;
+  channelId?: string;
 }
 
-export const NpiLevelTypography = ({ scientificValue, publisherId, ...typographyProps }: NpiLevelTypographyProps) => {
+export const NpiLevelTypography = ({ scientificValue, channelId, ...typographyProps }: NpiLevelTypographyProps) => {
   const { t } = useTranslation();
 
   const levelString = scientificValue ? ScientificValueMapper[scientificValue] : null;
-  const year = publisherId
-    ?.split('/')
-    .pop()
-    ?.match(/^\d{4}$/)
-    ? ` (${publisherId.split('/').pop()}) `
-    : '';
+  const year = channelId?.split('/').pop();
+  const yearString = year?.match(/^\d{4}$/) ? ` (${year}) ` : '';
 
   return (
     <Typography {...typographyProps}>
       {t('registration.resource_type.level')}
-      {year}: {levelString ?? t('common.not_decided')}
+      {yearString}: {levelString ?? t('common.not_decided')}
     </Typography>
   );
 };

--- a/src/components/NpiLevelTypography.tsx
+++ b/src/components/NpiLevelTypography.tsx
@@ -15,16 +15,20 @@ const ScientificValueMapper: ScientificValueMapperType = {
 
 interface NpiLevelTypographyProps extends TypographyProps {
   scientificValue?: ScientificValue;
+  publisherId?: string;
 }
 
-export const NpiLevelTypography = ({ scientificValue, ...typographyProps }: NpiLevelTypographyProps) => {
+export const NpiLevelTypography = ({ scientificValue, publisherId, ...typographyProps }: NpiLevelTypographyProps) => {
   const { t } = useTranslation();
 
   const levelString = scientificValue ? ScientificValueMapper[scientificValue] : null;
+  let year = publisherId ? publisherId.split('/').pop() : '';
+  year = year && year.match(/^\d{4}$/) ? ` (${year}) ` : '';
 
   return (
     <Typography {...typographyProps}>
-      {t('registration.resource_type.level')}: {levelString ?? t('common.not_decided')}
+      {t('registration.resource_type.level')}
+      {year}: {levelString ?? t('common.not_decided')}
     </Typography>
   );
 };

--- a/src/pages/public_registration/PublicPublicationContext.tsx
+++ b/src/pages/public_registration/PublicPublicationContext.tsx
@@ -117,7 +117,7 @@ export const PublicPublisher = ({ publisher }: { publisher?: ContextPublisher })
       ) : fetchedPublisher ? (
         <>
           <Typography>{fetchedPublisher.name}</Typography>
-          <NpiLevelTypography scientificValue={fetchedPublisher.scientificValue} />
+          <NpiLevelTypography scientificValue={fetchedPublisher.scientificValue} publisherId={fetchedPublisher.id} />
           {fetchedPublisher.sameAs && (
             <Typography component={Link} href={fetchedPublisher.sameAs} target="_blank">
               {t('registration.public_page.find_in_channel_registry')}
@@ -233,7 +233,7 @@ const PublicJournalContent = ({ id, errorMessage }: PublicJournalContentProps) =
           .filter((issn) => issn)
           .join(', ')}
       </Typography>
-      <NpiLevelTypography scientificValue={journal.scientificValue} />
+      <NpiLevelTypography scientificValue={journal.scientificValue} publisherId={journal.id} />
       {journal.sameAs && (
         <Typography component={Link} href={journal.sameAs} target="_blank">
           {t('registration.public_page.find_in_channel_registry')}

--- a/src/pages/public_registration/PublicPublicationContext.tsx
+++ b/src/pages/public_registration/PublicPublicationContext.tsx
@@ -117,7 +117,7 @@ export const PublicPublisher = ({ publisher }: { publisher?: ContextPublisher })
       ) : fetchedPublisher ? (
         <>
           <Typography>{fetchedPublisher.name}</Typography>
-          <NpiLevelTypography scientificValue={fetchedPublisher.scientificValue} publisherId={fetchedPublisher.id} />
+          <NpiLevelTypography scientificValue={fetchedPublisher.scientificValue} channelId={fetchedPublisher.id} />
           {fetchedPublisher.sameAs && (
             <Typography component={Link} href={fetchedPublisher.sameAs} target="_blank">
               {t('registration.public_page.find_in_channel_registry')}
@@ -233,7 +233,7 @@ const PublicJournalContent = ({ id, errorMessage }: PublicJournalContentProps) =
           .filter((issn) => issn)
           .join(', ')}
       </Typography>
-      <NpiLevelTypography scientificValue={journal.scientificValue} publisherId={journal.id} />
+      <NpiLevelTypography scientificValue={journal.scientificValue} channelId={journal.id} />
       {journal.sameAs && (
         <Typography component={Link} href={journal.sameAs} target="_blank">
           {t('registration.public_page.find_in_channel_registry')}


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46650

Added a new prop to `NpiLevelTypography` which takes in the id of the publisher, and then extracts the year of which the NPI-value derives from. The year is only displayed on the Registration Landing Page, and not in the selector on the wizard.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
