### PR TITLE
New button in publish view leads to file panel

### DIFF
--- a/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
@@ -32,8 +32,9 @@ import { MessageForm } from '../../../components/MessageForm';
 import { setNotification } from '../../../redux/notificationSlice';
 import { RootState } from '../../../redux/store';
 import { FileType } from '../../../types/associatedArtifact.types';
+import { RegistrationFormLocationState } from '../../../types/locationState.types';
 import { PublishingTicket } from '../../../types/publication_types/ticket.types';
-import { Registration, RegistrationStatus } from '../../../types/registration.types';
+import { Registration, RegistrationStatus, RegistrationTab } from '../../../types/registration.types';
 import { isErrorStatus, isSuccessStatus } from '../../../utils/constants';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { toDateString } from '../../../utils/date-helpers';
@@ -429,6 +430,20 @@ export const PublishingAccordion = ({
               disabled={isLoadingData || isLoading !== LoadingState.None || !registrationIsValid}>
               {t('registration.public_page.approve_publish_request')} ({filesAwaitingApproval})
             </LoadingButton>
+            <Typography>{t('registration.public_page.tasks_panel.edit_publishing_request_description')}</Typography>
+            <Button
+              sx={{ bgcolor: 'white', mb: '0.5rem' }}
+              variant="outlined"
+              data-testid={dataTestId.registrationLandingPage.tasksPanel.publishingRequestEditButton}
+              endIcon={<EditIcon fontSize="large" />}
+              component={RouterLink}
+              to={{
+                pathname: getRegistrationWizardPath(registration.identifier),
+                search: '?tab=' + RegistrationTab.FilesAndLicenses,
+                state: { previousPath: window.location.pathname } satisfies RegistrationFormLocationState,
+              }}>
+              {t('registration.public_page.tasks_panel.edit_registration_button')}
+            </Button>
 
             <Trans
               t={t}

--- a/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
@@ -442,7 +442,7 @@ export const PublishingAccordion = ({
                 search: '?tab=' + RegistrationTab.FilesAndLicenses,
                 state: { previousPath: window.location.pathname } satisfies RegistrationFormLocationState,
               }}>
-              {t('registration.public_page.tasks_panel.edit_registration_button')}
+              {t('registration.edit_registration')}
             </Button>
 
             <Trans

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1394,7 +1394,6 @@
         "assign_doi_about": "For at andre skal kunne benytte DOI, må du tildele denne. Metadata må være publisert.",
         "duplicate_title_description_details": "<0>Det skal ikke opprettes duplikater i NVA. Sjekk om resultatet som allerede er publisert er det samme som resultatet du har registrert.</0><0>Om resultatet som er publisert har feil eller mangler så be registrator eller bidragsyter som er tilknyttet resultatet om å endre det. Ikke registrer og publiser et nytt resultat med endringen siden begge resultatene blir tilgjengelig i NVA.</0>",
         "duplicate_title_description_introduction": "Denne registreringen har samme tittel og år som følgende publikasjon:",
-        "edit_registration_button": "Rediger registreringen",
         "edit_publishing_request_description": "Er det noen av filene til publiseringen som ikke skal publiseres så kan du endre publiseringsstatus på disse ved å redigere registreringen.",
         "files_will_soon_be_published": "Fil(er) vil være tilgjengelig for andre om kort tid. Vent litt før du oppdaterer siden på nytt for å se status.",
         "has_rejected_files_publishing_request": "<0>Beskrivelse (metadata) er publisert og offentlig tilgjengelig.</0><0>Kurator har avvist filen, og den er fjernet fra visningen av forskningsresultatet.</0>",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1394,6 +1394,8 @@
         "assign_doi_about": "For at andre skal kunne benytte DOI, må du tildele denne. Metadata må være publisert.",
         "duplicate_title_description_details": "<0>Det skal ikke opprettes duplikater i NVA. Sjekk om resultatet som allerede er publisert er det samme som resultatet du har registrert.</0><0>Om resultatet som er publisert har feil eller mangler så be registrator eller bidragsyter som er tilknyttet resultatet om å endre det. Ikke registrer og publiser et nytt resultat med endringen siden begge resultatene blir tilgjengelig i NVA.</0>",
         "duplicate_title_description_introduction": "Denne registreringen har samme tittel og år som følgende publikasjon:",
+        "edit_registration_button": "Rediger registreringen",
+        "edit_publishing_request_description": "Er det noen av filene til publiseringen som ikke skal publiseres så kan du endre publiseringsstatus på disse ved å redigere registreringen.",
         "files_will_soon_be_published": "Fil(er) vil være tilgjengelig for andre om kort tid. Vent litt før du oppdaterer siden på nytt for å se status.",
         "has_rejected_files_publishing_request": "<0>Beskrivelse (metadata) er publisert og offentlig tilgjengelig.</0><0>Kurator har avvist filen, og den er fjernet fra visningen av forskningsresultatet.</0>",
         "has_reserved_doi": "Du har reservert en DOI til denne registreringen. Den kan deles med de som ønsker å sitere dette resultatet. Når registreringen blir publisert og blir offentlig tilgjengelig, må en kurator validere metadata før DOI blir offentlig tilgjengelig.",

--- a/src/utils/dataTestIds.ts
+++ b/src/utils/dataTestIds.ts
@@ -273,6 +273,7 @@ export const dataTestId = {
       publishButton: 'button-publish-registration',
       publishingRequestAcceptButton: 'publishing-request-accept-button',
       publishingRequestAccordion: 'publishing-request-accordion',
+      publishingRequestEditButton: 'publishing-request-edit-button',
       publishingRequestRejectButton: 'publishing-request-reject-button',
       publishingRequestRejectionMessageTextField: 'publishing-request-rejection-message-textfield',
       refreshDoiRequestButton: 'refresh-doi-button',


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-46996](https://sikt.atlassian.net/browse/NP-46996)

For a curator we now have a new button in the task panel will take them directly to the file, license and link tab (the last).

![image](https://github.com/BIBSYSDEV/NVA-Frontend/assets/1130244/05f324be-5b94-468f-90ce-6c1ba44ffa9c)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-46996]: https://sikt.atlassian.net/browse/NP-46996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ