### PR TITLE
Update description tab styling

### DIFF
--- a/src/pages/registration/DescriptionPanel.tsx
+++ b/src/pages/registration/DescriptionPanel.tsx
@@ -83,7 +83,6 @@ export const DescriptionPanel = () => {
               variant="filled"
               fullWidth
               multiline
-              rows="4"
               label={t('registration.description.abstract')}
             />
           )}
@@ -99,7 +98,6 @@ export const DescriptionPanel = () => {
                   variant="filled"
                   fullWidth
                   multiline
-                  rows="4"
                   label={t('registration.description.alternative_abstract')}
                 />
               ) : null}
@@ -124,7 +122,6 @@ export const DescriptionPanel = () => {
             data-testid={dataTestId.registrationWizard.description.descriptionField}
             label={t('registration.description.description_of_content')}
             multiline
-            rows="4"
             fullWidth
             variant="filled"
           />

--- a/src/themes/mainTheme.ts
+++ b/src/themes/mainTheme.ts
@@ -183,11 +183,12 @@ export const mainTheme = createTheme(
     components: {
       MuiAutocomplete: {
         styleOverrides: {
+          inputRoot: {
+            gap: '0rem 0.5rem',
+          },
           tag: {
-            margin: '0.5rem 0',
-            '&:not(:last-child)': {
-              marginRight: '0.5rem',
-            },
+            marginTop: '0.4rem',
+            marginBottom: '0.4rem',
           },
         },
       },


### PR DESCRIPTION
# Description

Dukket opp en liten oppgave om å fikse småting på bidragsyter-fanen. Hovedproblemet er at det er knotete å rette sammendrag når man må scrolle mye. Også en liten sak hvor tags fikk unaturlig mye gap i noen tilfeller. Fant ikke noen veldig god løsning på sistnevnte, men mener det ble litt bedre.

Før:
![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/c75c5721-88ba-42fe-86ac-040ef8e8e8b4)

Etter:
![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/a3cc888c-5fa2-4bdb-88c7-d2b96d122658)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
