### PR TITLE
Np 47074 handle new deployment without crashing

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,7 +18,7 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
     'react/jsx-key': 'off', // TODO: Violations of this rule should be resolved, so we can implement this rule
     'react/no-children-prop': 'off', // TODO: Violations of this rule should be resolved, so we can implement this rule
-    'no-console': 'off',
+    'no-console': 'warn',
     'no-debugger': 'warn',
   },
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,7 +18,7 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
     'react/jsx-key': 'off', // TODO: Violations of this rule should be resolved, so we can implement this rule
     'react/no-children-prop': 'off', // TODO: Violations of this rule should be resolved, so we can implement this rule
-    'no-console': 'warn',
+    'no-console': 'off',
     'no-debugger': 'warn',
   },
 };

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -16,6 +16,7 @@ class ErrorBoundaryClass extends Component<PropsWithChildren<ErrorBoundaryClassP
   state = { error: ErrorType.None };
 
   static getDerivedStateFromError(error: any) {
+    console.log('ERROR', error);
     return /Loading chunk [\d]+ failed/.test(error) ? { error: ErrorType.Chunk } : { error: ErrorType.Other };
   }
 

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -18,6 +18,16 @@ class ErrorBoundaryClass extends Component<PropsWithChildren<ErrorBoundaryClassP
   static getDerivedStateFromError(error: any) {
     console.log('ERROR', error);
 
+    if (error instanceof Error) {
+      console.log('ErrorBoundary error:', error);
+    } else if (typeof error === 'object') {
+      console.log('ErrorBoundary object:', error);
+    } else if (typeof error === 'string') {
+      console.log('ErrorBoundary string:', error);
+    } else {
+      console.log('ErrorBoundary ??:', error);
+    }
+
     return /TypeError: error loading dynamically imported module/.test(error)
       ? { error: ErrorType.Chunk }
       : { error: ErrorType.Other };

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -17,7 +17,10 @@ class ErrorBoundaryClass extends Component<PropsWithChildren<ErrorBoundaryClassP
 
   static getDerivedStateFromError(error: any) {
     console.log('ERROR', error);
-    return /Loading chunk [\d]+ failed/.test(error) ? { error: ErrorType.Chunk } : { error: ErrorType.Other };
+
+    return /TypeError: error loading dynamically imported module/.test(error)
+      ? { error: ErrorType.Chunk }
+      : { error: ErrorType.Other };
   }
 
   componentDidUpdate(prevProps: ErrorBoundaryClassProps) {

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -16,18 +16,6 @@ class ErrorBoundaryClass extends Component<PropsWithChildren<ErrorBoundaryClassP
   state = { error: ErrorType.None };
 
   static getDerivedStateFromError(error: any) {
-    console.log('ERROR', error);
-
-    if (error instanceof Error) {
-      console.log('ErrorBoundary error:', error);
-    } else if (typeof error === 'object') {
-      console.log('ErrorBoundary object:', error);
-    } else if (typeof error === 'string') {
-      console.log('ErrorBoundary string:', error);
-    } else {
-      console.log('ErrorBoundary ??:', error);
-    }
-
     return /TypeError: error loading dynamically imported module/.test(error)
       ? { error: ErrorType.Chunk }
       : { error: ErrorType.Other };
@@ -72,8 +60,6 @@ class ErrorBoundaryClass extends Component<PropsWithChildren<ErrorBoundaryClassP
     const { t, children } = this.props;
     const { error } = this.state;
 
-    console.log('Error boundary', this.state);
-
     switch (error) {
       case ErrorType.None:
         return children;
@@ -97,8 +83,6 @@ export class BasicErrorBoundary extends Component<PropsWithChildren<unknown>> {
   render() {
     const { children } = this.props;
     const { hasError } = this.state;
-
-    console.log('Most basic error boundary', this.state);
 
     return hasError ? <ErrorMessage errorMessage={nbTranslations.common.error_occurred} /> : children;
   }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -59,6 +59,8 @@ class ErrorBoundaryClass extends Component<PropsWithChildren<ErrorBoundaryClassP
     const { t, children } = this.props;
     const { error } = this.state;
 
+    console.log('Error boundary', this.state);
+
     switch (error) {
       case ErrorType.None:
         return children;
@@ -82,6 +84,8 @@ export class BasicErrorBoundary extends Component<PropsWithChildren<unknown>> {
   render() {
     const { children } = this.props;
     const { hasError } = this.state;
+
+    console.log('Most basic error boundary', this.state);
 
     return hasError ? <ErrorMessage errorMessage={nbTranslations.common.error_occurred} /> : children;
   }

--- a/src/pages/messages/TasksPage.tsx
+++ b/src/pages/messages/TasksPage.tsx
@@ -48,7 +48,7 @@ const TasksPage = () => {
   const isNviCurator = !!user?.isNviCurator;
   const nvaUsername = user?.nvaUsername ?? '';
 
-  console.log('NY VERSJON TASKS PAGE');
+  console.log('NY VERSJON TASKS PAGE 2');
 
   const isOnTicketsPage = history.location.pathname === UrlPathTemplate.TasksDialogue;
   const isOnTicketPage = history.location.pathname.startsWith(UrlPathTemplate.TasksDialogue) && !isOnTicketsPage;

--- a/src/pages/messages/TasksPage.tsx
+++ b/src/pages/messages/TasksPage.tsx
@@ -48,8 +48,6 @@ const TasksPage = () => {
   const isNviCurator = !!user?.isNviCurator;
   const nvaUsername = user?.nvaUsername ?? '';
 
-  console.log('NY VERSJON TASKS PAGE 2');
-
   const isOnTicketsPage = history.location.pathname === UrlPathTemplate.TasksDialogue;
   const isOnTicketPage = history.location.pathname.startsWith(UrlPathTemplate.TasksDialogue) && !isOnTicketsPage;
   const isOnNviCandidatesPage = history.location.pathname === UrlPathTemplate.TasksNvi;

--- a/src/pages/messages/TasksPage.tsx
+++ b/src/pages/messages/TasksPage.tsx
@@ -9,14 +9,14 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { Link, Redirect, Switch, useHistory } from 'react-router-dom';
 import { fetchUser } from '../../api/roleApi';
-import { fetchCustomerTickets, FetchTicketsParams, TicketSearchParam } from '../../api/searchApi';
+import { FetchTicketsParams, TicketSearchParam, fetchCustomerTickets } from '../../api/searchApi';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
 import { NavigationListAccordion } from '../../components/NavigationListAccordion';
 import { LinkButton, NavigationList, SideNavHeader, StyledPageWithSideMenu } from '../../components/PageWithSideMenu';
 import { SelectableButton } from '../../components/SelectableButton';
 import { SideMenu, StyledMinimizedMenuButton } from '../../components/SideMenu';
-import { StyledTicketSearchFormGroup } from '../../components/styled/Wrappers';
 import { TicketListDefaultValuesWrapper } from '../../components/TicketListDefaultValuesWrapper';
+import { StyledTicketSearchFormGroup } from '../../components/styled/Wrappers';
 import { RootState } from '../../redux/store';
 import { PreviousSearchLocationState } from '../../types/locationState.types';
 import { ROWS_PER_PAGE_OPTIONS } from '../../utils/constants';
@@ -47,6 +47,8 @@ const TasksPage = () => {
   const isTicketCurator = isSupportCurator || isDoiCurator || isPublishingCurator;
   const isNviCurator = !!user?.isNviCurator;
   const nvaUsername = user?.nvaUsername ?? '';
+
+  console.log('NY VERSJON AV TASKS PAGE');
 
   const isOnTicketsPage = history.location.pathname === UrlPathTemplate.TasksDialogue;
   const isOnTicketPage = history.location.pathname.startsWith(UrlPathTemplate.TasksDialogue) && !isOnTicketsPage;

--- a/src/pages/messages/TasksPage.tsx
+++ b/src/pages/messages/TasksPage.tsx
@@ -48,7 +48,7 @@ const TasksPage = () => {
   const isNviCurator = !!user?.isNviCurator;
   const nvaUsername = user?.nvaUsername ?? '';
 
-  console.log('NY VERSJON AV TASKS PAGE');
+  console.log('NY VERSJON TASKS PAGE');
 
   const isOnTicketsPage = history.location.pathname === UrlPathTemplate.TasksDialogue;
   const isOnTicketPage = history.location.pathname.startsWith(UrlPathTemplate.TasksDialogue) && !isOnTicketsPage;


### PR DESCRIPTION
# Description

Link to Jira issue: https://unit.atlassian.net/browse/NP-47074

Håndter at ny versjon av appen deployes mens man bruker den. Bruker blir nå bedt om å laste inn siden på nytt, i stedet for at siden bare krasjer. Årsaken til endring er at `ract-scripts` og `vite` har ulike feilmeldinger for dette som vi må sjekke mot.

Ser at Vite har et eksempel for å håndtere dette i sin [dokumentasjon](https://vitejs.dev/guide/build#load-error-handling), men forslår at vi fortsetter med løsningen vi har i dag til det eventuelt blir et problem.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
