### PR TITLE
Np 47000 show link to upload files when no files can be published

### DIFF
--- a/src/pages/public_registration/public_files/FilesLandingPageAccordion.tsx
+++ b/src/pages/public_registration/public_files/FilesLandingPageAccordion.tsx
@@ -1,12 +1,13 @@
 import FileUploadIcon from '@mui/icons-material/FileUpload';
 import { Box, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { LandingPageAccordion } from '../../../components/landing_page/LandingPageAccordion';
 import { LinkButton } from '../../../components/PageWithSideMenu';
+import { LandingPageAccordion } from '../../../components/landing_page/LandingPageAccordion';
 import { FileType } from '../../../types/associatedArtifact.types';
 import { RegistrationStatus } from '../../../types/registration.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import {
+  associatedArtifactIsNullArtifact,
   getAssociatedFiles,
   isTypeWithFileVersionField,
   userCanEditRegistration,
@@ -37,6 +38,11 @@ export const FilesLandingPageAccordion = ({ registration }: PublicRegistrationCo
     registration.status === RegistrationStatus.Published ||
     registration.status === RegistrationStatus.PublishedMetadata;
 
+  const showLinkToUploadNewFiles =
+    userIsRegistrationAdmin &&
+    publishableFilesLength === 0 &&
+    !registration.associatedArtifacts.some(associatedArtifactIsNullArtifact);
+
   return publishableFilesLength > 0 ||
     (userIsRegistrationAdmin && associatedFiles.length > 0) ||
     (userIsRegistrationAdmin && registration.associatedArtifacts.length === 0) ? (
@@ -62,7 +68,7 @@ export const FilesLandingPageAccordion = ({ registration }: PublicRegistrationCo
           )}
         </Box>
       }>
-      {registration.associatedArtifacts.length === 0 && (
+      {showLinkToUploadNewFiles && (
         <Box
           sx={{
             display: 'flex',

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1278,8 +1278,6 @@
       "accepted": "Akseptert",
       "accepted_version": "Akseptert versjon",
       "add_files_or_links": "Legg til fil eller lenke",
-      "administrative_agreement": "Administrativ avtale",
-      "administrative_contract": "Intern fil som aldri skal publiseres. F.eks. forfatteravtale eller annen dokumentasjon for det registrerte resultatet",
       "conditions_for_using_file": "Betingelser for bruk",
       "disabled_helper_text": "Denne filen er allerede publisert med en godkjent lisens. Ta kontakt med kurator om du vil endre eller slette filen",
       "embargo": "Embargo/utsatt publisering",


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-47000

Fikser en glipp hvor "Legg til fil"-snarvei ikke ble vist om resultatet bare bar upubliserbare filer.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
