### PR TITLE
Category fields are persisted between choice of category if they are the same fields

### DIFF
--- a/src/pages/registration/resource_type_tab/SelectRegistrationTypeField.tsx
+++ b/src/pages/registration/resource_type_tab/SelectRegistrationTypeField.tsx
@@ -64,10 +64,7 @@ export const SelectRegistrationTypeField = () => {
 
   const closeSelectType = () => setOpenSelectType(false);
 
-  console.log('values', values);
-
   const updateRegistrationData = (newInstanceType: PublicationInstanceType) => {
-    console.log('newInstanceType', newInstanceType);
     if (newInstanceType !== currentInstanceType) {
       const newContextType = getMainRegistrationType(newInstanceType);
       const oldContextType = values.entityDescription?.reference?.publicationContext?.type;

--- a/src/pages/registration/resource_type_tab/SelectRegistrationTypeField.tsx
+++ b/src/pages/registration/resource_type_tab/SelectRegistrationTypeField.tsx
@@ -16,7 +16,6 @@ import {
   emptyExhibitionPublicationContext,
   emptyExhibitionPublicationInstance,
 } from '../../../types/publication_types/exhibitionContent.types';
-import { emptyJournalPublicationInstance } from '../../../types/publication_types/journalRegistration.types';
 import {
   emptyMediaContributionPeriodicalPublicationContext,
   emptyMediaContributionPeriodicalPublicationInstance,
@@ -68,19 +67,21 @@ export const SelectRegistrationTypeField = () => {
   const updateRegistrationData = (newInstanceType: PublicationInstanceType) => {
     if (newInstanceType !== currentInstanceType) {
       const newContextType = getMainRegistrationType(newInstanceType);
-      const newMainType = newContextType !== values.entityDescription?.reference?.publicationContext?.type;
+      const oldContextType = getMainRegistrationType(currentInstanceType);
+      const contextTypeIsChanged = newContextType !== oldContextType;
+
       switch (newContextType) {
         case PublicationType.PublicationInJournal:
-          newMainType &&
+          contextTypeIsChanged &&
             setFieldValue(contextTypeBaseFieldName, { type: PublicationChannelType.UnconfirmedJournal }, false);
           setFieldValue(
             instanceTypeBaseFieldName,
-            { ...emptyJournalPublicationInstance, type: newInstanceType },
+            { ...values.entityDescription?.reference?.publicationInstance, type: newInstanceType },
             false
           );
           break;
         case PublicationType.Book:
-          newMainType &&
+          contextTypeIsChanged &&
             setFieldValue(
               contextTypeBaseFieldName,
               {
@@ -93,7 +94,7 @@ export const SelectRegistrationTypeField = () => {
           setFieldValue(instanceTypeBaseFieldName, { ...emptyBookPublicationInstance, type: newInstanceType }, false);
           break;
         case PublicationType.Report:
-          newMainType &&
+          contextTypeIsChanged &&
             setFieldValue(
               contextTypeBaseFieldName,
               {
@@ -106,7 +107,7 @@ export const SelectRegistrationTypeField = () => {
           setFieldValue(instanceTypeBaseFieldName, { ...emptyReportPublicationInstance, type: newInstanceType }, false);
           break;
         case PublicationType.Degree:
-          newMainType &&
+          contextTypeIsChanged &&
             setFieldValue(
               contextTypeBaseFieldName,
               {
@@ -120,7 +121,7 @@ export const SelectRegistrationTypeField = () => {
           setFieldValue(instanceTypeBaseFieldName, { ...emptyDegreePublicationInstance, type: newInstanceType }, false);
           break;
         case PublicationType.Anthology:
-          newMainType && setFieldValue(contextTypeBaseFieldName, { type: PublicationType.Anthology }, false);
+          contextTypeIsChanged && setFieldValue(contextTypeBaseFieldName, { type: PublicationType.Anthology }, false);
           setFieldValue(
             instanceTypeBaseFieldName,
             { ...emptyChapterPublicationInstance, type: newInstanceType },
@@ -128,7 +129,7 @@ export const SelectRegistrationTypeField = () => {
           );
           break;
         case PublicationType.Presentation:
-          newMainType && setFieldValue(contextTypeBaseFieldName, emptyPresentationPublicationContext, false);
+          contextTypeIsChanged && setFieldValue(contextTypeBaseFieldName, emptyPresentationPublicationContext, false);
           setFieldValue(
             instanceTypeBaseFieldName,
             { ...emptyPresentationPublicationInstance, type: newInstanceType },
@@ -136,7 +137,8 @@ export const SelectRegistrationTypeField = () => {
           );
           break;
         case PublicationType.Artistic:
-          newMainType && setFieldValue(contextTypeBaseFieldName, { type: PublicationType.Artistic, venues: [] }, false);
+          contextTypeIsChanged &&
+            setFieldValue(contextTypeBaseFieldName, { type: PublicationType.Artistic, venues: [] }, false);
           setFieldValue(
             instanceTypeBaseFieldName,
             { ...emptyArtisticPublicationInstance, type: newInstanceType },
@@ -175,7 +177,7 @@ export const SelectRegistrationTypeField = () => {
           }
           break;
         case PublicationType.ResearchData:
-          newMainType && setFieldValue(contextTypeBaseFieldName, emptyResearchDataPublicationContext, false);
+          contextTypeIsChanged && setFieldValue(contextTypeBaseFieldName, emptyResearchDataPublicationContext, false);
           setFieldValue(
             instanceTypeBaseFieldName,
             { ...emptyResearchDataPublicationInstance, type: newInstanceType },
@@ -183,11 +185,11 @@ export const SelectRegistrationTypeField = () => {
           );
           break;
         case PublicationType.ExhibitionContent:
-          newMainType && setFieldValue(contextTypeBaseFieldName, emptyExhibitionPublicationContext, false);
+          contextTypeIsChanged && setFieldValue(contextTypeBaseFieldName, emptyExhibitionPublicationContext, false);
           setFieldValue(instanceTypeBaseFieldName, emptyExhibitionPublicationInstance, false);
           break;
         case PublicationType.GeographicalContent:
-          newMainType && setFieldValue(contextTypeBaseFieldName, emptyMapPublicationContext, false);
+          contextTypeIsChanged && setFieldValue(contextTypeBaseFieldName, emptyMapPublicationContext, false);
           setFieldValue(instanceTypeBaseFieldName, { ...emptyMapPublicationInstance, type: newInstanceType }, false);
           break;
       }

--- a/src/pages/registration/resource_type_tab/SelectRegistrationTypeField.tsx
+++ b/src/pages/registration/resource_type_tab/SelectRegistrationTypeField.tsx
@@ -16,6 +16,7 @@ import {
   emptyExhibitionPublicationContext,
   emptyExhibitionPublicationInstance,
 } from '../../../types/publication_types/exhibitionContent.types';
+import { emptyJournalPublicationInstance } from '../../../types/publication_types/journalRegistration.types';
 import {
   emptyMediaContributionPeriodicalPublicationContext,
   emptyMediaContributionPeriodicalPublicationInstance,
@@ -75,7 +76,11 @@ export const SelectRegistrationTypeField = () => {
           if (contextTypeIsChanged) {
             // If we move between category groups we reset all fields
             setFieldValue(contextTypeBaseFieldName, { type: PublicationChannelType.UnconfirmedJournal }, false);
-            setFieldValue(instanceTypeBaseFieldName, { ...emptyBookPublicationInstance, type: newInstanceType }, false);
+            setFieldValue(
+              instanceTypeBaseFieldName,
+              { ...emptyJournalPublicationInstance, type: newInstanceType },
+              false
+            );
           } else {
             // If we move between different categories in the same group with the same fields, we keep the info in the fields
             setFieldValue(
@@ -87,7 +92,6 @@ export const SelectRegistrationTypeField = () => {
           break;
         case PublicationType.Book:
           if (contextTypeIsChanged) {
-            // If we move between category groups we reset all fields
             setFieldValue(
               contextTypeBaseFieldName,
               {
@@ -99,7 +103,6 @@ export const SelectRegistrationTypeField = () => {
             );
             setFieldValue(instanceTypeBaseFieldName, { ...emptyBookPublicationInstance, type: newInstanceType }, false);
           } else {
-            // If we move between different categories in the same group with the same fields, we keep the info in the fields
             setFieldValue(
               instanceTypeBaseFieldName,
               { ...values.entityDescription?.reference?.publicationInstance, type: newInstanceType },
@@ -109,7 +112,6 @@ export const SelectRegistrationTypeField = () => {
           break;
         case PublicationType.Report:
           if (contextTypeIsChanged) {
-            // If we move between category groups we reset all fields
             setFieldValue(
               contextTypeBaseFieldName,
               {
@@ -125,7 +127,6 @@ export const SelectRegistrationTypeField = () => {
               false
             );
           } else {
-            // If we move between different categories in the same group with the same fields, we keep the info in the fields
             setFieldValue(
               instanceTypeBaseFieldName,
               { ...values.entityDescription?.reference?.publicationInstance, type: newInstanceType },
@@ -149,7 +150,6 @@ export const SelectRegistrationTypeField = () => {
           break;
         case PublicationType.Anthology:
           if (contextTypeIsChanged) {
-            // If we move between category groups we reset all fields
             setFieldValue(contextTypeBaseFieldName, { type: PublicationType.Anthology }, false);
             setFieldValue(
               instanceTypeBaseFieldName,
@@ -157,7 +157,6 @@ export const SelectRegistrationTypeField = () => {
               false
             );
           } else {
-            // If we move between different categories in the same group with the same fields, we keep the info in the fields
             setFieldValue(
               instanceTypeBaseFieldName,
               { ...values.entityDescription?.reference?.publicationInstance, type: newInstanceType },
@@ -167,7 +166,6 @@ export const SelectRegistrationTypeField = () => {
           break;
         case PublicationType.Presentation:
           if (contextTypeIsChanged) {
-            // If we move between category groups we reset all fields
             setFieldValue(contextTypeBaseFieldName, emptyPresentationPublicationContext, false);
             setFieldValue(
               instanceTypeBaseFieldName,
@@ -176,7 +174,6 @@ export const SelectRegistrationTypeField = () => {
             );
           } else {
             setFieldValue(
-              // If we move between different categories in the same group with the same fields, we keep the info in the fields
               instanceTypeBaseFieldName,
               { ...values.entityDescription?.reference?.publicationInstance, type: newInstanceType },
               false

--- a/src/pages/registration/resource_type_tab/SelectRegistrationTypeField.tsx
+++ b/src/pages/registration/resource_type_tab/SelectRegistrationTypeField.tsx
@@ -67,7 +67,7 @@ export const SelectRegistrationTypeField = () => {
   const updateRegistrationData = (newInstanceType: PublicationInstanceType) => {
     if (newInstanceType !== currentInstanceType) {
       const newContextType = getMainRegistrationType(newInstanceType);
-      const oldContextType = getMainRegistrationType(currentInstanceType);
+      const oldContextType = values.entityDescription?.reference?.publicationContext?.type;
       const contextTypeIsChanged = newContextType !== oldContextType;
 
       switch (newContextType) {

--- a/src/pages/registration/resource_type_tab/SelectRegistrationTypeField.tsx
+++ b/src/pages/registration/resource_type_tab/SelectRegistrationTypeField.tsx
@@ -64,7 +64,10 @@ export const SelectRegistrationTypeField = () => {
 
   const closeSelectType = () => setOpenSelectType(false);
 
+  console.log('values', values);
+
   const updateRegistrationData = (newInstanceType: PublicationInstanceType) => {
+    console.log('newInstanceType', newInstanceType);
     if (newInstanceType !== currentInstanceType) {
       const newContextType = getMainRegistrationType(newInstanceType);
       const oldContextType = values.entityDescription?.reference?.publicationContext?.type;
@@ -72,16 +75,22 @@ export const SelectRegistrationTypeField = () => {
 
       switch (newContextType) {
         case PublicationType.PublicationInJournal:
-          contextTypeIsChanged &&
+          if (contextTypeIsChanged) {
+            // If we move between category groups we reset all fields
             setFieldValue(contextTypeBaseFieldName, { type: PublicationChannelType.UnconfirmedJournal }, false);
-          setFieldValue(
-            instanceTypeBaseFieldName,
-            { ...values.entityDescription?.reference?.publicationInstance, type: newInstanceType },
-            false
-          );
+            setFieldValue(instanceTypeBaseFieldName, { ...emptyBookPublicationInstance, type: newInstanceType }, false);
+          } else {
+            // If we move between different categories in the same group with the same fields, we keep the info in the fields
+            setFieldValue(
+              instanceTypeBaseFieldName,
+              { ...values.entityDescription?.reference?.publicationInstance, type: newInstanceType },
+              false
+            );
+          }
           break;
         case PublicationType.Book:
-          contextTypeIsChanged &&
+          if (contextTypeIsChanged) {
+            // If we move between category groups we reset all fields
             setFieldValue(
               contextTypeBaseFieldName,
               {
@@ -91,10 +100,19 @@ export const SelectRegistrationTypeField = () => {
               },
               false
             );
-          setFieldValue(instanceTypeBaseFieldName, { ...emptyBookPublicationInstance, type: newInstanceType }, false);
+            setFieldValue(instanceTypeBaseFieldName, { ...emptyBookPublicationInstance, type: newInstanceType }, false);
+          } else {
+            // If we move between different categories in the same group with the same fields, we keep the info in the fields
+            setFieldValue(
+              instanceTypeBaseFieldName,
+              { ...values.entityDescription?.reference?.publicationInstance, type: newInstanceType },
+              false
+            );
+          }
           break;
         case PublicationType.Report:
-          contextTypeIsChanged &&
+          if (contextTypeIsChanged) {
+            // If we move between category groups we reset all fields
             setFieldValue(
               contextTypeBaseFieldName,
               {
@@ -104,7 +122,19 @@ export const SelectRegistrationTypeField = () => {
               },
               false
             );
-          setFieldValue(instanceTypeBaseFieldName, { ...emptyReportPublicationInstance, type: newInstanceType }, false);
+            setFieldValue(
+              instanceTypeBaseFieldName,
+              { ...emptyReportPublicationInstance, type: newInstanceType },
+              false
+            );
+          } else {
+            // If we move between different categories in the same group with the same fields, we keep the info in the fields
+            setFieldValue(
+              instanceTypeBaseFieldName,
+              { ...values.entityDescription?.reference?.publicationInstance, type: newInstanceType },
+              false
+            );
+          }
           break;
         case PublicationType.Degree:
           contextTypeIsChanged &&
@@ -121,20 +151,41 @@ export const SelectRegistrationTypeField = () => {
           setFieldValue(instanceTypeBaseFieldName, { ...emptyDegreePublicationInstance, type: newInstanceType }, false);
           break;
         case PublicationType.Anthology:
-          contextTypeIsChanged && setFieldValue(contextTypeBaseFieldName, { type: PublicationType.Anthology }, false);
-          setFieldValue(
-            instanceTypeBaseFieldName,
-            { ...emptyChapterPublicationInstance, type: newInstanceType },
-            false
-          );
+          if (contextTypeIsChanged) {
+            // If we move between category groups we reset all fields
+            setFieldValue(contextTypeBaseFieldName, { type: PublicationType.Anthology }, false);
+            setFieldValue(
+              instanceTypeBaseFieldName,
+              { ...emptyChapterPublicationInstance, type: newInstanceType },
+              false
+            );
+          } else {
+            // If we move between different categories in the same group with the same fields, we keep the info in the fields
+            setFieldValue(
+              instanceTypeBaseFieldName,
+              { ...values.entityDescription?.reference?.publicationInstance, type: newInstanceType },
+              false
+            );
+          }
           break;
         case PublicationType.Presentation:
-          contextTypeIsChanged && setFieldValue(contextTypeBaseFieldName, emptyPresentationPublicationContext, false);
-          setFieldValue(
-            instanceTypeBaseFieldName,
-            { ...emptyPresentationPublicationInstance, type: newInstanceType },
-            false
-          );
+          if (contextTypeIsChanged) {
+            // If we move between category groups we reset all fields
+            setFieldValue(contextTypeBaseFieldName, emptyPresentationPublicationContext, false);
+            setFieldValue(
+              instanceTypeBaseFieldName,
+              { ...emptyPresentationPublicationInstance, type: newInstanceType },
+              false
+            );
+          } else {
+            setFieldValue(
+              // If we move between different categories in the same group with the same fields, we keep the info in the fields
+              instanceTypeBaseFieldName,
+              { ...values.entityDescription?.reference?.publicationInstance, type: newInstanceType },
+              false
+            );
+          }
+
           break;
         case PublicationType.Artistic:
           contextTypeIsChanged &&
@@ -147,8 +198,8 @@ export const SelectRegistrationTypeField = () => {
           break;
         case PublicationType.MediaContribution:
           if (isPeriodicalMediaContribution(newInstanceType)) {
-            setFieldValue(contextTypeBaseFieldName, emptyMediaContributionPeriodicalPublicationContext, false);
             if (!isPeriodicalMediaContribution(currentInstanceType)) {
+              setFieldValue(contextTypeBaseFieldName, emptyMediaContributionPeriodicalPublicationContext, false);
               setFieldValue(
                 instanceTypeBaseFieldName,
                 {


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-47082](https://unit.atlassian.net/browse/NP-47082)

Earlier, if we filled out the fields for category on a new registration and then changed the category, the values in the field would disappear:

![image](https://github.com/BIBSYSDEV/NVA-Frontend/assets/1130244/1ac6d33b-f901-4bb6-abc3-e706d7b046e8)

![image](https://github.com/BIBSYSDEV/NVA-Frontend/assets/1130244/b2f46519-8a66-44d4-a727-0f5f2143a097)

Now, if we do the same, the fields are persisted if we change within certain groups that have the same fields.

This goes for the following groups:

![image](https://github.com/BIBSYSDEV/NVA-Frontend/assets/1130244/42c50c5b-d405-4a73-947e-02de53439f27)

If we change between groups the fields will not be remembered when we return to a previous group.

If the category is "Kronikk" or "Leseinnlegg" we are now preserving the "tidsskrift"-field as well as the other fields that were also preserved earlier.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-47082]: https://unit.atlassian.net/browse/NP-47082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ