### PR TITLE
NP-46702 Allow all book and report types for general chapters

### DIFF
--- a/src/pages/registration/resource_type_tab/sub_type_forms/ChapterForm.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/ChapterForm.tsx
@@ -12,7 +12,7 @@ import { NpiDisciplineField } from '../components/NpiDisciplineField';
 import { NviValidation } from '../components/NviValidation';
 import { SearchContainerField } from '../components/SearchContainerField';
 
-const anthologyChapterTypes: string[] = [
+const generalChapterTypes: string[] = [
   ChapterType.AcademicChapter,
   ChapterType.NonFictionChapter,
   ChapterType.PopularScienceChapter,
@@ -21,6 +21,8 @@ const anthologyChapterTypes: string[] = [
   ChapterType.Introduction,
   ChapterType.ExhibitionCatalogChapter,
 ];
+
+const generalChapterParentTypes = [...Object.values(BookType), ...Object.values(ReportType)];
 
 export const ChapterForm = () => {
   const { t } = useTranslation();
@@ -35,7 +37,7 @@ export const ChapterForm = () => {
         <Box sx={{ display: 'flex', justifyContent: 'center', gap: '1rem' }}>
           <InfoIcon color="primary" />
           <Typography variant="body1" gutterBottom>
-            {anthologyChapterTypes.includes(instanceType)
+            {generalChapterTypes.includes(instanceType)
               ? t('registration.resource_type.chapter.info_anthology')
               : instanceType === ChapterType.ConferenceAbstract
                 ? t('registration.resource_type.chapter.info_book_of_abstracts')
@@ -45,10 +47,10 @@ export const ChapterForm = () => {
           </Typography>
         </Box>
 
-        {anthologyChapterTypes.includes(instanceType) ? (
+        {generalChapterTypes.includes(instanceType) ? (
           <SearchContainerField
             fieldName={ResourceFieldNames.PublicationContextId}
-            searchSubtypes={[BookType.Anthology]}
+            searchSubtypes={generalChapterParentTypes}
             label={t('registration.resource_type.chapter.published_in')}
             placeholder={t('registration.resource_type.chapter.search_for_anthology')}
             dataTestId={dataTestId.registrationWizard.resourceType.partOfField}


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46702

Åpne for flere parent-typer når man registrerer kapittel. Dette kommer som krav da importen har mange poster som peker til andre typer enn vi har støtte for i dag. Dette vil kanskje føre til en renaming av typen "Innledning i antologi" til bare "Introduksjon" e.l., men det gjøres ikke i denne omgang da det ikke er avklart enda.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
