### PR TITLE
Fixed bug

### DIFF
--- a/src/api/scientificIndexApi.ts
+++ b/src/api/scientificIndexApi.ts
@@ -1,6 +1,6 @@
 import { Approval, Note, NviCandidate, NviPeriod, NviPeriodResponse, RejectedApproval } from '../types/nvi.types';
 import { ScientificIndexApiPath } from './apiPaths';
-import { authenticatedApiRequest2 } from './apiRequest';
+import { apiRequest2, authenticatedApiRequest2 } from './apiRequest';
 
 export type CreateNoteData = Pick<Note, 'text'>;
 
@@ -77,7 +77,7 @@ export const updateNviPeriod = async (data: NviPeriod) => {
 };
 
 export const fetchNviCandidateForRegistration = async (registrationId: string) => {
-  const fetchNviCandidateForRegistrationResponse = await authenticatedApiRequest2<NviCandidate>({
+  const fetchNviCandidateForRegistrationResponse = await apiRequest2<NviCandidate>({
     url: `${ScientificIndexApiPath.CandidateForRegistration}/${encodeURIComponent(registrationId)}`,
   });
 


### PR DESCRIPTION
# Description

Fixed bug introduced with [Vis NVI rapporteringsår på landing page](https://unit.atlassian.net/browse/NP-46917).

Because we are using a "new" endpoint to check the NVI-report year, we get an error when trying to load the landing page without being logged in, because this endpoint needs authentication.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [ ] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [ ] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
