### PR TITLE
Np 46935 go back to import candidate search

### DIFF
--- a/src/pages/basic_data/BasicDataPage.tsx
+++ b/src/pages/basic_data/BasicDataPage.tsx
@@ -19,6 +19,7 @@ import {
 import { SideMenu, StyledMinimizedMenuButton } from '../../components/SideMenu';
 import { RootState } from '../../redux/store';
 import { ImportCandidateStatus } from '../../types/importCandidate.types';
+import { PreviousSearchLocationState } from '../../types/locationState.types';
 import { dataTestId } from '../../utils/dataTestIds';
 import { PrivateRoute } from '../../utils/routes/Routes';
 import { UrlPathTemplate, getAdminInstitutionPath } from '../../utils/urlPaths';
@@ -42,7 +43,7 @@ const BasicDataPage = () => {
   const isInstitutionAdmin = !!user?.customerId && user.isInstitutionAdmin;
   const isAppAdmin = !!user?.customerId && user.isAppAdmin;
   const isInternalImporter = !!user?.customerId && user.isInternalImporter;
-  const location = useLocation();
+  const location = useLocation<PreviousSearchLocationState>();
   const currentPath = location.pathname.replace(/\/$/, ''); // Remove trailing slash
 
   const newCustomerIsSelected = currentPath === UrlPathTemplate.BasicDataInstitutions && location.search === '?id=new';
@@ -57,7 +58,11 @@ const BasicDataPage = () => {
         aria-labelledby="basic-data-title"
         expanded={expandedMenu}
         minimizedMenu={
-          <Link to={UrlPathTemplate.BasicDataCentralImport}>
+          <Link
+            to={{
+              pathname: UrlPathTemplate.BasicDataCentralImport,
+              search: location.state?.previousSearch,
+            }}>
             <StyledMinimizedMenuButton title={t('basic_data.basic_data')}>
               <BusinessCenterIcon />
             </StyledMinimizedMenuButton>

--- a/src/pages/basic_data/app_admin/central_import/CentralImportDuplicationCheckPage.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportDuplicationCheckPage.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import { fetchImportCandidate, fetchRegistration, updateImportCandidateStatus } from '../../../../api/registrationApi';
 import { FetchImportCandidatesParams, fetchImportCandidates } from '../../../../api/searchApi';
 import { ConfirmMessageDialog } from '../../../../components/ConfirmMessageDialog';
@@ -13,6 +13,7 @@ import { RegistrationListItemContent } from '../../../../components/Registration
 import { BackgroundDiv, SearchListItem } from '../../../../components/styled/Wrappers';
 import { setNotification } from '../../../../redux/notificationSlice';
 import { emptyDuplicateSearchFilter } from '../../../../types/duplicateSearchTypes';
+import { PreviousSearchLocationState } from '../../../../types/locationState.types';
 import { getIdentifierFromId } from '../../../../utils/general-helpers';
 import { stringIncludesMathJax, typesetMathJax } from '../../../../utils/mathJaxHelpers';
 import {
@@ -30,6 +31,7 @@ import { DuplicateSearchFilterForm } from './DuplicateSearchFilterForm';
 export const CentralImportDuplicationCheckPage = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
+  const location = useLocation<PreviousSearchLocationState>();
   const { identifier } = useParams<IdentifierParams>();
   const [duplicateSearchFilters, setDuplicateSearchFilters] = useState(emptyDuplicateSearchFilter);
   const [registrationIdentifier, setRegistrationIdentifier] = useState('');
@@ -223,7 +225,11 @@ export const CentralImportDuplicationCheckPage = () => {
           )}
 
           <Divider sx={{ my: '1rem' }} />
-          <Link to={UrlPathTemplate.BasicDataCentralImport}>
+          <Link
+            to={{
+              pathname: UrlPathTemplate.BasicDataCentralImport,
+              search: location.state?.previousSearch,
+            }}>
             <Button size="small" fullWidth variant="outlined">
               {t('common.cancel')}
             </Button>

--- a/src/pages/basic_data/app_admin/central_import/CentralImportResultItem.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportResultItem.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { ContributorIndicators } from '../../../../components/ContributorIndicators';
 import { SearchListItem } from '../../../../components/styled/Wrappers';
 import { ImportCandidateSummary } from '../../../../types/importCandidate.types';
+import { PreviousSearchLocationState } from '../../../../types/locationState.types';
 import { dataTestId } from '../../../../utils/dataTestIds';
 import { getIdentifierFromId, getTimePeriodString } from '../../../../utils/general-helpers';
 import { getTitleString } from '../../../../utils/registration-helpers';
@@ -44,7 +45,12 @@ export const CentralImportResultItem = ({ importCandidate }: CentralImportResult
           </Typography>
         )}
         <Typography gutterBottom sx={{ fontSize: '1rem', fontWeight: '600', wordWrap: 'break-word' }}>
-          <MuiLink component={Link} to={getImportCandidatePath(getIdentifierFromId(importCandidate.id))}>
+          <MuiLink
+            component={Link}
+            to={{
+              pathname: getImportCandidatePath(getIdentifierFromId(importCandidate.id)),
+              state: { previousSearch: location.search } satisfies PreviousSearchLocationState,
+            }}>
             {getTitleString(importCandidate.mainTitle)}
           </MuiLink>
         </Typography>

--- a/src/pages/messages/TasksPage.tsx
+++ b/src/pages/messages/TasksPage.tsx
@@ -18,7 +18,7 @@ import { SideMenu, StyledMinimizedMenuButton } from '../../components/SideMenu';
 import { TicketListDefaultValuesWrapper } from '../../components/TicketListDefaultValuesWrapper';
 import { StyledTicketSearchFormGroup } from '../../components/styled/Wrappers';
 import { RootState } from '../../redux/store';
-import { TasksPageLocationState } from '../../types/locationState.types';
+import { PreviousSearchLocationState } from '../../types/locationState.types';
 import { ROWS_PER_PAGE_OPTIONS } from '../../utils/constants';
 import { dataTestId } from '../../utils/dataTestIds';
 import { PrivateRoute } from '../../utils/routes/Routes';
@@ -39,7 +39,7 @@ export const StyledSearchModeButton = styled(LinkButton)({
 
 const TasksPage = () => {
   const { t } = useTranslation();
-  const history = useHistory<TasksPageLocationState>();
+  const history = useHistory<PreviousSearchLocationState>();
   const user = useSelector((store: RootState) => store.user);
   const isSupportCurator = !!user?.isSupportCurator;
   const isDoiCurator = !!user?.isDoiCurator;

--- a/src/pages/messages/components/NviMenuContent.tsx
+++ b/src/pages/messages/components/NviMenuContent.tsx
@@ -16,7 +16,7 @@ import { useFetchNviCandidates } from '../../../api/hooks/useFetchNviCandidates'
 import { NviCandidatesSearchParam } from '../../../api/searchApi';
 import { NavigationListAccordion } from '../../../components/NavigationListAccordion';
 import { StyledTicketSearchFormGroup } from '../../../components/styled/Wrappers';
-import { TasksPageLocationState } from '../../../types/locationState.types';
+import { PreviousSearchLocationState } from '../../../types/locationState.types';
 import { NviCandidateSearchStatus } from '../../../types/nvi.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { useNviCandidatesParams } from '../../../utils/hooks/useNviCandidatesParams';
@@ -34,7 +34,7 @@ const StyledNviStatusBox = styled(Box)({
 
 export const NviMenuContent = () => {
   const { t } = useTranslation();
-  const history = useHistory<TasksPageLocationState>();
+  const history = useHistory<PreviousSearchLocationState>();
   const searchParams = new URLSearchParams(history.location.search);
 
   const isOnNviCandidatesPage = history.location.pathname === UrlPathTemplate.TasksNvi;

--- a/src/pages/messages/components/TicketListItem.tsx
+++ b/src/pages/messages/components/TicketListItem.tsx
@@ -7,7 +7,7 @@ import { updateTicket } from '../../../api/registrationApi';
 import { RegistrationListItemContent } from '../../../components/RegistrationList';
 import { SearchListItem } from '../../../components/styled/Wrappers';
 import { RootState } from '../../../redux/store';
-import { TasksPageLocationState } from '../../../types/locationState.types';
+import { PreviousSearchLocationState } from '../../../types/locationState.types';
 import { ExpandedPublishingTicket, ExpandedTicket } from '../../../types/publication_types/ticket.types';
 import { Registration, emptyRegistration } from '../../../types/registration.types';
 import { getInitials, getTimePeriodString } from '../../../utils/general-helpers';
@@ -75,7 +75,7 @@ export const TicketListItem = ({ ticket }: TicketListItemProps) => {
               : window.location.pathname === UrlPathTemplate.MyPageMyMessages
                 ? getMyMessagesRegistrationPath(identifier)
                 : '',
-          state: { previousSearch: window.location.search } satisfies TasksPageLocationState,
+          state: { previousSearch: window.location.search } satisfies PreviousSearchLocationState,
         }}
         onClick={() => {
           if (!viewedByUser) {

--- a/src/types/locationState.types.ts
+++ b/src/types/locationState.types.ts
@@ -10,11 +10,11 @@ export interface RegistrationFormLocationState extends PreviousPathLocationState
   highestValidatedTab?: HighestTouchedTab;
 }
 
-export interface TasksPageLocationState {
+export interface PreviousSearchLocationState {
   previousSearch?: string;
 }
 
-export interface NviCandidatePageLocationState extends TasksPageLocationState {
+export interface NviCandidatePageLocationState extends PreviousSearchLocationState {
   candidateOffsetState?: {
     currentOffset: number;
     nviQueryParams: FetchNviCandidatesParams;


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46935

Dette er del 1 av oppgaven. Nå vil søket husket når man går rett inn og rett ut på en kandidat.

I del 2 skal vi også huske søket etter man har fullført en import eller merget en kandidat. Ser at det blir mer komplekst så må tenke litt mer på tilnærming der, siden det invloverer flere navigeringer i ulike retninger 🤔. Resten kommer derfor som egen PR.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
