### PR TITLE
Show warning only for NVI candidates with open period

### DIFF
--- a/src/pages/registration/RegistrationForm.tsx
+++ b/src/pages/registration/RegistrationForm.tsx
@@ -61,9 +61,9 @@ export const RegistrationForm = ({ identifier }: RegistrationFormProps) => {
     retry: false,
     meta: { errorMessage: false },
   });
-
   const isNviCandidate =
-    nviCandidateQuery.isSuccess && nviCandidateQuery.data.approvals.some((status) => status.status !== 'Pending');
+    nviCandidateQuery.data?.period.status === 'OpenPeriod' &&
+    nviCandidateQuery.data.approvals.some((status) => status.status !== 'Pending');
 
   const initialTabNumber = new URLSearchParams(history.location.search).get('tab');
   const [tabNumber, setTabNumber] = useState(initialTabNumber ? +initialTabNumber : RegistrationTab.Description);


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-47064

Dropp advarsel når man åpner wizard for et resultat med en historisk NVI-kandidate som _ikke_ har en åpen periode.
![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/8e5197fa-77aa-40a1-932d-fc83d96bb80b)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
