### PR TITLE
Remove trailing space after NPI year

### DIFF
--- a/src/components/NpiLevelTypography.tsx
+++ b/src/components/NpiLevelTypography.tsx
@@ -23,7 +23,7 @@ export const NpiLevelTypography = ({ scientificValue, channelId, ...typographyPr
 
   const levelString = scientificValue ? ScientificValueMapper[scientificValue] : null;
   const year = channelId?.split('/').pop();
-  const yearString = year?.match(/^\d{4}$/) ? ` (${year}) ` : '';
+  const yearString = year?.match(/^\d{4}$/) ? ` (${year})` : '';
 
   return (
     <Typography {...typographyProps}>


### PR DESCRIPTION
# Description

Link to Jira issue: N/A

Oppdaget at det hadde sneket seg med et mellomrom etter NPI årstall i forrige PR.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
