### PR TITLE
Keep selected NVI year when nnavigating between candidates and status page

### DIFF
--- a/src/pages/messages/components/NviMenuContent.tsx
+++ b/src/pages/messages/components/NviMenuContent.tsx
@@ -52,7 +52,7 @@ export const NviMenuContent = () => {
 
   const openCandidatesView = () => {
     if (!isOnNviCandidatesPage) {
-      history.push(UrlPathTemplate.TasksNvi);
+      history.push({ pathname: UrlPathTemplate.TasksNvi, search: searchParams.toString() });
     }
   };
 


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-46983

Løs feil hvor man mister valgt år når man trykker på et status-filter fra statussiden til NVI. Gjenbruker samme task som feilen ble introdusert.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
