### PR TITLE
Simplify file logic and fix alignment

### DIFF
--- a/src/pages/registration/FileList.tsx
+++ b/src/pages/registration/FileList.tsx
@@ -96,128 +96,131 @@ export const FileList = ({ title, files, uppy, remove, baseFieldName, archived }
               <StyledTableCell id={markForPublishId}>
                 {t('registration.files_and_license.mark_for_publish')}
               </StyledTableCell>
-              {showFileVersion && !archived && (
-                <StyledTableCell>
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: '0.5rem',
-                    }}>
-                    <Box sx={{ display: 'flex' }}>
-                      {t('common.version')}
-                      <Typography color="error">*</Typography>
-                    </Box>
-                    <HelperTextModal
-                      modalTitle={t('common.version')}
-                      modalDataTestId={dataTestId.registrationWizard.files.versionModal}
-                      buttonDataTestId={dataTestId.registrationWizard.files.versionHelpButton}>
-                      {registratorPublishesMetadataOnly ? (
-                        <>
-                          <Typography paragraph>
-                            {t('registration.files_and_license.version_helper_text_metadata_only')}
-                          </Typography>
-                          <Typography paragraph>
-                            <Trans
-                              i18nKey="registration.files_and_license.version_accepted_helper_text_metadata_only"
-                              components={[<Box component="span" sx={{ fontWeight: 'bold' }} />]}
-                            />
-                          </Typography>
-                          <Typography paragraph>
-                            <Trans
-                              i18nKey="registration.files_and_license.version_published_helper_text_metadata_only"
-                              components={[<Box component="span" sx={{ fontWeight: 'bold' }} />]}
-                            />
-                          </Typography>
-                          <Typography paragraph>
-                            <Trans
-                              i18nKey="registration.files_and_license.version_publishing_agreement_helper_text_metadata_only"
-                              components={[<Box component="span" sx={{ fontWeight: 'bold' }} />]}
-                            />
-                          </Typography>
-                        </>
-                      ) : (
-                        <>
-                          <Trans
-                            i18nKey="registration.files_and_license.version_helper_text"
-                            components={[
-                              <Typography paragraph />,
-                              <Typography paragraph>
-                                <Box component="span" sx={{ textDecoration: 'underline' }} />
-                              </Typography>,
-                            ]}
-                          />
-
-                          <Typography paragraph>
-                            <Trans
-                              i18nKey="registration.files_and_license.version_accepted_helper_text"
-                              components={[<Box component="span" sx={{ fontWeight: 'bold' }} />]}
-                            />
-                          </Typography>
-                          <Typography paragraph>
-                            <Trans
-                              i18nKey="registration.files_and_license.version_published_helper_text"
-                              components={[<Box component="span" sx={{ fontWeight: 'bold' }} />]}
-                            />
-                          </Typography>
-                          <Typography paragraph>
-                            <Trans
-                              i18nKey="registration.files_and_license.version_publishing_agreement_helper_text"
-                              components={[<Box component="span" sx={{ fontWeight: 'bold' }} />]}
-                            />
-                          </Typography>
-                          <Typography paragraph>
-                            <Trans
-                              i18nKey="registration.files_and_license.version_embargo_helper_text"
-                              components={[<Box component="span" sx={{ fontWeight: 'bold' }} />]}
-                            />
-                          </Typography>
-                        </>
-                      )}
-                    </HelperTextModal>
-                  </Box>
-                </StyledTableCell>
-              )}
               {!archived && (
-                <StyledTableCell>
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      gap: '0.5rem',
-                      alignItems: 'center',
-                    }}>
-                    {t('registration.files_and_license.license')}
-                    <HelperTextModal
-                      modalTitle={t('registration.files_and_license.licenses')}
-                      modalDataTestId={dataTestId.registrationWizard.files.licenseModal}
-                      buttonDataTestId={dataTestId.registrationWizard.files.licenseHelpButton}>
-                      <Typography paragraph>{t('registration.files_and_license.file_and_license_info')}</Typography>
-                      {licenses
-                        .filter(
-                          (license) =>
-                            license.version === 4 ||
-                            license.id === LicenseUri.CC0 ||
-                            license.id === LicenseUri.RightsReserved
-                        )
-                        .map((license) => (
-                          <Box key={license.id} sx={{ mb: '1rem', whiteSpace: 'pre-wrap' }}>
-                            <Typography variant="h3" gutterBottom>
-                              {license.name}
-                            </Typography>
-                            <Box component="img" src={license.logo} alt="" sx={{ width: '8rem' }} />
-                            <Typography paragraph>{license.description}</Typography>
-                            {license.link && (
-                              <Link href={license.link} target="blank">
-                                {license.link}
-                              </Link>
-                            )}
-                          </Box>
-                        ))}
-                    </HelperTextModal>
-                  </Box>
-                </StyledTableCell>
+                <>
+                  {showFileVersion && (
+                    <StyledTableCell>
+                      <Box
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: '0.5rem',
+                        }}>
+                        <Box sx={{ display: 'flex' }}>
+                          {t('common.version')}
+                          <Typography color="error">*</Typography>
+                        </Box>
+                        <HelperTextModal
+                          modalTitle={t('common.version')}
+                          modalDataTestId={dataTestId.registrationWizard.files.versionModal}
+                          buttonDataTestId={dataTestId.registrationWizard.files.versionHelpButton}>
+                          {registratorPublishesMetadataOnly ? (
+                            <>
+                              <Typography paragraph>
+                                {t('registration.files_and_license.version_helper_text_metadata_only')}
+                              </Typography>
+                              <Typography paragraph>
+                                <Trans
+                                  i18nKey="registration.files_and_license.version_accepted_helper_text_metadata_only"
+                                  components={[<Box component="span" sx={{ fontWeight: 'bold' }} />]}
+                                />
+                              </Typography>
+                              <Typography paragraph>
+                                <Trans
+                                  i18nKey="registration.files_and_license.version_published_helper_text_metadata_only"
+                                  components={[<Box component="span" sx={{ fontWeight: 'bold' }} />]}
+                                />
+                              </Typography>
+                              <Typography paragraph>
+                                <Trans
+                                  i18nKey="registration.files_and_license.version_publishing_agreement_helper_text_metadata_only"
+                                  components={[<Box component="span" sx={{ fontWeight: 'bold' }} />]}
+                                />
+                              </Typography>
+                            </>
+                          ) : (
+                            <>
+                              <Trans
+                                i18nKey="registration.files_and_license.version_helper_text"
+                                components={[
+                                  <Typography paragraph />,
+                                  <Typography paragraph>
+                                    <Box component="span" sx={{ textDecoration: 'underline' }} />
+                                  </Typography>,
+                                ]}
+                              />
+
+                              <Typography paragraph>
+                                <Trans
+                                  i18nKey="registration.files_and_license.version_accepted_helper_text"
+                                  components={[<Box component="span" sx={{ fontWeight: 'bold' }} />]}
+                                />
+                              </Typography>
+                              <Typography paragraph>
+                                <Trans
+                                  i18nKey="registration.files_and_license.version_published_helper_text"
+                                  components={[<Box component="span" sx={{ fontWeight: 'bold' }} />]}
+                                />
+                              </Typography>
+                              <Typography paragraph>
+                                <Trans
+                                  i18nKey="registration.files_and_license.version_publishing_agreement_helper_text"
+                                  components={[<Box component="span" sx={{ fontWeight: 'bold' }} />]}
+                                />
+                              </Typography>
+                              <Typography paragraph>
+                                <Trans
+                                  i18nKey="registration.files_and_license.version_embargo_helper_text"
+                                  components={[<Box component="span" sx={{ fontWeight: 'bold' }} />]}
+                                />
+                              </Typography>
+                            </>
+                          )}
+                        </HelperTextModal>
+                      </Box>
+                    </StyledTableCell>
+                  )}
+
+                  <StyledTableCell>
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        gap: '0.5rem',
+                        alignItems: 'center',
+                      }}>
+                      {t('registration.files_and_license.license')}
+                      <HelperTextModal
+                        modalTitle={t('registration.files_and_license.licenses')}
+                        modalDataTestId={dataTestId.registrationWizard.files.licenseModal}
+                        buttonDataTestId={dataTestId.registrationWizard.files.licenseHelpButton}>
+                        <Typography paragraph>{t('registration.files_and_license.file_and_license_info')}</Typography>
+                        {licenses
+                          .filter(
+                            (license) =>
+                              license.version === 4 ||
+                              license.id === LicenseUri.CC0 ||
+                              license.id === LicenseUri.RightsReserved
+                          )
+                          .map((license) => (
+                            <Box key={license.id} sx={{ mb: '1rem', whiteSpace: 'pre-wrap' }}>
+                              <Typography variant="h3" gutterBottom>
+                                {license.name}
+                              </Typography>
+                              <Box component="img" src={license.logo} alt="" sx={{ width: '8rem' }} />
+                              <Typography paragraph>{license.description}</Typography>
+                              {license.link && (
+                                <Link href={license.link} target="blank">
+                                  {license.link}
+                                </Link>
+                              )}
+                            </Box>
+                          ))}
+                      </HelperTextModal>
+                    </Box>
+                  </StyledTableCell>
+                  <TableCell />
+                </>
               )}
-              {!archived && <TableCell />}
             </TableRow>
           </TableHead>
           <TableBody>
@@ -251,6 +254,7 @@ export const FileList = ({ title, files, uppy, remove, baseFieldName, archived }
                   baseFieldName={`${baseFieldName}[${associatedFileIndex}]`}
                   showFileVersion={showFileVersion}
                   showRrs={isTypeWithRrs(publicationInstanceType)}
+                  archived={archived}
                 />
               );
             })}

--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -47,9 +47,7 @@ import { DownloadFileButton } from './DownloadFileButton';
 export const markForPublishId = 'mark-for-publish';
 
 const VerticalAlignedTableCell = (props: TableCellProps) => (
-  <TableCell style={{ verticalAlign: 'middle' }} {...props}>
-    {props.children}
-  </TableCell>
+  <TableCell style={{ verticalAlign: 'middle' }} {...props} />
 );
 
 interface FilesTableRowProps {

--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -144,29 +144,27 @@ export const FilesTableRow = ({
             </Typography>
           </ConfirmDialog>
         </TableCell>
-        <TableCell>
-          <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-            <Field name={fileTypeFieldName}>
-              {({ field }: FieldProps) => (
-                <Checkbox
-                  {...field}
-                  data-testid={dataTestId.registrationWizard.files.toPublishCheckbox}
-                  checked={field.value === FileType.UnpublishedFile || field.value === FileType.PublishedFile}
-                  disabled={disabled}
-                  inputProps={{
-                    'aria-labelledby': markForPublishId,
-                  }}
-                  onChange={(_, checked) => {
-                    if (!checked) {
-                      setFieldValue(fileTypeFieldName, FileType.UnpublishableFile);
-                    } else {
-                      setFieldValue(fileTypeFieldName, FileType.UnpublishedFile);
-                    }
-                  }}
-                />
-              )}
-            </Field>
-          </Box>
+        <TableCell align="center">
+          <Field name={fileTypeFieldName}>
+            {({ field }: FieldProps) => (
+              <Checkbox
+                {...field}
+                data-testid={dataTestId.registrationWizard.files.toPublishCheckbox}
+                checked={field.value === FileType.UnpublishedFile || field.value === FileType.PublishedFile}
+                disabled={disabled}
+                inputProps={{
+                  'aria-labelledby': markForPublishId,
+                }}
+                onChange={(_, checked) => {
+                  if (!checked) {
+                    setFieldValue(fileTypeFieldName, FileType.UnpublishableFile);
+                  } else {
+                    setFieldValue(fileTypeFieldName, FileType.UnpublishedFile);
+                  }
+                }}
+              />
+            )}
+          </Field>
         </TableCell>
         {!archived && (
           <>

--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -19,6 +19,7 @@ import {
   Radio,
   RadioGroup,
   TableCell,
+  TableCellProps,
   TableRow,
   TextField,
   Tooltip,
@@ -44,6 +45,12 @@ import { DeleteIconButton } from '../../messages/components/DeleteIconButton';
 import { DownloadFileButton } from './DownloadFileButton';
 
 export const markForPublishId = 'mark-for-publish';
+
+const VerticalAlignedTableCell = (props: TableCellProps) => (
+  <TableCell style={{ verticalAlign: 'middle' }} {...props}>
+    {props.children}
+  </TableCell>
+);
 
 interface FilesTableRowProps {
   file: AssociatedFile;
@@ -114,37 +121,39 @@ export const FilesTableRow = ({
           bgcolor: disabled ? 'grey.400' : '',
           td: { verticalAlign: 'top', borderBottom: !archived ? 'unset' : '' },
         }}>
-        <TableCell sx={{ display: 'flex', minWidth: '13rem', gap: '0.75rem' }}>
-          <InsertDriveFileOutlinedIcon sx={{ color: disabled ? 'grey.600' : '' }} />
-          <Box sx={{ minWidth: '10rem' }}>
-            <TruncatableTypography sx={{ fontWeight: 'bold', color: disabled ? 'grey.600' : '' }}>
-              {file.name}
-            </TruncatableTypography>
-            <Typography sx={{ color: disabled ? 'grey.600' : '' }}>{prettyBytes(file.size)}</Typography>
+        <VerticalAlignedTableCell>
+          <Box sx={{ display: 'flex', minWidth: '13rem', gap: '0.75rem', alignItems: 'center' }}>
+            <InsertDriveFileOutlinedIcon sx={{ color: disabled ? 'grey.600' : '' }} />
+            <Box sx={{ minWidth: '10rem' }}>
+              <TruncatableTypography sx={{ fontWeight: 'bold', color: disabled ? 'grey.600' : '' }}>
+                {file.name}
+              </TruncatableTypography>
+              <Typography sx={{ color: disabled ? 'grey.600' : '' }}>{prettyBytes(file.size)}</Typography>
+            </Box>
+            <Box sx={{ minWidth: '1.5rem' }}>
+              <DownloadFileButton file={file} greyTones={disabled} />
+            </Box>
+            <DeleteIconButton
+              data-testid={dataTestId.registrationWizard.files.deleteFile}
+              onClick={disabled ? undefined : toggleOpenConfirmDialog}
+              tooltip={t('registration.files_and_license.remove_file')}
+              disabled={disabled}
+            />
+            <ConfirmDialog
+              open={openConfirmDialog}
+              title={t('registration.files_and_license.remove_file')}
+              onAccept={() => {
+                removeFile();
+                toggleOpenConfirmDialog();
+              }}
+              onCancel={toggleOpenConfirmDialog}>
+              <Typography>
+                {t('registration.files_and_license.remove_file_description', { fileName: file.name })}
+              </Typography>
+            </ConfirmDialog>
           </Box>
-          <Box sx={{ minWidth: '1.5rem' }}>
-            <DownloadFileButton file={file} greyTones={disabled} />
-          </Box>
-          <DeleteIconButton
-            data-testid={dataTestId.registrationWizard.files.deleteFile}
-            onClick={disabled ? undefined : toggleOpenConfirmDialog}
-            tooltip={t('registration.files_and_license.remove_file')}
-            disabled={disabled}
-          />
-          <ConfirmDialog
-            open={openConfirmDialog}
-            title={t('registration.files_and_license.remove_file')}
-            onAccept={() => {
-              removeFile();
-              toggleOpenConfirmDialog();
-            }}
-            onCancel={toggleOpenConfirmDialog}>
-            <Typography>
-              {t('registration.files_and_license.remove_file_description', { fileName: file.name })}
-            </Typography>
-          </ConfirmDialog>
-        </TableCell>
-        <TableCell align="center">
+        </VerticalAlignedTableCell>
+        <VerticalAlignedTableCell>
           <Field name={fileTypeFieldName}>
             {({ field }: FieldProps) => (
               <Checkbox
@@ -165,11 +174,11 @@ export const FilesTableRow = ({
               />
             )}
           </Field>
-        </TableCell>
+        </VerticalAlignedTableCell>
         {!archived && (
           <>
             {showFileVersion && (
-              <TableCell>
+              <VerticalAlignedTableCell>
                 <Field name={publisherVersionFieldName}>
                   {({ field, meta: { error, touched } }: FieldProps<FileVersion | null>) => (
                     <FormControl data-testid={dataTestId.registrationWizard.files.version} required disabled={disabled}>
@@ -222,9 +231,9 @@ export const FilesTableRow = ({
                     </FormControl>
                   )}
                 </Field>
-              </TableCell>
+              </VerticalAlignedTableCell>
             )}
-            <TableCell>
+            <VerticalAlignedTableCell>
               <Field name={licenseFieldName}>
                 {({ field, meta: { error, touched } }: FieldProps<string>) => (
                   <TextField
@@ -317,16 +326,15 @@ export const FilesTableRow = ({
                   )}
                 </>
               )}
-            </TableCell>
+            </VerticalAlignedTableCell>
 
-            <TableCell>
+            <VerticalAlignedTableCell>
               <IconButton
                 onClick={() => setOpenCollapsable(!openCollapsable)}
-                size="small"
                 data-testid={dataTestId.registrationWizard.files.expandFileRowButton}>
                 {openCollapsable ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
               </IconButton>
-            </TableCell>
+            </VerticalAlignedTableCell>
           </>
         )}
       </TableRow>


### PR DESCRIPTION
# Description

Disse endringene retter trolig noe av det samme som i https://github.com/BIBSYSDEV/NVA-Frontend/pull/5845

Blir en nokså stor diff pga endringer med innrykk, men det som er gjort er egentlig bare:
- Slår sammen det som tidligere var flere gjentatte sjekker på om gjeldende fil var arkivert
- Gjenbruk `archived` prop, i stedet for å definere den enda en gang i child component
- Fikser på alignment på mange av elementene i fil-tabellene (se bilder)

Før:
![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/982fdcb9-d14d-409f-b813-3faa3f8f0f76)

Etter:
![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/3077f10e-3b65-4ae5-b43f-a4a91250f449)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
