### PR TITLE
NP-46764 Add log entry for file(s) uploaded by

### DIFF
--- a/src/pages/public_registration/LogPanel.tsx
+++ b/src/pages/public_registration/LogPanel.tsx
@@ -209,7 +209,7 @@ const FilenamesList = ({ filenames }: FilenamesProps) => {
         color: 'black',
       }}>
       {filenames.map((filename, index) => (
-        <li key={index}>
+        <li key={`${filename}-${index}`}>
           <Tooltip title={filename}>
             <Typography
               sx={{

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -678,6 +678,8 @@
       "files_published_other": "{{count}} filer publisert",
       "files_published_unknown": "Fil(er) publisert",
       "files_rejected": "Fil(er) avvist",
+      "files_uploaded_one": "{{count}} fil lastet opp",
+      "files_uploaded_other": "{{count}} filer lastet opp",
       "general_support_pending": "Venter på oppfølging",
       "get_curator_support": "Få hjelp av kurator",
       "mark_as_completed": "Sett til ferdig",

--- a/src/types/associatedArtifact.types.ts
+++ b/src/types/associatedArtifact.types.ts
@@ -31,6 +31,13 @@ export interface AssociatedFile {
   license: string | null;
   legalNote?: string;
   rightsRetentionStrategy: FileRrs;
+  uploadDetails?: UploadDetails;
+}
+
+export interface UploadDetails {
+  type: 'UploadDetails';
+  uploadedBy: string;
+  uploadedDate: string;
 }
 
 export const emptyFile: AssociatedFile = {

--- a/src/types/publication_types/ticket.types.ts
+++ b/src/types/publication_types/ticket.types.ts
@@ -62,7 +62,7 @@ type TicketPublication = Pick<
 
 export interface PublishingTicket extends Ticket {
   approvedFiles: string[];
-  filesForApproval: AssociatedFile[];
+  filesForApproval: string[];
   workflow: PublishStrategy;
 }
 


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-46764](https://unit.atlassian.net/browse/NP-46764)

Legger til logginnsalg for å vise hvem som har lastet opp hvilke filer til godkjenning. Dvs., `PublishingRequest` med status `New` eller `Pending` er lagt til.

En liten bug  dersom man laster opp filer til godkjenning i flere omganger. Da vil det ikke opprettes ticket/logginnslag for de nye filene. Må se om det er en frontend eller backend feature/bug.

Denne loggfilen har veldige voksesmerter, men gjør heller en refaktorering av hele greia når det nye designet skal implementeres.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-46764]: https://unit.atlassian.net/browse/NP-46764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ