### PR TITLE
New flow for "Add affiliation"

### DIFF
--- a/src/api/hooks/useSearchForOrganizations.ts
+++ b/src/api/hooks/useSearchForOrganizations.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { OrganizationSearchParams, searchForOrganizations } from '../cristinApi';
+
+export const useSearchForOrganizations = (searchTerm: string) => {
+  const { t } = useTranslation();
+
+  const organizationQueryParams: OrganizationSearchParams = {
+    query: searchTerm,
+    includeSubunits: true,
+  };
+  return useQuery({
+    enabled: !!searchTerm,
+    queryKey: ['organization', organizationQueryParams],
+    queryFn: () => searchForOrganizations(organizationQueryParams),
+    meta: { errorMessage: t('feedback.error.get_institutions') },
+  });
+};

--- a/src/components/OrganizationAccordion.tsx
+++ b/src/components/OrganizationAccordion.tsx
@@ -1,0 +1,116 @@
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import RadioButtonCheckedIcon from '@mui/icons-material/RadioButtonChecked';
+import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
+import { Accordion, AccordionDetails, AccordionSummary, Box, Typography } from '@mui/material';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Organization } from '../types/organization.types';
+import { dataTestId } from '../utils/dataTestIds';
+import { getIdentifierFromId } from '../utils/general-helpers';
+import { getAllChildOrganizations } from '../utils/institutions-helpers';
+import { getLanguageString } from '../utils/translation-helpers';
+
+interface OrganizationAccordionProps {
+  organization: Organization;
+  searchId: string;
+  selectedId: string;
+  setSelectedId: (id: string) => void;
+  level?: number;
+  includeAllSubunits?: boolean;
+  displayOrgId?: boolean;
+  displaySubunitsCount?: boolean;
+}
+
+export const OrganizationAccordion = ({
+  organization,
+  searchId,
+  selectedId,
+  setSelectedId,
+  level = 0,
+  includeAllSubunits = false,
+  displayOrgId = false,
+  displaySubunitsCount = false,
+}: OrganizationAccordionProps) => {
+  const { t } = useTranslation();
+
+  const foundBySearch = organization.id === searchId;
+  const foundBySelect = organization.id === selectedId;
+
+  const allSubunits = getAllChildOrganizations(organization.hasPart);
+
+  const [isExpanded, setIsExpanded] = useState(
+    foundBySelect || allSubunits.some((subunit) => subunit.id === selectedId)
+  );
+
+  // Hide this element if the searched ID is not a part of this unit
+  if (!!searchId && !foundBySearch && !includeAllSubunits && !allSubunits.some((subunit) => subunit.id === searchId)) {
+    return null;
+  }
+
+  const expanded = isExpanded || (!!searchId && !includeAllSubunits);
+  const subunitsCount = organization.hasPart?.length ?? 0;
+
+  return (
+    <Accordion
+      data-testid={dataTestId.editor.organizationAccordion(organization.id)}
+      elevation={2}
+      disableGutters
+      sx={{
+        bgcolor: level % 2 === 0 ? 'secondary.main' : 'secondary.light',
+        ml: { xs: undefined, md: level > 0 ? '1rem' : 0 },
+      }}
+      expanded={expanded}
+      onChange={() => {
+        setIsExpanded(!expanded);
+        setSelectedId(organization.id);
+      }}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ visibility: subunitsCount > 0 ? null : 'hidden' }} />}>
+        <Box
+          sx={{
+            width: '100%',
+            display: 'grid',
+            gap: '0.25rem 1rem',
+            gridTemplateColumns: {
+              xs: 'auto 1fr',
+              lg: 'auto 3fr 3fr 1fr 1fr',
+              alignItems: 'center',
+            },
+            py: '0.25rem',
+            '& > p': { fontWeight: foundBySearch ? 700 : undefined },
+          }}>
+          {foundBySelect ? <RadioButtonCheckedIcon fontSize="small" /> : <RadioButtonUncheckedIcon fontSize="small" />}
+          <Typography>{getLanguageString(organization.labels, 'nb')}</Typography>
+          <Typography sx={{ gridColumn: { xs: '1/3', lg: '3/4' } }}>{organization.labels['en']}</Typography>
+          {displayOrgId && (
+            <Typography sx={{ gridColumn: { xs: '1/3', lg: '4/5' } }}>
+              {getIdentifierFromId(organization.id)}
+            </Typography>
+          )}
+          {displaySubunitsCount && (
+            <Typography sx={{ gridColumn: { xs: '1/3', lg: '5/6' } }}>
+              {subunitsCount > 0 && t('editor.subunits_count', { count: subunitsCount })}
+            </Typography>
+          )}
+        </Box>
+      </AccordionSummary>
+      {subunitsCount > 0 && (
+        <AccordionDetails sx={{ pr: 0 }}>
+          {expanded &&
+            organization.hasPart?.map((subunit) => (
+              <OrganizationAccordion
+                key={subunit.id}
+                organization={subunit}
+                level={level + 1}
+                searchId={searchId}
+                includeAllSubunits={includeAllSubunits || foundBySearch}
+                selectedId={selectedId}
+                setSelectedId={setSelectedId}
+                displayOrgId={displayOrgId}
+                displaySubunitsCount={displaySubunitsCount}
+              />
+            ))}
+        </AccordionDetails>
+      )}
+    </Accordion>
+  );
+};

--- a/src/components/institution/SelectInstitutionForm.tsx
+++ b/src/components/institution/SelectInstitutionForm.tsx
@@ -81,7 +81,7 @@ export const SelectInstitutionForm = ({
           {suggestedInstitutions.length > 0 && (
             <Paper elevation={4} sx={{ p: '1rem', maxHeight: '35vh', overflow: 'auto', mb: '1.5rem' }}>
               <FormControl>
-                <FormLabel>{t('registration.contributors.suggested_affiliations')}</FormLabel>
+                <FormLabel sx={{ mb: '0.5rem' }}>{t('registration.contributors.suggested_affiliations')}</FormLabel>
                 <Field name={SelectOrganizationFormField.selectedSuggestedAffiliationId}>
                   {({ field }: FieldProps<string>) => (
                     <RadioGroup
@@ -150,7 +150,7 @@ export const SelectInstitutionForm = ({
             </Field>
             {values.unit?.hasPart && values.unit.hasPart.length > 0 && (
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-                <Typography variant="h3" component="h2" sx={{ marginTop: '1rem', fontWeight: 'normal' }}>
+                <Typography variant="h3" sx={{ marginTop: '1rem', fontWeight: 'normal' }}>
                   {t('common.select_unit')}
                 </Typography>
                 <Field name={SelectOrganizationFormField.Subunit}>

--- a/src/components/institution/SelectInstitutionForm.tsx
+++ b/src/components/institution/SelectInstitutionForm.tsx
@@ -21,6 +21,7 @@ import { dataTestId } from '../../utils/dataTestIds';
 import { useDebounce } from '../../utils/hooks/useDebounce';
 import { getSortedSubUnits } from '../../utils/institutions-helpers';
 import { getLanguageString } from '../../utils/translation-helpers';
+import { OrganizationAccordion } from '../OrganizationAccordion';
 import { OrganizationRenderOption } from '../OrganizationRenderOption';
 import { OrganizationBox } from './OrganizationBox';
 
@@ -55,6 +56,8 @@ export const SelectInstitutionForm = ({
 }: SelectInstitutionFormProps) => {
   const { t } = useTranslation();
   const [searchTerm, setSearchTerm] = useState('');
+  const [selectedSubunitId, setSelectedSubunitId] = useState('');
+
   const debouncedQuery = useDebounce(searchTerm);
   const organizationSearchQuery = useSearchForOrganizations(debouncedQuery);
 
@@ -66,99 +69,103 @@ export const SelectInstitutionForm = ({
           addAffiliation(values.selectedSuggestedAffiliationId);
         } else if (values.subunit?.id) {
           addAffiliation(values.subunit.id);
+        } else if (selectedSubunitId) {
+          addAffiliation(selectedSubunitId);
         } else if (values.unit?.id) {
           addAffiliation(values.unit?.id);
         }
         setSubmitting(false);
       }}>
-      {({ isSubmitting, values, setFieldValue, resetForm }: FormikProps<OrganizationForm>) => {
-        console.log('values', values);
-        return (
-          <Form noValidate>
-            {suggestedInstitutions.length > 0 && (
-              <Paper elevation={4} sx={{ p: '1rem', maxHeight: '35vh', overflow: 'auto', mb: '1.5rem' }}>
-                <FormControl>
-                  <FormLabel>{t('registration.contributors.suggested_affiliations')}</FormLabel>
-                  <Field name={SelectOrganizationFormField.selectedSuggestedAffiliationId}>
-                    {({ field }: FieldProps<string>) => (
-                      <RadioGroup
-                        sx={{ gap: '0.5rem' }}
-                        {...field}
-                        onChange={(event) => {
-                          setSearchTerm('');
-                          resetForm();
-                          field.onChange(event);
-                        }}>
-                        {suggestedInstitutions.map((suggestedInstitution) => (
-                          <FormControlLabel
-                            sx={{
-                              '& .MuiFormControlLabel-label': {
-                                width: '100%',
-                              },
-                            }}
-                            key={suggestedInstitution}
-                            value={suggestedInstitution}
-                            control={<Radio size="small" />}
-                            label={<OrganizationBox unitUri={suggestedInstitution} />}
-                          />
-                        ))}
-                      </RadioGroup>
-                    )}
-                  </Field>
-                </FormControl>
-              </Paper>
-            )}
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-              <Field name={SelectOrganizationFormField.Unit}>
-                {({ field }: FieldProps<Organization>) => (
-                  <Autocomplete
-                    {...field}
-                    options={organizationSearchQuery.data?.hits ?? []}
-                    inputValue={field.value ? getLanguageString(field.value.labels) : searchTerm}
-                    getOptionLabel={(option) => getLanguageString(option.labels)}
-                    renderOption={(props, option) => (
-                      <OrganizationRenderOption key={option.id} props={props} option={option} />
-                    )}
-                    filterOptions={(options) => options}
-                    onInputChange={(_, value, reason) => {
-                      if (field.value) {
-                        setFieldValue(field.name, null);
-                      }
-                      if (reason !== 'reset') {
-                        setSearchTerm(value);
-                      }
-                    }}
-                    onChange={(_, value) => {
-                      resetForm();
-                      setFieldValue(field.name, value);
-                    }}
-                    loading={organizationSearchQuery.isPending}
-                    renderInput={(params) => (
-                      <TextField
-                        {...params}
-                        data-testid={dataTestId.organization.searchField}
-                        label={t('registration.contributors.search_for_institution')}
-                        variant="filled"
-                        fullWidth
-                      />
-                    )}
-                  />
-                )}
-              </Field>
-              {values.unit?.hasPart && values.unit.hasPart.length > 0 && (
-                <>
-                  <Typography variant="h3" component="h2" sx={{ marginTop: '1rem', fontWeight: 'normal' }}>
-                    {t('common.select_unit')}
-                  </Typography>
-                  <Field name={SelectOrganizationFormField.Subunit}>
-                    {({ field }: FieldProps<Organization>) => (
+      {({ isSubmitting, values, setFieldValue, resetForm }: FormikProps<OrganizationForm>) => (
+        <Form noValidate>
+          {suggestedInstitutions.length > 0 && (
+            <Paper elevation={4} sx={{ p: '1rem', maxHeight: '35vh', overflow: 'auto', mb: '1.5rem' }}>
+              <FormControl>
+                <FormLabel>{t('registration.contributors.suggested_affiliations')}</FormLabel>
+                <Field name={SelectOrganizationFormField.selectedSuggestedAffiliationId}>
+                  {({ field }: FieldProps<string>) => (
+                    <RadioGroup
+                      sx={{ gap: '0.5rem' }}
+                      {...field}
+                      onChange={(event) => {
+                        setSearchTerm('');
+                        resetForm();
+                        field.onChange(event);
+                      }}>
+                      {suggestedInstitutions.map((suggestedInstitution) => (
+                        <FormControlLabel
+                          sx={{
+                            '& .MuiFormControlLabel-label': {
+                              width: '100%',
+                            },
+                          }}
+                          key={suggestedInstitution}
+                          value={suggestedInstitution}
+                          control={<Radio size="small" />}
+                          label={<OrganizationBox unitUri={suggestedInstitution} />}
+                        />
+                      ))}
+                    </RadioGroup>
+                  )}
+                </Field>
+              </FormControl>
+            </Paper>
+          )}
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+            <Field name={SelectOrganizationFormField.Unit}>
+              {({ field }: FieldProps<Organization>) => (
+                <Autocomplete
+                  {...field}
+                  options={organizationSearchQuery.data?.hits ?? []}
+                  inputValue={field.value ? getLanguageString(field.value.labels) : searchTerm}
+                  getOptionLabel={(option) => getLanguageString(option.labels)}
+                  renderOption={(props, option) => (
+                    <OrganizationRenderOption key={option.id} props={props} option={option} />
+                  )}
+                  filterOptions={(options) => options}
+                  onInputChange={(_, value, reason) => {
+                    if (field.value) {
+                      setFieldValue(field.name, null);
+                    }
+                    if (reason !== 'reset') {
+                      setSearchTerm(value);
+                    }
+                  }}
+                  onChange={(_, value) => {
+                    resetForm();
+                    setFieldValue(field.name, value);
+                  }}
+                  loading={organizationSearchQuery.isPending}
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      data-testid={dataTestId.organization.searchField}
+                      label={t('registration.contributors.search_for_institution')}
+                      variant="filled"
+                      fullWidth
+                    />
+                  )}
+                />
+              )}
+            </Field>
+            {values.unit?.hasPart && values.unit.hasPart.length > 0 && (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                <Typography variant="h3" component="h2" sx={{ marginTop: '1rem', fontWeight: 'normal' }}>
+                  {t('common.select_unit')}
+                </Typography>
+                <Field name={SelectOrganizationFormField.Subunit}>
+                  {({ field }: FieldProps<Organization>) => (
+                    <>
                       <Autocomplete
                         options={getSortedSubUnits(values.unit?.hasPart)}
                         getOptionLabel={(option) => getLanguageString(option.labels)}
                         renderOption={(props, option) => (
                           <OrganizationRenderOption key={option.id} props={props} option={option} />
                         )}
-                        onChange={(_, value) => setFieldValue(field.name, value)}
+                        onChange={(_, value) => {
+                          setFieldValue(field.name, value);
+                          setSelectedSubunitId(value?.id ?? '');
+                        }}
                         filterOptions={(options, state) =>
                           options.filter((option) =>
                             state
@@ -177,30 +184,38 @@ export const SelectInstitutionForm = ({
                           />
                         )}
                       />
-                    )}
-                  </Field>
-                </>
-              )}
-
-              <Box sx={{ display: 'flex', gap: '1rem', justifyContent: 'center' }}>
-                {onClose && (
-                  <Button onClick={onClose} data-testid={dataTestId.confirmDialog.cancelButton}>
-                    {t('common.cancel')}
-                  </Button>
-                )}
-                <LoadingButton
-                  variant="contained"
-                  type="submit"
-                  loading={isSubmitting}
-                  disabled={!values.unit && !values.selectedSuggestedAffiliationId}
-                  data-testid={dataTestId.registrationWizard.contributors.addSelectedAffiliationButton}>
-                  {t('common.add')}
-                </LoadingButton>
+                      {values[SelectOrganizationFormField.Unit]?.hasPart?.map((organization) => (
+                        <OrganizationAccordion
+                          key={organization.id}
+                          organization={organization}
+                          searchId={values[SelectOrganizationFormField.Subunit]?.id ?? ''}
+                          selectedId={selectedSubunitId}
+                          setSelectedId={setSelectedSubunitId}
+                        />
+                      ))}
+                    </>
+                  )}
+                </Field>
               </Box>
+            )}
+            <Box sx={{ display: 'flex', gap: '1rem', justifyContent: 'center' }}>
+              {onClose && (
+                <Button onClick={onClose} data-testid={dataTestId.confirmDialog.cancelButton}>
+                  {t('common.cancel')}
+                </Button>
+              )}
+              <LoadingButton
+                variant="contained"
+                type="submit"
+                loading={isSubmitting}
+                disabled={!values.unit && !values.selectedSuggestedAffiliationId}
+                data-testid={dataTestId.registrationWizard.contributors.addSelectedAffiliationButton}>
+                {t('common.add')}
+              </LoadingButton>
             </Box>
-          </Form>
-        );
-      }}
+          </Box>
+        </Form>
+      )}
     </Formik>
   );
 };

--- a/src/components/institution/SelectInstitutionForm.tsx
+++ b/src/components/institution/SelectInstitutionForm.tsx
@@ -10,12 +10,12 @@ import {
   Radio,
   RadioGroup,
   TextField,
+  Typography,
 } from '@mui/material';
-import { useQuery } from '@tanstack/react-query';
 import { Field, FieldProps, Form, Formik, FormikProps } from 'formik';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { OrganizationSearchParams, searchForOrganizations } from '../../api/cristinApi';
+import { useSearchForOrganizations } from '../../api/hooks/useSearchForOrganizations';
 import { Organization } from '../../types/organization.types';
 import { dataTestId } from '../../utils/dataTestIds';
 import { useDebounce } from '../../utils/hooks/useDebounce';
@@ -43,132 +43,101 @@ const initialValuesOrganizationForm: OrganizationForm = {
 };
 
 interface SelectInstitutionFormProps {
-  onSubmit: (id: string) => void;
+  addAffiliation: (id: string) => void;
   onClose?: () => void;
   suggestedInstitutions: string[];
 }
 
-export const SelectInstitutionForm = ({ onSubmit, onClose, suggestedInstitutions }: SelectInstitutionFormProps) => {
+export const SelectInstitutionForm = ({
+  addAffiliation,
+  onClose,
+  suggestedInstitutions,
+}: SelectInstitutionFormProps) => {
   const { t } = useTranslation();
   const [searchTerm, setSearchTerm] = useState('');
   const debouncedQuery = useDebounce(searchTerm);
-
-  const organizationQueryParams: OrganizationSearchParams = {
-    query: debouncedQuery,
-    includeSubunits: true,
-  };
-  const organizationSearchQuery = useQuery({
-    enabled: !!debouncedQuery,
-    queryKey: ['organization', organizationQueryParams],
-    queryFn: () => searchForOrganizations(organizationQueryParams),
-    meta: { errorMessage: t('feedback.error.get_institutions') },
-  });
+  const organizationSearchQuery = useSearchForOrganizations(debouncedQuery);
 
   return (
     <Formik
       initialValues={initialValuesOrganizationForm}
       onSubmit={(values, { setSubmitting }) => {
         if (values.selectedSuggestedAffiliationId) {
-          onSubmit(values.selectedSuggestedAffiliationId);
+          addAffiliation(values.selectedSuggestedAffiliationId);
         } else if (values.subunit?.id) {
-          onSubmit(values.subunit.id);
+          addAffiliation(values.subunit.id);
         } else if (values.unit?.id) {
-          onSubmit(values.unit?.id);
+          addAffiliation(values.unit?.id);
         }
         setSubmitting(false);
       }}>
-      {({ isSubmitting, values, setFieldValue, resetForm }: FormikProps<OrganizationForm>) => (
-        <Form noValidate>
-          {suggestedInstitutions.length > 0 && (
-            <Paper elevation={4} sx={{ p: '1rem', maxHeight: '35vh', overflow: 'auto', mb: '1.5rem' }}>
-              <FormControl>
-                <FormLabel>{t('registration.contributors.suggested_affiliations')}</FormLabel>
-                <Field name={SelectOrganizationFormField.selectedSuggestedAffiliationId}>
-                  {({ field }: FieldProps<string>) => (
-                    <RadioGroup
-                      sx={{ gap: '0.5rem' }}
-                      {...field}
-                      onChange={(event) => {
-                        setSearchTerm('');
-                        resetForm();
-                        field.onChange(event);
-                      }}>
-                      {suggestedInstitutions.map((suggestedInstitution) => (
-                        <FormControlLabel
-                          sx={{
-                            '& .MuiFormControlLabel-label': {
-                              width: '100%',
-                            },
-                          }}
-                          key={suggestedInstitution}
-                          value={suggestedInstitution}
-                          control={<Radio size="small" />}
-                          label={<OrganizationBox unitUri={suggestedInstitution} />}
-                        />
-                      ))}
-                    </RadioGroup>
-                  )}
-                </Field>
-              </FormControl>
-            </Paper>
-          )}
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-            <Field name={SelectOrganizationFormField.Unit}>
-              {({ field }: FieldProps<Organization>) => (
-                <Autocomplete
-                  {...field}
-                  options={organizationSearchQuery.data?.hits ?? []}
-                  inputValue={field.value ? getLanguageString(field.value.labels) : searchTerm}
-                  getOptionLabel={(option) => getLanguageString(option.labels)}
-                  renderOption={(props, option) => (
-                    <OrganizationRenderOption key={option.id} props={props} option={option} />
-                  )}
-                  filterOptions={(options) => options}
-                  onInputChange={(_, value, reason) => {
-                    if (field.value) {
-                      setFieldValue(field.name, null);
-                    }
-                    if (reason !== 'reset') {
-                      setSearchTerm(value);
-                    }
-                  }}
-                  onChange={(_, value) => {
-                    resetForm();
-                    setFieldValue(field.name, value);
-                  }}
-                  loading={organizationSearchQuery.isPending}
-                  renderInput={(params) => (
-                    <TextField
-                      {...params}
-                      data-testid={dataTestId.organization.searchField}
-                      label={t('registration.contributors.search_for_institution')}
-                      variant="filled"
-                      fullWidth
-                    />
-                  )}
-                />
-              )}
-            </Field>
-            {values.unit?.hasPart && values.unit.hasPart.length > 0 && (
-              <Field name={SelectOrganizationFormField.Subunit}>
+      {({ isSubmitting, values, setFieldValue, resetForm }: FormikProps<OrganizationForm>) => {
+        console.log('values', values);
+        return (
+          <Form noValidate>
+            {suggestedInstitutions.length > 0 && (
+              <Paper elevation={4} sx={{ p: '1rem', maxHeight: '35vh', overflow: 'auto', mb: '1.5rem' }}>
+                <FormControl>
+                  <FormLabel>{t('registration.contributors.suggested_affiliations')}</FormLabel>
+                  <Field name={SelectOrganizationFormField.selectedSuggestedAffiliationId}>
+                    {({ field }: FieldProps<string>) => (
+                      <RadioGroup
+                        sx={{ gap: '0.5rem' }}
+                        {...field}
+                        onChange={(event) => {
+                          setSearchTerm('');
+                          resetForm();
+                          field.onChange(event);
+                        }}>
+                        {suggestedInstitutions.map((suggestedInstitution) => (
+                          <FormControlLabel
+                            sx={{
+                              '& .MuiFormControlLabel-label': {
+                                width: '100%',
+                              },
+                            }}
+                            key={suggestedInstitution}
+                            value={suggestedInstitution}
+                            control={<Radio size="small" />}
+                            label={<OrganizationBox unitUri={suggestedInstitution} />}
+                          />
+                        ))}
+                      </RadioGroup>
+                    )}
+                  </Field>
+                </FormControl>
+              </Paper>
+            )}
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+              <Field name={SelectOrganizationFormField.Unit}>
                 {({ field }: FieldProps<Organization>) => (
                   <Autocomplete
-                    options={getSortedSubUnits(values.unit?.hasPart)}
+                    {...field}
+                    options={organizationSearchQuery.data?.hits ?? []}
+                    inputValue={field.value ? getLanguageString(field.value.labels) : searchTerm}
                     getOptionLabel={(option) => getLanguageString(option.labels)}
                     renderOption={(props, option) => (
                       <OrganizationRenderOption key={option.id} props={props} option={option} />
                     )}
-                    onChange={(_, value) => setFieldValue(field.name, value)}
-                    filterOptions={(options, state) =>
-                      options.filter((option) =>
-                        state.getOptionLabel(option).toLocaleLowerCase().includes(state.inputValue.toLocaleLowerCase())
-                      )
-                    }
+                    filterOptions={(options) => options}
+                    onInputChange={(_, value, reason) => {
+                      if (field.value) {
+                        setFieldValue(field.name, null);
+                      }
+                      if (reason !== 'reset') {
+                        setSearchTerm(value);
+                      }
+                    }}
+                    onChange={(_, value) => {
+                      resetForm();
+                      setFieldValue(field.name, value);
+                    }}
+                    loading={organizationSearchQuery.isPending}
                     renderInput={(params) => (
                       <TextField
                         {...params}
-                        data-testid={dataTestId.organization.subSearchField}
-                        label={t('registration.contributors.department')}
+                        data-testid={dataTestId.organization.searchField}
+                        label={t('registration.contributors.search_for_institution')}
                         variant="filled"
                         fullWidth
                       />
@@ -176,27 +145,62 @@ export const SelectInstitutionForm = ({ onSubmit, onClose, suggestedInstitutions
                   />
                 )}
               </Field>
-            )}
-
-            <Box sx={{ display: 'flex', gap: '1rem' }}>
-              <LoadingButton
-                variant="contained"
-                type="submit"
-                loading={isSubmitting}
-                disabled={!values.unit && !values.selectedSuggestedAffiliationId}
-                data-testid={dataTestId.registrationWizard.contributors.addSelectedAffiliationButton}>
-                {t('common.add')}
-              </LoadingButton>
-
-              {onClose && (
-                <Button onClick={onClose} data-testid={dataTestId.confirmDialog.cancelButton}>
-                  {t('common.cancel')}
-                </Button>
+              {values.unit?.hasPart && values.unit.hasPart.length > 0 && (
+                <>
+                  <Typography variant="h3" component="h2" sx={{ marginTop: '1rem', fontWeight: 'normal' }}>
+                    {t('common.select_unit')}
+                  </Typography>
+                  <Field name={SelectOrganizationFormField.Subunit}>
+                    {({ field }: FieldProps<Organization>) => (
+                      <Autocomplete
+                        options={getSortedSubUnits(values.unit?.hasPart)}
+                        getOptionLabel={(option) => getLanguageString(option.labels)}
+                        renderOption={(props, option) => (
+                          <OrganizationRenderOption key={option.id} props={props} option={option} />
+                        )}
+                        onChange={(_, value) => setFieldValue(field.name, value)}
+                        filterOptions={(options, state) =>
+                          options.filter((option) =>
+                            state
+                              .getOptionLabel(option)
+                              .toLocaleLowerCase()
+                              .includes(state.inputValue.toLocaleLowerCase())
+                          )
+                        }
+                        renderInput={(params) => (
+                          <TextField
+                            {...params}
+                            data-testid={dataTestId.organization.subSearchField}
+                            label={t('registration.contributors.department')}
+                            variant="filled"
+                            fullWidth
+                          />
+                        )}
+                      />
+                    )}
+                  </Field>
+                </>
               )}
+
+              <Box sx={{ display: 'flex', gap: '1rem', justifyContent: 'center' }}>
+                {onClose && (
+                  <Button onClick={onClose} data-testid={dataTestId.confirmDialog.cancelButton}>
+                    {t('common.cancel')}
+                  </Button>
+                )}
+                <LoadingButton
+                  variant="contained"
+                  type="submit"
+                  loading={isSubmitting}
+                  disabled={!values.unit && !values.selectedSuggestedAffiliationId}
+                  data-testid={dataTestId.registrationWizard.contributors.addSelectedAffiliationButton}>
+                  {t('common.add')}
+                </LoadingButton>
+              </Box>
             </Box>
-          </Box>
-        </Form>
-      )}
+          </Form>
+        );
+      }}
     </Formik>
   );
 };

--- a/src/components/institution/SelectInstitutionForm.tsx
+++ b/src/components/institution/SelectInstitutionForm.tsx
@@ -184,11 +184,11 @@ export const SelectInstitutionForm = ({
                           />
                         )}
                       />
-                      {values[SelectOrganizationFormField.Unit]?.hasPart?.map((organization) => (
+                      {values.unit?.hasPart?.map((organization) => (
                         <OrganizationAccordion
                           key={organization.id}
                           organization={organization}
-                          searchId={values[SelectOrganizationFormField.Subunit]?.id ?? ''}
+                          searchId={values.subunit?.id ?? ''}
                           selectedId={selectedSubunitId}
                           setSelectedId={setSelectedSubunitId}
                         />

--- a/src/pages/registration/contributors_tab/components/AddAffiliationModal.tsx
+++ b/src/pages/registration/contributors_tab/components/AddAffiliationModal.tsx
@@ -83,40 +83,37 @@ export const AddAffiliationModal = ({
       fullWidth={true}
       headingText={t('registration.contributors.add_new_affiliation')}
       dataTestId="affiliation-modal">
-      <>
-        <Trans
-          i18nKey="registration.contributors.add_new_affiliation_helper_text"
-          components={[<Typography paragraph />]}
-        />
-        <Box
-          sx={{
-            bgcolor: 'secondary.main',
-            borderRadius: '0.25rem',
-            padding: '0.5rem 0.75rem',
-            marginBottom: '2rem',
-          }}>
-          {' '}
-          <Typography>
-            {t('common.contributor')}: <b>{authorName}</b>
-          </Typography>
-        </Box>
-        {affiliationToVerify && (
-          <Typography paragraph>
-            {t('registration.contributors.prefilled_affiliation')}: <b>{affiliationToVerify}</b>
-          </Typography>
-        )}
-        <Typography variant="h3" component="h2" sx={{ marginBottom: '1rem', fontWeight: 'normal' }}>
-          {t('common.select_institution')}
+      <Trans
+        i18nKey="registration.contributors.add_new_affiliation_helper_text"
+        components={[<Typography paragraph />]}
+      />
+      <Box
+        sx={{
+          bgcolor: 'secondary.main',
+          borderRadius: '0.25rem',
+          padding: '0.5rem 0.75rem',
+          marginBottom: '2rem',
+        }}>
+        <Typography>
+          {t('common.contributor')}: <b>{authorName}</b>
         </Typography>
-        <SelectInstitutionForm
-          addAffiliation={addAffiliation}
-          onClose={toggleAffiliationModal}
-          suggestedInstitutions={getDistinctContributorUnits(values.entityDescription?.contributors ?? []).filter(
-            (suggestion) =>
-              !affiliations.some((affiliation) => affiliation.type === 'Organization' && affiliation.id === suggestion)
-          )}
-        />
-      </>
+      </Box>
+      {affiliationToVerify && (
+        <Typography paragraph>
+          {t('registration.contributors.prefilled_affiliation')}: <b>{affiliationToVerify}</b>
+        </Typography>
+      )}
+      <Typography variant="h3" component="h2" sx={{ marginBottom: '1rem', fontWeight: 'normal' }}>
+        {t('common.select_institution')}
+      </Typography>
+      <SelectInstitutionForm
+        addAffiliation={addAffiliation}
+        onClose={toggleAffiliationModal}
+        suggestedInstitutions={getDistinctContributorUnits(values.entityDescription?.contributors ?? []).filter(
+          (suggestion) =>
+            !affiliations.some((affiliation) => affiliation.type === 'Organization' && affiliation.id === suggestion)
+        )}
+      />
     </Modal>
   );
 };

--- a/src/pages/registration/contributors_tab/components/AddAffiliationModal.tsx
+++ b/src/pages/registration/contributors_tab/components/AddAffiliationModal.tsx
@@ -1,0 +1,122 @@
+import { Box, Typography } from '@mui/material';
+import { useFormikContext } from 'formik';
+import { Trans, useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
+import { SelectInstitutionForm } from '../../../../components/institution/SelectInstitutionForm';
+import { Modal } from '../../../../components/Modal';
+import { setNotification } from '../../../../redux/notificationSlice';
+import { Affiliation } from '../../../../types/contributor.types';
+import { SpecificContributorFieldNames } from '../../../../types/publicationFieldNames';
+import { Registration } from '../../../../types/registration.types';
+import { getDistinctContributorUnits } from '../../../../utils/institutions-helpers';
+
+interface AddAffiliationModalProps {
+  openAffiliationModal: boolean;
+  setAffiliationToVerify: (val: string) => void;
+  toggleAffiliationModal: () => void;
+  authorName: string;
+  affiliationToVerify: string;
+  affiliations?: Affiliation[];
+  baseFieldName: string;
+}
+
+export const AddAffiliationModal = ({
+  openAffiliationModal,
+  setAffiliationToVerify,
+  toggleAffiliationModal,
+  affiliationToVerify,
+  authorName,
+  affiliations = [],
+  baseFieldName,
+}: AddAffiliationModalProps) => {
+  const { t } = useTranslation();
+  const { setFieldValue, values } = useFormikContext<Registration>();
+  const dispatch = useDispatch();
+
+  const addAffiliation = (newAffiliationId: string) => {
+    if (!newAffiliationId) {
+      return;
+    }
+
+    // Avoid adding same unit twice
+    if (
+      affiliations.some((affiliation) => affiliation.type === 'Organization' && affiliation.id === newAffiliationId)
+    ) {
+      dispatch(setNotification({ message: t('registration.contributors.add_duplicate_affiliation'), variant: 'info' }));
+      return;
+    }
+
+    const addedAffiliation: Affiliation = {
+      type: 'Organization',
+      id: newAffiliationId,
+    };
+
+    let updatedAffiliations = [...affiliations]; // Must spread affiliations in order to keep changes when switching tab
+
+    if (affiliationToVerify) {
+      // Verify affiliation
+      const affiliationIndex = updatedAffiliations.findIndex(
+        (affiliation) => affiliation.type === 'UnconfirmedOrganization' && affiliation.name === affiliationToVerify
+      );
+      updatedAffiliations[affiliationIndex] = addedAffiliation;
+    } else {
+      // Add new affiliation
+      if (updatedAffiliations) {
+        updatedAffiliations.push(addedAffiliation);
+      } else {
+        updatedAffiliations = [addedAffiliation];
+      }
+    }
+
+    setFieldValue(`${baseFieldName}.${SpecificContributorFieldNames.Affiliations}`, updatedAffiliations);
+    toggleAffiliationModal();
+  };
+
+  return (
+    <Modal
+      open={openAffiliationModal}
+      onClose={() => {
+        setAffiliationToVerify('');
+        toggleAffiliationModal();
+      }}
+      maxWidth="md"
+      fullWidth={true}
+      headingText={t('registration.contributors.add_new_affiliation')}
+      dataTestId="affiliation-modal">
+      <>
+        <Trans
+          i18nKey="registration.contributors.add_new_affiliation_helper_text"
+          components={[<Typography paragraph />]}
+        />
+        <Box
+          sx={{
+            bgcolor: 'secondary.main',
+            borderRadius: '0.25rem',
+            padding: '0.5rem 0.75rem',
+            marginBottom: '2rem',
+          }}>
+          {' '}
+          <Typography>
+            {t('common.contributor')}: <b>{authorName}</b>
+          </Typography>
+        </Box>
+        {affiliationToVerify && (
+          <Typography paragraph>
+            {t('registration.contributors.prefilled_affiliation')}: <b>{affiliationToVerify}</b>
+          </Typography>
+        )}
+        <Typography variant="h3" component="h2" sx={{ marginBottom: '1rem', fontWeight: 'normal' }}>
+          {t('common.select_institution')}
+        </Typography>
+        <SelectInstitutionForm
+          addAffiliation={addAffiliation}
+          onClose={toggleAffiliationModal}
+          suggestedInstitutions={getDistinctContributorUnits(values.entityDescription?.contributors ?? []).filter(
+            (suggestion) =>
+              !affiliations.some((affiliation) => affiliation.type === 'Organization' && affiliation.id === suggestion)
+          )}
+        />
+      </>
+    </Modal>
+  );
+};

--- a/src/pages/registration/contributors_tab/components/AddAffiliationModal.tsx
+++ b/src/pages/registration/contributors_tab/components/AddAffiliationModal.tsx
@@ -103,7 +103,7 @@ export const AddAffiliationModal = ({
           {t('registration.contributors.prefilled_affiliation')}: <b>{affiliationToVerify}</b>
         </Typography>
       )}
-      <Typography variant="h3" component="h2" sx={{ marginBottom: '1rem', fontWeight: 'normal' }}>
+      <Typography variant="h3" sx={{ marginBottom: '1rem', fontWeight: 'normal' }}>
         {t('common.select_institution')}
       </Typography>
       <SelectInstitutionForm

--- a/src/pages/registration/contributors_tab/components/AffiliationsCell.tsx
+++ b/src/pages/registration/contributors_tab/components/AffiliationsCell.tsx
@@ -1,19 +1,15 @@
 import AddIcon from '@mui/icons-material/AddCircleOutline';
-import { Box, Button, Typography } from '@mui/material';
+import { Box, Button } from '@mui/material';
 import { useFormikContext } from 'formik';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDispatch } from 'react-redux';
-import { Modal } from '../../../../components/Modal';
 import { OrganizationBox } from '../../../../components/institution/OrganizationBox';
-import { SelectInstitutionForm } from '../../../../components/institution/SelectInstitutionForm';
 import { UnconfirmedOrganizationBox } from '../../../../components/institution/UnconfirmedOrganizationBox';
-import { setNotification } from '../../../../redux/notificationSlice';
 import { Affiliation } from '../../../../types/contributor.types';
 import { SpecificContributorFieldNames } from '../../../../types/publicationFieldNames';
 import { Registration } from '../../../../types/registration.types';
 import { dataTestId } from '../../../../utils/dataTestIds';
-import { getDistinctContributorUnits } from '../../../../utils/institutions-helpers';
+import { AddAffiliationModal } from './AddAffiliationModal';
 
 interface AffiliationsCellProps {
   affiliations?: Affiliation[];
@@ -23,8 +19,7 @@ interface AffiliationsCellProps {
 
 export const AffiliationsCell = ({ affiliations = [], authorName, baseFieldName }: AffiliationsCellProps) => {
   const { t } = useTranslation();
-  const dispatch = useDispatch();
-  const { setFieldValue, values } = useFormikContext<Registration>();
+  const { setFieldValue } = useFormikContext<Registration>();
   const [openAffiliationModal, setOpenAffiliationModal] = useState(false);
   const [affiliationToVerify, setAffiliationToVerify] = useState('');
 
@@ -32,44 +27,6 @@ export const AffiliationsCell = ({ affiliations = [], authorName, baseFieldName 
 
   const onIdentifyAffiliationClick = (affiliationString: string) => {
     setAffiliationToVerify(affiliationString);
-    toggleAffiliationModal();
-  };
-
-  const addAffiliation = (newAffiliationId: string) => {
-    if (!newAffiliationId) {
-      return;
-    }
-
-    // Avoid adding same unit twice
-    if (
-      affiliations.some((affiliation) => affiliation.type === 'Organization' && affiliation.id === newAffiliationId)
-    ) {
-      dispatch(setNotification({ message: t('registration.contributors.add_duplicate_affiliation'), variant: 'info' }));
-      return;
-    }
-
-    const addedAffiliation: Affiliation = {
-      type: 'Organization',
-      id: newAffiliationId,
-    };
-
-    let updatedAffiliations = [...affiliations]; // Must spread affiliations in order to keep changes when switching tab
-    if (affiliationToVerify) {
-      // Verify affiliation
-      const affiliationIndex = updatedAffiliations.findIndex(
-        (affiliation) => affiliation.type === 'UnconfirmedOrganization' && affiliation.name === affiliationToVerify
-      );
-      updatedAffiliations[affiliationIndex] = addedAffiliation;
-    } else {
-      // Add new affiliation
-      if (updatedAffiliations) {
-        updatedAffiliations.push(addedAffiliation);
-      } else {
-        updatedAffiliations = [addedAffiliation];
-      }
-    }
-
-    setFieldValue(`${baseFieldName}.${SpecificContributorFieldNames.Affiliations}`, updatedAffiliations);
     toggleAffiliationModal();
   };
 
@@ -123,39 +80,15 @@ export const AffiliationsCell = ({ affiliations = [], authorName, baseFieldName 
         onClick={toggleAffiliationModal}>
         {t('registration.contributors.add_affiliation')}
       </Button>
-
-      {/* Modal for adding affiliation */}
-      <Modal
-        open={openAffiliationModal}
-        onClose={() => {
-          setAffiliationToVerify('');
-          toggleAffiliationModal();
-        }}
-        maxWidth="sm"
-        fullWidth={true}
-        headingText={t('common.select_institution')}
-        dataTestId="affiliation-modal">
-        <>
-          <Typography paragraph>
-            {t('common.name')}: <b>{authorName}</b>
-          </Typography>
-          {affiliationToVerify && (
-            <Typography paragraph>
-              {t('registration.contributors.prefilled_affiliation')}: <b>{affiliationToVerify}</b>
-            </Typography>
-          )}
-          <SelectInstitutionForm
-            onSubmit={addAffiliation}
-            onClose={toggleAffiliationModal}
-            suggestedInstitutions={getDistinctContributorUnits(values.entityDescription?.contributors ?? []).filter(
-              (suggestion) =>
-                !affiliations.some(
-                  (affiliation) => affiliation.type === 'Organization' && affiliation.id === suggestion
-                )
-            )}
-          />
-        </>
-      </Modal>
+      <AddAffiliationModal
+        openAffiliationModal={openAffiliationModal}
+        affiliationToVerify={affiliationToVerify}
+        setAffiliationToVerify={setAffiliationToVerify}
+        toggleAffiliationModal={toggleAffiliationModal}
+        authorName={authorName}
+        affiliations={affiliations}
+        baseFieldName={baseFieldName}
+      />
     </Box>
   );
 };

--- a/src/pages/search/advanced_search/OrganizationHierarchyFilter.tsx
+++ b/src/pages/search/advanced_search/OrganizationHierarchyFilter.tsx
@@ -1,10 +1,4 @@
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import RadioButtonCheckedIcon from '@mui/icons-material/RadioButtonChecked';
-import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
 import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
   Autocomplete,
   Box,
   Button,
@@ -21,11 +15,12 @@ import { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { ResultParam } from '../../../api/searchApi';
+import { OrganizationAccordion } from '../../../components/OrganizationAccordion';
 import { OrganizationRenderOption } from '../../../components/OrganizationRenderOption';
 import { Organization } from '../../../types/organization.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { getIdentifierFromId } from '../../../utils/general-helpers';
-import { getAllChildOrganizations, getSortedSubUnits } from '../../../utils/institutions-helpers';
+import { getSortedSubUnits } from '../../../utils/institutions-helpers';
 import { getLanguageString } from '../../../utils/translation-helpers';
 
 interface OrganizationHierarchyFilterProps extends Pick<DialogProps, 'open'> {
@@ -102,6 +97,8 @@ export const OrganizationHierarchyFilter = ({ organization, open, onClose }: Org
               searchId={searchId}
               selectedId={selectedId}
               setSelectedId={setSelectedId}
+              displayOrgId
+              displaySubunitsCount
             />
           ))}
         </Box>
@@ -128,99 +125,5 @@ export const OrganizationHierarchyFilter = ({ organization, open, onClose }: Org
         </Button>
       </DialogActions>
     </Dialog>
-  );
-};
-
-interface OrganizationAccordionProps {
-  organization: Organization;
-  searchId: string;
-  includeAllSubunits?: boolean;
-  level?: number;
-  selectedId: string;
-  setSelectedId: (id: string) => void;
-}
-
-const OrganizationAccordion = ({
-  organization,
-  searchId,
-  level = 0,
-  includeAllSubunits = false,
-  selectedId,
-  setSelectedId,
-}: OrganizationAccordionProps) => {
-  const { t } = useTranslation();
-
-  const isSearchedUnit = organization.id === searchId;
-  const isSelectedUnit = organization.id === selectedId;
-
-  const allSubunits = getAllChildOrganizations(organization.hasPart);
-
-  const [expandedState, setExpandedState] = useState(
-    isSelectedUnit || allSubunits.some((subunit) => subunit.id === selectedId)
-  );
-
-  if (!!searchId && !isSearchedUnit && !includeAllSubunits) {
-    if (!allSubunits.some((subunit) => subunit.id === searchId)) {
-      return null; // Hide this element if the searched ID is not a part of this unit
-    }
-  }
-
-  const expanded = expandedState || (!!searchId && !includeAllSubunits);
-  const subunitsCount = organization.hasPart?.length ?? 0;
-
-  return (
-    <Accordion
-      data-testid={dataTestId.editor.organizationAccordion(organization.id)}
-      elevation={2}
-      disableGutters
-      sx={{
-        bgcolor: level % 2 === 0 ? 'secondary.main' : 'secondary.light',
-        ml: { xs: undefined, md: level > 0 ? '1rem' : 0 },
-      }}
-      expanded={expanded}
-      onChange={() => {
-        setExpandedState(!expandedState);
-        setSelectedId(organization.id);
-      }}>
-      <AccordionSummary expandIcon={<ExpandMoreIcon sx={{ visibility: subunitsCount > 0 ? null : 'hidden' }} />}>
-        <Box
-          sx={{
-            width: '100%',
-            display: 'grid',
-            gap: '0.25rem 1rem',
-            gridTemplateColumns: {
-              xs: 'auto 1fr',
-              lg: 'auto 3fr 3fr 1fr 1fr',
-              alignItems: 'center',
-            },
-            py: '0.25rem',
-            '& > p': { fontWeight: isSearchedUnit ? 700 : undefined },
-          }}>
-          {isSelectedUnit ? <RadioButtonCheckedIcon fontSize="small" /> : <RadioButtonUncheckedIcon fontSize="small" />}
-          <Typography>{getLanguageString(organization.labels, 'nb')}</Typography>
-          <Typography sx={{ gridColumn: { xs: '1/3', lg: '3/4' } }}>{organization.labels['en']}</Typography>
-          <Typography sx={{ gridColumn: { xs: '1/3', lg: '4/5' } }}>{getIdentifierFromId(organization.id)}</Typography>
-          <Typography sx={{ gridColumn: { xs: '1/3', lg: '5/6' } }}>
-            {subunitsCount > 0 && t('editor.subunits_count', { count: subunitsCount })}
-          </Typography>
-        </Box>
-      </AccordionSummary>
-      {subunitsCount > 0 && (
-        <AccordionDetails sx={{ pr: 0 }}>
-          {expanded &&
-            organization.hasPart?.map((subunit) => (
-              <OrganizationAccordion
-                key={subunit.id}
-                organization={subunit}
-                level={level + 1}
-                searchId={searchId}
-                includeAllSubunits={includeAllSubunits || isSearchedUnit}
-                selectedId={selectedId}
-                setSelectedId={setSelectedId}
-              />
-            ))}
-        </AccordionDetails>
-      )}
-    </Accordion>
   );
 };

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -168,6 +168,7 @@
     "click_to_show_all": "Trykk for å vise alt",
     "close": "Lukk",
     "close_forever": "Lukk og ikke vis igjen",
+    "contributor": "Bidragsyter",
     "country": "Land",
     "create": "Opprett",
     "created": "Opprettet",
@@ -1125,6 +1126,8 @@
     "citation_points_to": "Siteringen viser til",
     "contributors": {
       "add_affiliation": "Legg til tilknytning",
+      "add_new_affiliation": "Legg til ny tilknytning",
+      "add_new_affiliation_helper_text": "<0>Det er kun institusjoner som forskningen er gjennomført i samarbeid med som skal legges til som tilknytning til bidragsyteren.</0> <0>Legg til tilknytning til bidragsyteren ved å først søke opp institusjonen og eventuelt enhet.</0> <0>Tilhører bidragsyteren flere forskjellige enheter under samme institusjon så må du legge til dette som ny tilknytning.</0>",
       "add_contributor": "Legg til bidragsyter",
       "add_duplicate_affiliation": "Tilknytningen er allerede lagt til",
       "add_new_contributor": "Legg til ny bidragsyter",


### PR DESCRIPTION
# Description

Link to Jira issue: [New flow for "Add affiliation"](https://unit.atlassian.net/browse/NP-46798)

**New flow for "Add affiliation"**

When in the contributor view of a registration, this is the modal that pops up when you click the "Legg til tilknytning"-button:

![image](https://github.com/BIBSYSDEV/NVA-Frontend/assets/1130244/6fe9bb24-c104-4d14-8411-7273f7102c10)

**Old design:**

![image](https://github.com/BIBSYSDEV/NVA-Frontend/assets/1130244/93d707ba-6357-40c2-8cd5-665c41720b73)

![image](https://github.com/BIBSYSDEV/NVA-Frontend/assets/1130244/d5c26d00-b408-4bb3-a40b-9fd9166f052b)

New design:

![image](https://github.com/BIBSYSDEV/NVA-Frontend/assets/1130244/5ffc045c-52bd-4cde-9fd6-ccb6111e4b89)

You can either search for a faculty / institute and select the search result:

![image](https://github.com/BIBSYSDEV/NVA-Frontend/assets/1130244/9e4b75ca-219e-4e5c-945a-69f6b87d9caa)

![image](https://github.com/BIBSYSDEV/NVA-Frontend/assets/1130244/bf86ac2a-aabd-46e9-bb12-e98a82f7bcbf)

Or you can select it from the list of choices:

![image](https://github.com/BIBSYSDEV/NVA-Frontend/assets/1130244/44dfe358-c8f3-4d4f-93ad-691b425e0a08)

**Implementation**

Search for institution in "Avansert søk" should be tested as well, since it is now sharing a component with this code.

Note:

When searching for insitution for the first time we get an error in the console. This was there before this PR as well, but we should have a look at it in a later issue / bug:

![image](https://github.com/BIBSYSDEV/NVA-Frontend/assets/1130244/dd7261c0-eb47-4e29-9084-09c60d0ba438)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
