### PR TITLE
Remove support for old role string

### DIFF
--- a/src/redux/userSlice.ts
+++ b/src/redux/userSlice.ts
@@ -20,12 +20,7 @@ const userSlice = createSlice({
       const feideId = getStringValue(action.payload['custom:feideId']);
       const rolesString = getStringValue(action.payload['custom:roles']);
       const allowedCustomersString = getStringValue(action.payload['custom:allowedCustomers']);
-
-      const roleItems = rolesString.split(',').map((roleItem) => roleItem.split('@') as [RoleName, string]);
-      const roles = roleItems.flatMap(([role, thisCustomerId]) =>
-        !thisCustomerId || thisCustomerId === customerId ? [role] : []
-      );
-
+      const roles = rolesString.split(',') as RoleName[];
       const allowedCustomers = allowedCustomersString.split(',').filter((customer) => customer);
 
       const user: User = {


### PR DESCRIPTION
Fjern håndtering av gammelt format for rollestrengen man får etter innlogging. Backend oppdaterte dette i alle miljø for noen måneder siden.

Bakgrunn: https://github.com/BIBSYSDEV/NVA-Frontend/pull/5428