### PR TITLE
Same name warning now links to registration with same name instead of search result

### DIFF
--- a/src/pages/registration/DescriptionPanel.tsx
+++ b/src/pages/registration/DescriptionPanel.tsx
@@ -66,7 +66,10 @@ export const DescriptionPanel = () => {
           )}
         </Field>
         {registrationWithSameName?.entityDescription?.mainTitle && (
-          <SameNameWarning name={registrationWithSameName.entityDescription?.mainTitle} />
+          <SameNameWarning
+            name={registrationWithSameName.entityDescription?.mainTitle}
+            id={registrationWithSameName.identifier}
+          />
         )}
         <Field name={DescriptionFieldNames.AlternativeTitles}>
           {({ field }: FieldProps<string>) => (

--- a/src/pages/registration/SameNameWarning.tsx
+++ b/src/pages/registration/SameNameWarning.tsx
@@ -3,7 +3,7 @@ import { Box, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { dataTestId } from '../../utils/dataTestIds';
-import { UrlPathTemplate } from '../../utils/urlPaths';
+import { getRegistrationLandingPagePath } from '../../utils/urlPaths';
 
 interface SameNameWarningProps {
   name: string;
@@ -28,8 +28,8 @@ export const SameNameWarning = ({ name, id }: SameNameWarningProps) => {
       <Typography sx={{ fontWeight: 'bold' }}>{t('common.result')}</Typography>
       <Link
         target="_blank"
-        data-testid={dataTestId.registrationLandingPage.duplicateRegistrationSearchLink}
-        to={`${UrlPathTemplate.RegistrationNew}/${id}`}>
+        data-testid={dataTestId.registrationLandingPage.duplicateRegistrationLink}
+        to={getRegistrationLandingPagePath(id)}>
         <Box sx={{ display: 'flex', gap: '0.5rem' }}>
           <Typography sx={{ textDecoration: 'underline', cursor: 'pointer' }}>{name}</Typography>
           <OpenInNewOutlinedIcon sx={{ cursor: 'pointer', color: 'primary.main', height: '1.3rem', width: '1.3rem' }} />

--- a/src/pages/registration/SameNameWarning.tsx
+++ b/src/pages/registration/SameNameWarning.tsx
@@ -7,9 +7,10 @@ import { UrlPathTemplate } from '../../utils/urlPaths';
 
 interface SameNameWarningProps {
   name: string;
+  id: string;
 }
 
-export const SameNameWarning = ({ name }: SameNameWarningProps) => {
+export const SameNameWarning = ({ name, id }: SameNameWarningProps) => {
   const { t } = useTranslation();
   return (
     <Box
@@ -28,10 +29,7 @@ export const SameNameWarning = ({ name }: SameNameWarningProps) => {
       <Link
         target="_blank"
         data-testid={dataTestId.registrationLandingPage.duplicateRegistrationSearchLink}
-        to={{
-          pathname: UrlPathTemplate.Home,
-          search: `?query=${encodeURIComponent(name)}`,
-        }}>
+        to={`${UrlPathTemplate.RegistrationNew}/${id}`}>
         <Box sx={{ display: 'flex', gap: '0.5rem' }}>
           <Typography sx={{ textDecoration: 'underline', cursor: 'pointer' }}>{name}</Typography>
           <OpenInNewOutlinedIcon sx={{ cursor: 'pointer', color: 'primary.main', height: '1.3rem', width: '1.3rem' }} />

--- a/src/utils/dataTestIds.ts
+++ b/src/utils/dataTestIds.ts
@@ -225,7 +225,7 @@ export const dataTestId = {
     doiLink: 'doi-link',
     doiMessageField: 'request-doi-message',
     doiOriginalLink: 'doi-original-link',
-    duplicateRegistrationSearchLink: 'duplicate-registration-search-link',
+    duplicateRegistrationLink: 'duplicate-registration-link',
     editButton: 'button-edit-registration',
     externalLinksAccordion: 'external-links-accordion',
     file: 'file',


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-47135](https://unit.atlassian.net/browse/NP-47135)

When we get a warning that there already exists a registration with the same name and we click the link, we are now taken to the registration page instead of the search.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-47135]: https://unit.atlassian.net/browse/NP-47135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ