### PR TITLE
Update eslint rules

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,12 +13,12 @@ module.exports = {
     'plugin:prettier/recommended',
   ],
   rules: {
-    'react/react-in-jsx-scope': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': ['warn', { ignoreRestSiblings: true }],
+    'react/react-in-jsx-scope': 'off',
     'react/jsx-key': 'off', // TODO: Violations of this rule should be resolved, so we can implement this rule
     'react/no-children-prop': 'off', // TODO: Violations of this rule should be resolved, so we can implement this rule
     'no-console': 'warn',
     'no-debugger': 'warn',
-    '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],
   },
 };


### PR DESCRIPTION
Gi warning i stedet for error for ubrukte variabler. Dette for å unngå at lokal kjøring stoppes når kode er i utvikling. Bygg vil fortsatt feile ved ubrukte variabler.