### PR TITLE
Subunit search now searches in english as well

### DIFF
--- a/src/components/institution/SelectInstitutionForm.tsx
+++ b/src/components/institution/SelectInstitutionForm.tsx
@@ -167,13 +167,10 @@ export const SelectInstitutionForm = ({
                           setSelectedSubunitId(value?.id ?? '');
                         }}
                         filterOptions={(options, state) =>
-                          options.filter(
-                            (option) =>
-                              state
-                                .getOptionLabel(option)
-                                .toLocaleLowerCase()
-                                .includes(state.inputValue.toLocaleLowerCase()) ||
-                              option.labels['en']?.toLocaleLowerCase().includes(state.inputValue.toLocaleLowerCase())
+                          options.filter((option) =>
+                            Object.values(option.labels).some((label) =>
+                              label.toLowerCase().includes(state.inputValue.toLowerCase())
+                            )
                           )
                         }
                         renderInput={(params) => (

--- a/src/components/institution/SelectInstitutionForm.tsx
+++ b/src/components/institution/SelectInstitutionForm.tsx
@@ -167,11 +167,13 @@ export const SelectInstitutionForm = ({
                           setSelectedSubunitId(value?.id ?? '');
                         }}
                         filterOptions={(options, state) =>
-                          options.filter((option) =>
-                            state
-                              .getOptionLabel(option)
-                              .toLocaleLowerCase()
-                              .includes(state.inputValue.toLocaleLowerCase())
+                          options.filter(
+                            (option) =>
+                              state
+                                .getOptionLabel(option)
+                                .toLocaleLowerCase()
+                                .includes(state.inputValue.toLocaleLowerCase()) ||
+                              option.labels['en']?.toLocaleLowerCase().includes(state.inputValue.toLocaleLowerCase())
                           )
                         }
                         renderInput={(params) => (


### PR DESCRIPTION
# Description

Link to Jira: [Search for english subunits name](https://unit.atlassian.net/browse/NP-47014)

Earlier when searching for subunits in the affiliations view, you would get no hits if you searched for english words while having selected norwegian as your language:

![image](https://github.com/BIBSYSDEV/NVA-Frontend/assets/1130244/b93ff4ac-2fd7-46c5-a5ac-a6f313c79fff)

But now you do:

![image](https://github.com/BIBSYSDEV/NVA-Frontend/assets/1130244/44e68e5b-987d-478b-805b-24f95166bc52)

### Implementation

I added a hardcoded check for english labels as well as the already existing check for the selected language (see commit 1), but then I found out this was already done in advanced search, so I copied that solution because it was better (it included search for all languages, not just english).

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
