### PR TITLE
Np 47021 avoid prefilling viewing scope

### DIFF
--- a/src/components/TicketListDefaultValuesWrapper.tsx
+++ b/src/components/TicketListDefaultValuesWrapper.tsx
@@ -1,58 +1,30 @@
 import { ReactNode, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
-import { fetchOrganizations } from '../api/cristinApi';
-import { fetchUser } from '../api/roleApi';
 import { TicketSearchParam } from '../api/searchApi';
 import { RootState } from '../redux/store';
 import { TicketStatus } from '../types/publication_types/ticket.types';
-import { getAllChildOrganizations } from '../utils/institutions-helpers';
 
 interface TicketListDefaultValuesWrapperProps {
   children: ReactNode;
 }
 
 export const TicketListDefaultValuesWrapper = ({ children }: TicketListDefaultValuesWrapperProps) => {
-  const { t } = useTranslation();
   const user = useSelector((store: RootState) => store.user);
   const nvaUsername = user?.nvaUsername ?? '';
 
   const history = useHistory();
 
-  const institutionUserQuery = useQuery({
-    enabled: !!nvaUsername,
-    queryKey: ['user', nvaUsername],
-    queryFn: () => fetchUser(nvaUsername),
-    meta: { errorMessage: t('feedback.error.get_person') },
-  });
-  const areasOfResponsibilityIds = institutionUserQuery.data?.viewingScope?.includedUnits ?? [];
-
-  const organizationQuery = useQuery({
-    enabled: areasOfResponsibilityIds.length > 0,
-    queryKey: ['organizations', areasOfResponsibilityIds],
-    queryFn: async () => fetchOrganizations(areasOfResponsibilityIds),
-    meta: { errorMessage: t('feedback.error.get_institution') },
-  });
-
   useEffect(() => {
-    if (!organizationQuery.data || history.location.search) {
+    if (history.location.search) {
       return;
     }
 
-    const organizations = organizationQuery.data;
-    const organizationsWithSubUnits = getAllChildOrganizations(organizations);
-
     const searchParams = new URLSearchParams(history.location.search);
-    searchParams.set(
-      TicketSearchParam.OrganizationId,
-      organizationsWithSubUnits.map((org) => org.identifier).join(',')
-    );
     searchParams.set(TicketSearchParam.Assignee, nvaUsername);
     searchParams.set(TicketSearchParam.Status, 'Pending' as TicketStatus);
     history.push({ search: searchParams.toString() });
-  }, [organizationQuery.data, history, nvaUsername]);
+  }, [history, nvaUsername]);
 
   return <>{children}</>;
 };

--- a/src/pages/messages/TasksPage.tsx
+++ b/src/pages/messages/TasksPage.tsx
@@ -79,12 +79,10 @@ const TasksPage = () => {
     .filter(([, selected]) => selected)
     .map(([key]) => key);
 
-  const numberOfResultsGivenViewingScope = searchParams.get(TicketSearchParam.OrganizationId) ? rowsPerPage : 0;
-
   const ticketSearchParams: FetchTicketsParams = {
     aggregation: 'all',
     query: searchParams.get(TicketSearchParam.Query),
-    results: numberOfResultsGivenViewingScope,
+    results: rowsPerPage,
     from: (page - 1) * rowsPerPage,
     orderBy: searchParams.get(TicketSearchParam.OrderBy) as 'createdDate' | null,
     sortOrder: searchParams.get(TicketSearchParam.SortOrder) as 'asc' | 'desc' | null,

--- a/src/pages/messages/TasksPage.tsx
+++ b/src/pages/messages/TasksPage.tsx
@@ -79,6 +79,8 @@ const TasksPage = () => {
     .filter(([, selected]) => selected)
     .map(([key]) => key);
 
+  const organizationIdParam = searchParams.get(TicketSearchParam.OrganizationId);
+
   const ticketSearchParams: FetchTicketsParams = {
     aggregation: 'all',
     query: searchParams.get(TicketSearchParam.Query),
@@ -86,8 +88,8 @@ const TasksPage = () => {
     from: (page - 1) * rowsPerPage,
     orderBy: searchParams.get(TicketSearchParam.OrderBy) as 'createdDate' | null,
     sortOrder: searchParams.get(TicketSearchParam.SortOrder) as 'asc' | 'desc' | null,
-    organizationId: searchParams.get(TicketSearchParam.OrganizationId),
-    excludeSubUnits: true,
+    organizationId: organizationIdParam,
+    excludeSubUnits: organizationIdParam ? true : undefined,
     assignee: searchParams.get(TicketSearchParam.Assignee),
     status: searchParams.get(TicketSearchParam.Status),
     type: selectedTicketTypes.join(','),


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-47021

En enkel fiks for at noen med ansvar for UiO skal kunne søke opp tickets igjen. Skulle helst gjort samme jobben her som har blitt gjort for UiO ved å bruke egen hook `useTicketSearchParams()` e.l., men prioriterer ikke den jobben akkurat nå

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
