### PR TITLE
NP-46918 show custom artistic subtype

### DIFF
--- a/src/pages/public_registration/PublicPublicationInstance.tsx
+++ b/src/pages/public_registration/PublicPublicationInstance.tsx
@@ -98,7 +98,7 @@ export const PublicPublicationInstanceChapter = ({
   return pagesInterval ? <Typography>{pagesInterval}</Typography> : null;
 };
 
-const otherArtisticTypes = [
+const otherArtisticSubtypes = [
   DesignType.Other,
   ArchitectureType.Other,
   PerformingArtType.Other,
@@ -131,7 +131,7 @@ export const PublicPublicationInstanceArtistic = ({
                 : '';
 
   const typeString = subtype?.type
-    ? otherArtisticTypes.includes(subtype.type) && subtype.description
+    ? otherArtisticSubtypes.includes(subtype.type) && subtype.description
       ? subtype.description
       : t(`${i18nTypeBase}${subtype.type}` as any)
     : '';

--- a/src/pages/public_registration/PublicPublicationInstance.tsx
+++ b/src/pages/public_registration/PublicPublicationInstance.tsx
@@ -3,7 +3,15 @@ import { hyphenate } from 'isbn3';
 import { useTranslation } from 'react-i18next';
 import i18n from '../../translations/i18n';
 import { ArtisticType } from '../../types/publicationFieldNames';
-import { ArtisticPublicationInstance, DesignType } from '../../types/publication_types/artisticRegistration.types';
+import {
+  ArchitectureType,
+  ArtisticPublicationInstance,
+  DesignType,
+  LiteraryArtsType,
+  MovingPictureType,
+  PerformingArtType,
+  VisualArtType,
+} from '../../types/publication_types/artisticRegistration.types';
 import { BookPublicationInstance } from '../../types/publication_types/bookRegistration.types';
 import { ChapterPublicationInstance } from '../../types/publication_types/chapterRegistration.types';
 import { DegreePublicationInstance } from '../../types/publication_types/degreeRegistration.types';
@@ -90,6 +98,15 @@ export const PublicPublicationInstanceChapter = ({
   return pagesInterval ? <Typography>{pagesInterval}</Typography> : null;
 };
 
+const otherArtisticTypes = [
+  DesignType.Other,
+  ArchitectureType.Other,
+  PerformingArtType.Other,
+  MovingPictureType.Other,
+  VisualArtType.Other,
+  LiteraryArtsType.Other,
+];
+
 export const PublicPublicationInstanceArtistic = ({
   publicationInstance,
 }: {
@@ -114,7 +131,7 @@ export const PublicPublicationInstanceArtistic = ({
                 : '';
 
   const typeString = subtype?.type
-    ? subtype.type === DesignType.Other && subtype.description
+    ? otherArtisticTypes.includes(subtype.type) && subtype.description
       ? subtype.description
       : t(`${i18nTypeBase}${subtype.type}` as any)
     : '';


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46918

Vis navnet brukeren skriver inn når man velger "Annet" på valg av undertype for Kunstnerisk resultat. Tidligere virket dette bare for Design-typen.

Før:
![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/530ec0e5-617e-478c-baca-92b6472db60e)

Etter (Når bruker velger "annet" og oppgiv en verdi):
![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/5b485c50-93c1-4186-9dbc-79eb7905475c)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
