### PR TITLE
NP-46884 Handle very old dates

### DIFF
--- a/src/pages/registration/description_tab/DatePickerField.tsx
+++ b/src/pages/registration/description_tab/DatePickerField.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { DescriptionFieldNames } from '../../../types/publicationFieldNames';
 import { EntityDescription, Registration, RegistrationDate } from '../../../types/registration.types';
 import { dataTestId } from '../../../utils/dataTestIds';
+import { getRegistrationDate } from '../../../utils/date-helpers';
 
 export const DatePickerField = () => {
   const { t } = useTranslation();
@@ -17,22 +18,10 @@ export const DatePickerField = () => {
     setFieldTouched,
   } = useFormikContext<Registration>();
 
-  const dateData = entityDescription?.publicationDate ?? { year: '', month: '', day: '' };
+  const dateData = entityDescription?.publicationDate;
 
-  const { year, month, day } = dateData;
-
-  const yearInt = parseInt(year);
-  const monthInt = parseInt(month);
-  const dayInt = parseInt(day);
-
-  const [date, setDate] = useState<Date | null>(
-    !isNaN(yearInt)
-      ? !isNaN(monthInt)
-        ? new Date(yearInt, monthInt - 1, !isNaN(dayInt) ? dayInt : 1, 12, 0, 0)
-        : new Date(yearInt, 0, 1, 12, 0, 0)
-      : null
-  );
-  const [yearOnly, setYearOnly] = useState(!!year && !month);
+  const [date, setDate] = useState(getRegistrationDate(dateData));
+  const [yearOnly, setYearOnly] = useState(!!dateData?.year && !dateData?.month);
 
   const updateDateValues = (newDate: Date | null, isYearOnly: boolean) => {
     const updatedDate: RegistrationDate = {

--- a/src/utils/date-helpers.ts
+++ b/src/utils/date-helpers.ts
@@ -3,13 +3,29 @@ import { enGB as englishDateLocale, nb as norwegianDateLocale } from 'date-fns/l
 import { RegistrationDate } from '../types/registration.types';
 
 export const displayDate = (date: Omit<RegistrationDate, 'type'> | undefined) => {
-  if (date?.month && date?.day) {
-    return toDateString(new Date(+date.year, +date.month - 1, +date.day));
+  if (date?.month && date?.day && date?.year) {
+    const dateObject = getRegistrationDate(date);
+    if (dateObject) {
+      return toDateString(dateObject);
+    } else {
+      return '';
+    }
   } else if (date?.year) {
     return date.year;
   } else {
     return '';
   }
+};
+
+export const getRegistrationDate = (date: Omit<RegistrationDate, 'type'> | undefined) => {
+  if (!date || !date.year) {
+    return null;
+  }
+  const year = date.year.padStart(4, '0');
+  const month = (date?.month ?? '1').padStart(2, '0');
+  const day = (date?.day ?? '1').padStart(2, '0');
+
+  return new Date(`${year}-${month}-${day}T12:00:00.000Z`);
 };
 
 export const getDateFnsLocale = (language: string) => {

--- a/src/utils/date-helpers.ts
+++ b/src/utils/date-helpers.ts
@@ -21,7 +21,7 @@ export const getRegistrationDate = (date: Omit<RegistrationDate, 'type'> | undef
   if (!date || !date.year) {
     return null;
   }
-  const year = date.year.padStart(4, '0');
+  const year = date.year.padStart(4, '0'); // Values are padded to handle (erronuous) dates like year=2 etc.
   const month = (date?.month ?? '1').padStart(2, '0');
   const day = (date?.day ?? '1').padStart(2, '0');
 


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46884

Håndter veldig gamle datoer (feks år 0). Som regel en feil av registrator, men vi må håndtere det. Klarte å reprodusere bugen som er i prod ved å skrive "2024" uten å velge "Kun årstall" i wizarden. Selv syns jeg faktisk koden ble mer lesbar selv om vi nå gjør mer manuelt. Flyten endres litt, men ser ut til å virke som det skal der jeg har sjekket.

Bakgrunn:
`new Date(4, 1, 1)` blir til `01.02.1904`, mens vi ønsker at det skal bli `01.02.0004`. Beste måten jeg har funnet på å løse dette er å lage date basert på ISO streng (som vi da først må lage :( ). Dette er veldig corner case som jeg ikke har lyst til å legge inn overalt, men har lagt det inn på fremvising av dato og i wizard nå, sånn at folk ser at dette er feil, og kan rette opp til dato det skal være.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
