### PR TITLE
Handle key spread warnings

### DIFF
--- a/src/components/AreaOfResponsibiltySelector.tsx
+++ b/src/components/AreaOfResponsibiltySelector.tsx
@@ -107,7 +107,7 @@ export const AreaOfResponsibilitySelector = ({ sx, paramName, resetPagination }:
         resetPagination();
         history.push({ search: searchParams.toString() });
       }}
-      renderOption={(props, option, { selected }) => (
+      renderOption={({ key, ...props }, option, { selected }) => (
         <li {...props} key={option.id}>
           <Checkbox sx={{ ml: `${option.level}rem`, mr: '0.5rem' }} checked={selected} size="small" />
           {getLanguageString(option.labels)}

--- a/src/components/AreaOfResponsibiltySelector.tsx
+++ b/src/components/AreaOfResponsibiltySelector.tsx
@@ -107,8 +107,8 @@ export const AreaOfResponsibilitySelector = ({ sx, paramName, resetPagination }:
         resetPagination();
         history.push({ search: searchParams.toString() });
       }}
-      renderOption={({ key, ...props }, option, { selected }) => (
-        <li {...props} key={option.identifier}>
+      renderOption={(props, option, { selected }) => (
+        <li {...props} key={option.id}>
           <Checkbox sx={{ ml: `${option.level}rem`, mr: '0.5rem' }} checked={selected} size="small" />
           {getLanguageString(option.labels)}
         </li>

--- a/src/components/AreaOfResponsibiltySelector.tsx
+++ b/src/components/AreaOfResponsibiltySelector.tsx
@@ -107,7 +107,7 @@ export const AreaOfResponsibilitySelector = ({ sx, paramName, resetPagination }:
         resetPagination();
         history.push({ search: searchParams.toString() });
       }}
-      renderOption={(props, option, { selected }) => (
+      renderOption={({ key, ...props }, option, { selected }) => (
         <li {...props} key={option.identifier}>
           <Checkbox sx={{ ml: `${option.level}rem`, mr: '0.5rem' }} checked={selected} size="small" />
           {getLanguageString(option.labels)}

--- a/src/components/AssigneeSelector.tsx
+++ b/src/components/AssigneeSelector.tsx
@@ -59,7 +59,7 @@ export const AssigneeSelector = ({
   return showCuratorSearch ? (
     <Autocomplete
       options={curatorOptions}
-      renderOption={(props, option) => (
+      renderOption={({ key, ...props }, option) => (
         <li {...props} key={option.username}>
           {getFullName(option.givenName, option.familyName)}
         </li>

--- a/src/components/AssigneeSelector.tsx
+++ b/src/components/AssigneeSelector.tsx
@@ -59,7 +59,7 @@ export const AssigneeSelector = ({
   return showCuratorSearch ? (
     <Autocomplete
       options={curatorOptions}
-      renderOption={({ key, ...props }, option) => (
+      renderOption={(props, option) => (
         <li {...props} key={option.username}>
           {getFullName(option.givenName, option.familyName)}
         </li>

--- a/src/components/AutocompleteProjectOption.tsx
+++ b/src/components/AutocompleteProjectOption.tsx
@@ -5,13 +5,14 @@ import { dataTestId } from '../utils/dataTestIds';
 import { getLanguageString } from '../utils/translation-helpers';
 import { EmphasizeSubstring } from './EmphasizeSubstring';
 
-interface AutocompleteProjectOptionProps extends HTMLAttributes<HTMLLIElement> {
+interface AutocompleteProjectOptionProps {
+  props: HTMLAttributes<HTMLLIElement>;
   project: CristinProject;
   inputValue: string;
 }
 
-export const AutocompleteProjectOption = ({ project, inputValue, ...props }: AutocompleteProjectOptionProps) => (
-  <li {...props} key={project.id}>
+export const AutocompleteProjectOption = ({ project, inputValue, props }: AutocompleteProjectOptionProps) => (
+  <li {...props}>
     <Box
       sx={{ display: 'flex', flexDirection: 'column' }}
       data-testid={dataTestId.registrationWizard.description.projectSearchOption(project.id)}>

--- a/src/components/CuratorSelector.tsx
+++ b/src/components/CuratorSelector.tsx
@@ -53,7 +53,7 @@ export const CuratorSelector = ({ roleFilter, selectedUsername, onChange, sx }: 
       getOptionLabel={(option) => getFullName(option.givenName, option.familyName)}
       isOptionEqualToValue={(option, value) => option.username === value?.username}
       onChange={(_, value) => onChange(value)}
-      renderOption={({ key, ...props }, curator) => (
+      renderOption={(props, curator) => (
         <li {...props} key={curator.username}>
           <Box sx={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
             {CuratorAvatar(curator)}

--- a/src/components/CuratorSelector.tsx
+++ b/src/components/CuratorSelector.tsx
@@ -53,7 +53,7 @@ export const CuratorSelector = ({ roleFilter, selectedUsername, onChange, sx }: 
       getOptionLabel={(option) => getFullName(option.givenName, option.familyName)}
       isOptionEqualToValue={(option, value) => option.username === value?.username}
       onChange={(_, value) => onChange(value)}
-      renderOption={(props, curator) => (
+      renderOption={({ key, ...props }, curator) => (
         <li {...props} key={curator.username}>
           <Box sx={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
             {CuratorAvatar(curator)}

--- a/src/components/FundingSourceField.tsx
+++ b/src/components/FundingSourceField.tsx
@@ -37,7 +37,7 @@ export const FundingSourceField = ({ fieldName }: FundingSourceFieldProps) => {
               return identifier.includes(filter) || names.some((name) => name.includes(filter));
             });
           }}
-          renderOption={(props, option) => (
+          renderOption={({ key, ...props }, option) => (
             <li {...props} key={option.identifier}>
               {getLanguageString(option.name)}
             </li>

--- a/src/components/FundingSourceField.tsx
+++ b/src/components/FundingSourceField.tsx
@@ -37,7 +37,7 @@ export const FundingSourceField = ({ fieldName }: FundingSourceFieldProps) => {
               return identifier.includes(filter) || names.some((name) => name.includes(filter));
             });
           }}
-          renderOption={({ key, ...props }, option) => (
+          renderOption={(props, option) => (
             <li {...props} key={option.identifier}>
               {getLanguageString(option.name)}
             </li>

--- a/src/components/NfrProjectSearch.tsx
+++ b/src/components/NfrProjectSearch.tsx
@@ -33,7 +33,7 @@ export const NfrProjectSearch = ({ onSelectProject, errorMessage, ...textFieldPr
       filterOptions={(options) => options}
       onInputChange={(_, newInputValue) => setSearchTerm(newInputValue)}
       getOptionLabel={(option) => getLanguageString(option.labels)}
-      renderOption={(props, option) => {
+      renderOption={({ key, ...props }, option) => {
         const projectName = getLanguageString(option.labels);
         const period = getPeriodString(option.activeFrom, option.activeTo);
         const manager = option.lead ? `${t('project.project_manager')}: ${option.lead}` : '';

--- a/src/components/NfrProjectSearch.tsx
+++ b/src/components/NfrProjectSearch.tsx
@@ -33,12 +33,12 @@ export const NfrProjectSearch = ({ onSelectProject, errorMessage, ...textFieldPr
       filterOptions={(options) => options}
       onInputChange={(_, newInputValue) => setSearchTerm(newInputValue)}
       getOptionLabel={(option) => getLanguageString(option.labels)}
-      renderOption={(props, option) => {
+      renderOption={({ key, ...props }, option) => {
         const projectName = getLanguageString(option.labels);
         const period = getPeriodString(option.activeFrom, option.activeTo);
         const manager = option.lead ? `${t('project.project_manager')}: ${option.lead}` : '';
         return (
-          <li {...props}>
+          <li {...props} key={option.identifier}>
             <Box sx={{ display: 'flex', flexDirection: 'column' }}>
               <Typography sx={{ fontWeight: 600 }}>{projectName}</Typography>
               <Typography variant="body1">{period}</Typography>

--- a/src/components/NfrProjectSearch.tsx
+++ b/src/components/NfrProjectSearch.tsx
@@ -33,7 +33,7 @@ export const NfrProjectSearch = ({ onSelectProject, errorMessage, ...textFieldPr
       filterOptions={(options) => options}
       onInputChange={(_, newInputValue) => setSearchTerm(newInputValue)}
       getOptionLabel={(option) => getLanguageString(option.labels)}
-      renderOption={({ key, ...props }, option) => {
+      renderOption={(props, option) => {
         const projectName = getLanguageString(option.labels);
         const period = getPeriodString(option.activeFrom, option.activeTo);
         const manager = option.lead ? `${t('project.project_manager')}: ${option.lead}` : '';

--- a/src/components/SelectCustomerInstitutionDialog.tsx
+++ b/src/components/SelectCustomerInstitutionDialog.tsx
@@ -98,7 +98,7 @@ export const SelectCustomerInstitutionDialog = ({ allowedCustomerIds }: SelectCu
           renderOption={(props, option) => {
             const organization = organizations && organizations.find((org) => org.id === option.cristinId);
             return organization ? (
-              <OrganizationRenderOption key={option.id} props={props} option={organization} />
+              <OrganizationRenderOption key={organization.id} props={props} option={organization} />
             ) : (
               <li {...props} key={option.id}>
                 <Typography fontWeight="bold">{option.displayName}</Typography>

--- a/src/components/SelectCustomerInstitutionDialog.tsx
+++ b/src/components/SelectCustomerInstitutionDialog.tsx
@@ -95,7 +95,7 @@ export const SelectCustomerInstitutionDialog = ({ allowedCustomerIds }: SelectCu
           loading={isLoadingCustomers}
           onChange={(_, value) => setSelectedCustomer(value)}
           isOptionEqualToValue={(option, value) => option.id === value.id}
-          renderOption={({ key, ...props }, option) => {
+          renderOption={(props, option) => {
             const organization = organizations && organizations.find((org) => org.id === option.cristinId);
             return organization ? (
               <OrganizationRenderOption key={option.id} props={props} option={organization} />

--- a/src/components/SelectCustomerInstitutionDialog.tsx
+++ b/src/components/SelectCustomerInstitutionDialog.tsx
@@ -95,7 +95,7 @@ export const SelectCustomerInstitutionDialog = ({ allowedCustomerIds }: SelectCu
           loading={isLoadingCustomers}
           onChange={(_, value) => setSelectedCustomer(value)}
           isOptionEqualToValue={(option, value) => option.id === value.id}
-          renderOption={(props, option) => {
+          renderOption={({ key, ...props }, option) => {
             const organization = organizations && organizations.find((org) => org.id === option.cristinId);
             return organization ? (
               <OrganizationRenderOption key={organization.id} props={props} option={organization} />

--- a/src/components/SelectCustomerInstitutionDialog.tsx
+++ b/src/components/SelectCustomerInstitutionDialog.tsx
@@ -95,15 +95,13 @@ export const SelectCustomerInstitutionDialog = ({ allowedCustomerIds }: SelectCu
           loading={isLoadingCustomers}
           onChange={(_, value) => setSelectedCustomer(value)}
           isOptionEqualToValue={(option, value) => option.id === value.id}
-          renderOption={(props, option) => {
+          renderOption={({ key, ...props }, option) => {
             const organization = organizations && organizations.find((org) => org.id === option.cristinId);
             return organization ? (
-              <OrganizationRenderOption key={organization.id} props={props} option={organization} />
+              <OrganizationRenderOption key={option.id} props={props} option={organization} />
             ) : (
-              <li {...props}>
-                <Typography fontWeight="bold" key={option.id}>
-                  {option.displayName}
-                </Typography>
+              <li {...props} key={option.id}>
+                <Typography fontWeight="bold">{option.displayName}</Typography>
               </li>
             );
           }}

--- a/src/components/institution/SelectInstitutionForm.tsx
+++ b/src/components/institution/SelectInstitutionForm.tsx
@@ -125,7 +125,7 @@ export const SelectInstitutionForm = ({
                     options={organizationSearchQuery.data?.hits ?? []}
                     inputValue={field.value ? getLanguageString(field.value.labels) : searchTerm}
                     getOptionLabel={(option) => getLanguageString(option.labels)}
-                    renderOption={(props, option) => (
+                    renderOption={({ key, ...props }, option) => (
                       <OrganizationRenderOption key={option.id} props={props} option={option} />
                     )}
                     filterOptions={(options) => options}
@@ -172,7 +172,7 @@ export const SelectInstitutionForm = ({
                         value={field.value}
                         options={getSortedSubUnits(values.unit?.hasPart)}
                         getOptionLabel={(option) => getLanguageString(option.labels)}
-                        renderOption={(props, option) => (
+                        renderOption={({ key, ...props }, option) => (
                           <OrganizationRenderOption key={option.id} props={props} option={option} />
                         )}
                         onChange={(_, value) => {

--- a/src/components/institution/SelectInstitutionForm.tsx
+++ b/src/components/institution/SelectInstitutionForm.tsx
@@ -125,7 +125,7 @@ export const SelectInstitutionForm = ({
                     options={organizationSearchQuery.data?.hits ?? []}
                     inputValue={field.value ? getLanguageString(field.value.labels) : searchTerm}
                     getOptionLabel={(option) => getLanguageString(option.labels)}
-                    renderOption={({ key, ...props }, option) => (
+                    renderOption={(props, option) => (
                       <OrganizationRenderOption key={option.id} props={props} option={option} />
                     )}
                     filterOptions={(options) => options}
@@ -172,7 +172,7 @@ export const SelectInstitutionForm = ({
                         value={field.value}
                         options={getSortedSubUnits(values.unit?.hasPart)}
                         getOptionLabel={(option) => getLanguageString(option.labels)}
-                        renderOption={({ key, ...props }, option) => (
+                        renderOption={(props, option) => (
                           <OrganizationRenderOption key={option.id} props={props} option={option} />
                         )}
                         onChange={(_, value) => {

--- a/src/pages/basic_data/SearchForCristinPerson.tsx
+++ b/src/pages/basic_data/SearchForCristinPerson.tsx
@@ -89,7 +89,7 @@ export const SearchForCristinPerson = ({
           }}
           onInputChange={(_, value) => setSearchQuery(value)}
           loading={isLoadingSearchByNin || isLoadingSearchByName}
-          renderOption={({ key, ...props }, option) => (
+          renderOption={(props, option) => (
             <li {...props} key={option.id}>
               <Box sx={{ display: 'flex', flexDirection: 'column' }} data-testid={`person-option-${option.id}`}>
                 <Typography variant="subtitle1">

--- a/src/pages/basic_data/SearchForCristinPerson.tsx
+++ b/src/pages/basic_data/SearchForCristinPerson.tsx
@@ -89,7 +89,7 @@ export const SearchForCristinPerson = ({
           }}
           onInputChange={(_, value) => setSearchQuery(value)}
           loading={isLoadingSearchByNin || isLoadingSearchByName}
-          renderOption={(props, option) => (
+          renderOption={({ key, ...props }, option) => (
             <li {...props} key={option.id}>
               <Box sx={{ display: 'flex', flexDirection: 'column' }} data-testid={`person-option-${option.id}`}>
                 <Typography variant="subtitle1">

--- a/src/pages/basic_data/fields/PositionField.tsx
+++ b/src/pages/basic_data/fields/PositionField.tsx
@@ -57,7 +57,7 @@ export const PositionField = ({
           disabled={disabled}
           value={sortedPositions.find((option) => option.id === field.value) ?? null}
           options={sortedPositions}
-          renderOption={({ key, ...props }, option) => (
+          renderOption={(props, option) => (
             <li {...props} key={option.id}>
               <div>
                 <Typography>{getLanguageString(option.labels)}</Typography>

--- a/src/pages/basic_data/fields/PositionField.tsx
+++ b/src/pages/basic_data/fields/PositionField.tsx
@@ -57,7 +57,7 @@ export const PositionField = ({
           disabled={disabled}
           value={sortedPositions.find((option) => option.id === field.value) ?? null}
           options={sortedPositions}
-          renderOption={(props, option) => (
+          renderOption={({ key, ...props }, option) => (
             <li {...props} key={option.id}>
               <div>
                 <Typography>{getLanguageString(option.labels)}</Typography>

--- a/src/pages/basic_data/institution_admin/AddAffiliationSection.tsx
+++ b/src/pages/basic_data/institution_admin/AddAffiliationSection.tsx
@@ -40,7 +40,7 @@ export const AddAffiliationSection = () => {
               value={organizationOptions.find((option) => option.id === field.value) ?? null}
               options={organizationOptions}
               getOptionLabel={(option) => getLanguageString(option.labels)}
-              renderOption={({ key, ...props }, option) => (
+              renderOption={(props, option) => (
                 <OrganizationRenderOption key={option.id} props={props} option={option} />
               )}
               loading={isLoadingCurrentOrganization}

--- a/src/pages/basic_data/institution_admin/AddAffiliationSection.tsx
+++ b/src/pages/basic_data/institution_admin/AddAffiliationSection.tsx
@@ -40,7 +40,7 @@ export const AddAffiliationSection = () => {
               value={organizationOptions.find((option) => option.id === field.value) ?? null}
               options={organizationOptions}
               getOptionLabel={(option) => getLanguageString(option.labels)}
-              renderOption={(props, option) => (
+              renderOption={({ key, ...props }, option) => (
                 <OrganizationRenderOption key={option.id} props={props} option={option} />
               )}
               loading={isLoadingCurrentOrganization}

--- a/src/pages/basic_data/institution_admin/edit_user/AreaOfResponsibility.tsx
+++ b/src/pages/basic_data/institution_admin/edit_user/AreaOfResponsibility.tsx
@@ -64,7 +64,9 @@ export const AreaOfResponsibility = ({ viewingScopes, updateViewingScopes }: Are
           data-testid={dataTestId.myInstitutionUsersPage.areaOfResponsibilityField}
           options={options}
           getOptionLabel={(option) => getLanguageString(option.labels)}
-          renderOption={(props, option) => <OrganizationRenderOption key={option.id} props={props} option={option} />}
+          renderOption={({ key, ...props }, option) => (
+            <OrganizationRenderOption key={option.id} props={props} option={option} />
+          )}
           disabled={isSubmitting}
           onChange={(_, value) => {
             if (value) {

--- a/src/pages/basic_data/institution_admin/edit_user/AreaOfResponsibility.tsx
+++ b/src/pages/basic_data/institution_admin/edit_user/AreaOfResponsibility.tsx
@@ -64,9 +64,7 @@ export const AreaOfResponsibility = ({ viewingScopes, updateViewingScopes }: Are
           data-testid={dataTestId.myInstitutionUsersPage.areaOfResponsibilityField}
           options={options}
           getOptionLabel={(option) => getLanguageString(option.labels)}
-          renderOption={({ key, ...props }, option) => (
-            <OrganizationRenderOption key={option.id} props={props} option={option} />
-          )}
+          renderOption={(props, option) => <OrganizationRenderOption key={option.id} props={props} option={option} />}
           disabled={isSubmitting}
           onChange={(_, value) => {
             if (value) {

--- a/src/pages/editor/OrganizationOverview.tsx
+++ b/src/pages/editor/OrganizationOverview.tsx
@@ -66,7 +66,9 @@ export const OrganizationOverview = () => {
             options={allSubUnits}
             inputMode="search"
             getOptionLabel={(option) => getLanguageString(option.labels)}
-            renderOption={(props, option) => <OrganizationRenderOption key={option.id} props={props} option={option} />}
+            renderOption={({ key, ...props }, option) => (
+              <OrganizationRenderOption key={option.id} props={props} option={option} />
+            )}
             filterOptions={(options, state) =>
               options.filter(
                 (option) =>

--- a/src/pages/editor/OrganizationOverview.tsx
+++ b/src/pages/editor/OrganizationOverview.tsx
@@ -66,9 +66,7 @@ export const OrganizationOverview = () => {
             options={allSubUnits}
             inputMode="search"
             getOptionLabel={(option) => getLanguageString(option.labels)}
-            renderOption={({ key, ...props }, option) => (
-              <OrganizationRenderOption key={option.id} props={props} option={option} />
-            )}
+            renderOption={(props, option) => <OrganizationRenderOption key={option.id} props={props} option={option} />}
             filterOptions={(options, state) =>
               options.filter(
                 (option) =>

--- a/src/pages/editor/curators/AddCuratorDialog.tsx
+++ b/src/pages/editor/curators/AddCuratorDialog.tsx
@@ -118,7 +118,7 @@ export const AddCuratorDialog = ({
       <DialogContent>
         <Autocomplete
           options={employeeSearchQuery.data?.hits ?? []}
-          renderOption={(props, option) => (
+          renderOption={({ key, ...props }, option) => (
             <li {...props} key={option.id}>
               {getFullCristinName(option.names)}
             </li>

--- a/src/pages/editor/curators/AddCuratorDialog.tsx
+++ b/src/pages/editor/curators/AddCuratorDialog.tsx
@@ -118,7 +118,7 @@ export const AddCuratorDialog = ({
       <DialogContent>
         <Autocomplete
           options={employeeSearchQuery.data?.hits ?? []}
-          renderOption={({ key, ...props }, option) => (
+          renderOption={(props, option) => (
             <li {...props} key={option.id}>
               {getFullCristinName(option.names)}
             </li>

--- a/src/pages/editor/curators/OrganizationCurators.tsx
+++ b/src/pages/editor/curators/OrganizationCurators.tsx
@@ -103,7 +103,7 @@ export const OrganizationCurators = ({ heading, canEditUsers = false }: Organiza
                 options={allSubUnits}
                 inputMode="search"
                 getOptionLabel={(option) => getLanguageString(option.labels)}
-                renderOption={(props, option) => (
+                renderOption={({ key, ...props }, option) => (
                   <OrganizationRenderOption key={option.id} props={props} option={option} />
                 )}
                 filterOptions={(options, state) =>

--- a/src/pages/editor/curators/OrganizationCurators.tsx
+++ b/src/pages/editor/curators/OrganizationCurators.tsx
@@ -103,7 +103,7 @@ export const OrganizationCurators = ({ heading, canEditUsers = false }: Organiza
                 options={allSubUnits}
                 inputMode="search"
                 getOptionLabel={(option) => getLanguageString(option.labels)}
-                renderOption={({ key, ...props }, option) => (
+                renderOption={(props, option) => (
                   <OrganizationRenderOption key={option.id} props={props} option={option} />
                 )}
                 filterOptions={(options, state) =>

--- a/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
+++ b/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
@@ -119,7 +119,7 @@ export const MyFieldAndBackground = () => {
                       getOptionDisabled={(option) =>
                         field.value.some((keyword) => keyword.identifier === option.identifier)
                       }
-                      renderOption={({ key, ...props }, option) => (
+                      renderOption={(props, option) => (
                         <li {...props} key={option.identifier}>
                           <Typography>{getLanguageString(option.labels)}</Typography>
                         </li>

--- a/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
+++ b/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
@@ -126,7 +126,11 @@ export const MyFieldAndBackground = () => {
                       )}
                       renderTags={(value, getTagProps) =>
                         value.map((option, index) => (
-                          <Chip {...getTagProps({ index })} key={index} label={getLanguageString(option.labels)} />
+                          <Chip
+                            {...getTagProps({ index })}
+                            key={option.identifier}
+                            label={getLanguageString(option.labels)}
+                          />
                         ))
                       }
                       filterOptions={(options) => options}

--- a/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
+++ b/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
@@ -119,7 +119,7 @@ export const MyFieldAndBackground = () => {
                       getOptionDisabled={(option) =>
                         field.value.some((keyword) => keyword.identifier === option.identifier)
                       }
-                      renderOption={(props, option) => (
+                      renderOption={({ key, ...props }, option) => (
                         <li {...props} key={option.identifier}>
                           <Typography>{getLanguageString(option.labels)}</Typography>
                         </li>

--- a/src/pages/projects/form/RelatedProjectsField.tsx
+++ b/src/pages/projects/form/RelatedProjectsField.tsx
@@ -61,8 +61,8 @@ export const RelatedProjectsField = () => {
           }
           getOptionDisabled={(option) => field.value.some((project) => project === option.id)}
           loading={projectsQuery.isFetching}
-          renderOption={(props, option: CristinProject, state) => (
-            <AutocompleteProjectOption project={option} inputValue={state.inputValue} {...props} />
+          renderOption={({ key, ...props }, option: CristinProject, state) => (
+            <AutocompleteProjectOption key={option.id} project={option} inputValue={state.inputValue} props={props} />
           )}
           renderInput={(params) => (
             <AutocompleteTextField

--- a/src/pages/projects/form/RelatedProjectsField.tsx
+++ b/src/pages/projects/form/RelatedProjectsField.tsx
@@ -53,7 +53,7 @@ export const RelatedProjectsField = () => {
             value.map((option, index) => (
               <ProjectChip
                 {...getTagProps({ index })}
-                key={option}
+                key={index}
                 id={option}
                 fallbackName={option.split('/').pop() ?? ''}
               />

--- a/src/pages/projects/form/RelatedProjectsField.tsx
+++ b/src/pages/projects/form/RelatedProjectsField.tsx
@@ -61,7 +61,7 @@ export const RelatedProjectsField = () => {
           }
           getOptionDisabled={(option) => field.value.some((project) => project === option.id)}
           loading={projectsQuery.isFetching}
-          renderOption={({ key, ...props }, option: CristinProject, state) => (
+          renderOption={(props, option: CristinProject, state) => (
             <AutocompleteProjectOption key={option.id} project={option} inputValue={state.inputValue} props={props} />
           )}
           renderInput={(params) => (

--- a/src/pages/projects/form/RelatedProjectsField.tsx
+++ b/src/pages/projects/form/RelatedProjectsField.tsx
@@ -61,7 +61,7 @@ export const RelatedProjectsField = () => {
           }
           getOptionDisabled={(option) => field.value.some((project) => project === option.id)}
           loading={projectsQuery.isFetching}
-          renderOption={(props, option: CristinProject, state) => (
+          renderOption={({ key, ...props }, option: CristinProject, state) => (
             <AutocompleteProjectOption key={option.id} project={option} inputValue={state.inputValue} props={props} />
           )}
           renderInput={(params) => (

--- a/src/pages/registration/description_tab/projects_field/ProjectContributorRow.tsx
+++ b/src/pages/registration/description_tab/projects_field/ProjectContributorRow.tsx
@@ -151,7 +151,7 @@ export const ProjectContributorRow = ({
               setSearchTerm('');
             }}
             loading={personQuery.isFetching}
-            renderOption={(props, option) => {
+            renderOption={({ key, ...props }, option) => {
               const orgId = option.affiliations.length > 0 ? option.affiliations[0].organization ?? '' : '';
               return (
                 <li {...props} key={option.id}>

--- a/src/pages/registration/description_tab/projects_field/ProjectContributorRow.tsx
+++ b/src/pages/registration/description_tab/projects_field/ProjectContributorRow.tsx
@@ -151,7 +151,7 @@ export const ProjectContributorRow = ({
               setSearchTerm('');
             }}
             loading={personQuery.isFetching}
-            renderOption={({ key, ...props }, option) => {
+            renderOption={(props, option) => {
               const orgId = option.affiliations.length > 0 ? option.affiliations[0].organization ?? '' : '';
               return (
                 <li {...props} key={option.id}>

--- a/src/pages/registration/description_tab/projects_field/ProjectsField.tsx
+++ b/src/pages/registration/description_tab/projects_field/ProjectsField.tsx
@@ -87,7 +87,7 @@ export const ProjectsField = () => {
                 }
                 getOptionDisabled={(option) => field.value.some((project) => project.id === option.id)}
                 loading={projectsQuery.isFetching}
-                renderOption={({ key, ...props }, option: CristinProject, state) => (
+                renderOption={(props, option: CristinProject, state) => (
                   <AutocompleteProjectOption
                     key={option.id}
                     project={option}

--- a/src/pages/registration/description_tab/projects_field/ProjectsField.tsx
+++ b/src/pages/registration/description_tab/projects_field/ProjectsField.tsx
@@ -82,8 +82,13 @@ export const ProjectsField = () => {
                 }
                 getOptionDisabled={(option) => field.value.some((project) => project.id === option.id)}
                 loading={projectsQuery.isFetching}
-                renderOption={(props, option: CristinProject, state) => (
-                  <AutocompleteProjectOption project={option} inputValue={state.inputValue} {...props} />
+                renderOption={({ key, ...props }, option: CristinProject, state) => (
+                  <AutocompleteProjectOption
+                    key={option.id}
+                    project={option}
+                    inputValue={state.inputValue}
+                    props={props}
+                  />
                 )}
                 renderInput={(params) => (
                   <AutocompleteTextField

--- a/src/pages/registration/description_tab/projects_field/ProjectsField.tsx
+++ b/src/pages/registration/description_tab/projects_field/ProjectsField.tsx
@@ -77,7 +77,12 @@ export const ProjectsField = () => {
                 value={(field.value ?? []) as any[]}
                 renderTags={(value: ResearchProject[], getTagProps) =>
                   value.map((option, index) => (
-                    <ProjectChip {...getTagProps({ index })} key={index} id={option.id} fallbackName={option.name} />
+                    <ProjectChip
+                      {...getTagProps({ index })}
+                      key={option.id}
+                      id={option.id}
+                      fallbackName={option.name}
+                    />
                   ))
                 }
                 getOptionDisabled={(option) => field.value.some((project) => project.id === option.id)}

--- a/src/pages/registration/description_tab/projects_field/ProjectsField.tsx
+++ b/src/pages/registration/description_tab/projects_field/ProjectsField.tsx
@@ -87,7 +87,7 @@ export const ProjectsField = () => {
                 }
                 getOptionDisabled={(option) => field.value.some((project) => project.id === option.id)}
                 loading={projectsQuery.isFetching}
-                renderOption={(props, option: CristinProject, state) => (
+                renderOption={({ key, ...props }, option: CristinProject, state) => (
                   <AutocompleteProjectOption
                     key={option.id}
                     project={option}

--- a/src/pages/registration/description_tab/vocabularies/HrcsActivityInput.tsx
+++ b/src/pages/registration/description_tab/vocabularies/HrcsActivityInput.tsx
@@ -21,7 +21,7 @@ export const HrcsActivityInput = (props: VocabularyComponentProps) => {
       options={hrcsActivityOptions}
       id="hrcs-activities"
       label={t('registration.description.hrcs_activities')}
-      renderOption={({ key, ...props }, option) => {
+      renderOption={(props, option) => {
         const indentsCount = option.cristinIdentifier.split('.').length - 1;
         return (
           <li {...props} key={option.id}>

--- a/src/pages/registration/description_tab/vocabularies/HrcsActivityInput.tsx
+++ b/src/pages/registration/description_tab/vocabularies/HrcsActivityInput.tsx
@@ -21,7 +21,7 @@ export const HrcsActivityInput = (props: VocabularyComponentProps) => {
       options={hrcsActivityOptions}
       id="hrcs-activities"
       label={t('registration.description.hrcs_activities')}
-      renderOption={(props, option) => {
+      renderOption={({ key, ...props }, option) => {
         const indentsCount = option.cristinIdentifier.split('.').length - 1;
         return (
           <li {...props} key={option.id}>

--- a/src/pages/registration/resource_type_tab/components/JournalField.tsx
+++ b/src/pages/registration/resource_type_tab/components/JournalField.tsx
@@ -165,17 +165,14 @@ export const JournalField = ({ confirmedContextType, unconfirmedContextType }: J
               } satisfies AutocompleteListboxWithExpansionProps as any
             }
             renderTags={(value, getTagProps) =>
-              value.map((option, index) => {
-                const { key, ...rest } = getTagProps({ index });
-                return (
-                  <Chip
-                    key={key}
-                    {...rest}
-                    data-testid={dataTestId.registrationWizard.resourceType.journalChip}
-                    label={<PublicationChannelChipLabel value={option} />}
-                  />
-                );
-              })
+              value.map((option, index) => (
+                <Chip
+                  {...getTagProps({ index })}
+                  key={option.identifier}
+                  data-testid={dataTestId.registrationWizard.resourceType.journalChip}
+                  label={<PublicationChannelChipLabel value={option} />}
+                />
+              ))
             }
             renderInput={(params) => (
               <AutocompleteTextField

--- a/src/pages/registration/resource_type_tab/components/JournalField.tsx
+++ b/src/pages/registration/resource_type_tab/components/JournalField.tsx
@@ -153,7 +153,7 @@ export const JournalField = ({ confirmedContextType, unconfirmedContextType }: J
             }}
             loading={journalOptionsQuery.isFetching || journalQuery.isFetching}
             getOptionLabel={(option) => option.name}
-            renderOption={({ key, ...props }, option, state) => (
+            renderOption={(props, option, state) => (
               <PublicationChannelOption key={option.identifier} props={props} option={option} state={state} />
             )}
             ListboxComponent={AutocompleteListboxWithExpansion}

--- a/src/pages/registration/resource_type_tab/components/JournalField.tsx
+++ b/src/pages/registration/resource_type_tab/components/JournalField.tsx
@@ -153,7 +153,7 @@ export const JournalField = ({ confirmedContextType, unconfirmedContextType }: J
             }}
             loading={journalOptionsQuery.isFetching || journalQuery.isFetching}
             getOptionLabel={(option) => option.name}
-            renderOption={(props, option, state) => (
+            renderOption={({ key, ...props }, option, state) => (
               <PublicationChannelOption key={option.identifier} props={props} option={option} state={state} />
             )}
             ListboxComponent={AutocompleteListboxWithExpansion}

--- a/src/pages/registration/resource_type_tab/components/JournalField.tsx
+++ b/src/pages/registration/resource_type_tab/components/JournalField.tsx
@@ -153,8 +153,8 @@ export const JournalField = ({ confirmedContextType, unconfirmedContextType }: J
             }}
             loading={journalOptionsQuery.isFetching || journalQuery.isFetching}
             getOptionLabel={(option) => option.name}
-            renderOption={(props, option, state) => (
-              <PublicationChannelOption key={option.id} props={props} option={option} state={state} />
+            renderOption={({ key, ...props }, option, state) => (
+              <PublicationChannelOption key={option.identifier} props={props} option={option} state={state} />
             )}
             ListboxComponent={AutocompleteListboxWithExpansion}
             ListboxProps={

--- a/src/pages/registration/resource_type_tab/components/PublisherField.tsx
+++ b/src/pages/registration/resource_type_tab/components/PublisherField.tsx
@@ -113,7 +113,7 @@ export const PublisherField = () => {
             }}
             loading={publisherOptionsQuery.isFetching || publisherQuery.isFetching}
             getOptionLabel={(option) => option.name}
-            renderOption={(props, option, state) => (
+            renderOption={({ key, ...props }, option, state) => (
               <PublicationChannelOption key={option.identifier} props={props} option={option} state={state} />
             )}
             ListboxComponent={AutocompleteListboxWithExpansion}

--- a/src/pages/registration/resource_type_tab/components/PublisherField.tsx
+++ b/src/pages/registration/resource_type_tab/components/PublisherField.tsx
@@ -126,17 +126,14 @@ export const PublisherField = () => {
               } satisfies AutocompleteListboxWithExpansionProps as any
             }
             renderTags={(value, getTagProps) =>
-              value.map((option, index) => {
-                const { key, ...rest } = getTagProps({ index });
-                return (
-                  <Chip
-                    key={key}
-                    {...rest}
-                    data-testid={dataTestId.registrationWizard.resourceType.publisherChip}
-                    label={<PublicationChannelChipLabel value={option} />}
-                  />
-                );
-              })
+              value.map((option, index) => (
+                <Chip
+                  {...getTagProps({ index })}
+                  key={option.identifier}
+                  data-testid={dataTestId.registrationWizard.resourceType.publisherChip}
+                  label={<PublicationChannelChipLabel value={option} />}
+                />
+              ))
             }
             renderInput={(params) => (
               <AutocompleteTextField

--- a/src/pages/registration/resource_type_tab/components/PublisherField.tsx
+++ b/src/pages/registration/resource_type_tab/components/PublisherField.tsx
@@ -114,7 +114,7 @@ export const PublisherField = () => {
             loading={publisherOptionsQuery.isFetching || publisherQuery.isFetching}
             getOptionLabel={(option) => option.name}
             renderOption={(props, option, state) => (
-              <PublicationChannelOption key={option.id} props={props} option={option} state={state} />
+              <PublicationChannelOption key={option.identifier} props={props} option={option} state={state} />
             )}
             ListboxComponent={AutocompleteListboxWithExpansion}
             ListboxProps={

--- a/src/pages/registration/resource_type_tab/components/SearchContainerField.tsx
+++ b/src/pages/registration/resource_type_tab/components/SearchContainerField.tsx
@@ -100,7 +100,7 @@ export const SearchContainerField = ({
             }}
             loading={containerOptionsQuery.isFetching || isLoadingSelectedContainer}
             getOptionLabel={(option) => getTitleString(option.entityDescription?.mainTitle)}
-            renderOption={({ key, ...props }, option, state) => (
+            renderOption={(props, option, state) => (
               <li {...props} key={option.identifier}>
                 <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                   <Typography variant="subtitle1">

--- a/src/pages/registration/resource_type_tab/components/SearchContainerField.tsx
+++ b/src/pages/registration/resource_type_tab/components/SearchContainerField.tsx
@@ -100,8 +100,8 @@ export const SearchContainerField = ({
             }}
             loading={containerOptionsQuery.isFetching || isLoadingSelectedContainer}
             getOptionLabel={(option) => getTitleString(option.entityDescription?.mainTitle)}
-            renderOption={(props, option, state) => (
-              <li {...props}>
+            renderOption={({ key, ...props }, option, state) => (
+              <li {...props} key={option.identifier}>
                 <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                   <Typography variant="subtitle1">
                     <EmphasizeSubstring

--- a/src/pages/registration/resource_type_tab/components/SearchContainerField.tsx
+++ b/src/pages/registration/resource_type_tab/components/SearchContainerField.tsx
@@ -100,7 +100,7 @@ export const SearchContainerField = ({
             }}
             loading={containerOptionsQuery.isFetching || isLoadingSelectedContainer}
             getOptionLabel={(option) => getTitleString(option.entityDescription?.mainTitle)}
-            renderOption={(props, option, state) => (
+            renderOption={({ key, ...props }, option, state) => (
               <li {...props} key={option.identifier}>
                 <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                   <Typography variant="subtitle1">

--- a/src/pages/registration/resource_type_tab/components/SearchContainerField.tsx
+++ b/src/pages/registration/resource_type_tab/components/SearchContainerField.tsx
@@ -121,31 +121,26 @@ export const SearchContainerField = ({
               </li>
             )}
             renderTags={(value, getTagProps) =>
-              value.map((option, index) => {
-                const { key, ...rest } = getTagProps({ index });
-                return (
-                  <Chip
-                    key={key}
-                    {...rest}
-                    data-testid={dataTestIds.registrationWizard.resourceType.journalChip}
-                    label={
-                      <>
-                        <Typography variant="subtitle1">
-                          {getTitleString(option.entityDescription?.mainTitle)}
-                        </Typography>
-                        {descriptionToShow === 'year-and-contributors' ? (
-                          <YearAndContributorsText
-                            date={option.entityDescription?.publicationDate}
-                            contributors={option.entityDescription?.contributors ?? []}
-                          />
-                        ) : (
-                          <ContainerAndLevelText registration={option} />
-                        )}
-                      </>
-                    }
-                  />
-                );
-              })
+              value.map((option, index) => (
+                <Chip
+                  {...getTagProps({ index })}
+                  key={option.identifier}
+                  data-testid={dataTestIds.registrationWizard.resourceType.journalChip}
+                  label={
+                    <>
+                      <Typography variant="subtitle1">{getTitleString(option.entityDescription?.mainTitle)}</Typography>
+                      {descriptionToShow === 'year-and-contributors' ? (
+                        <YearAndContributorsText
+                          date={option.entityDescription?.publicationDate}
+                          contributors={option.entityDescription?.contributors ?? []}
+                        />
+                      ) : (
+                        <ContainerAndLevelText registration={option} />
+                      )}
+                    </>
+                  }
+                />
+              ))
             }
             renderInput={(params) => (
               <AutocompleteTextField

--- a/src/pages/registration/resource_type_tab/components/SearchRelatedResultField.tsx
+++ b/src/pages/registration/resource_type_tab/components/SearchRelatedResultField.tsx
@@ -58,7 +58,7 @@ export const SearchRelatedResultField = () => {
             loading={relatedRegistrationsOptionsQuery.isPending}
             filterOptions={(options) => options}
             getOptionLabel={(option) => getTitleString(option.entityDescription?.mainTitle)}
-            renderOption={(props, option, state) => (
+            renderOption={({ key, ...props }, option, state) => (
               <li {...props} key={option.identifier}>
                 <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                   <Typography variant="subtitle1">

--- a/src/pages/registration/resource_type_tab/components/SearchRelatedResultField.tsx
+++ b/src/pages/registration/resource_type_tab/components/SearchRelatedResultField.tsx
@@ -58,7 +58,7 @@ export const SearchRelatedResultField = () => {
             loading={relatedRegistrationsOptionsQuery.isPending}
             filterOptions={(options) => options}
             getOptionLabel={(option) => getTitleString(option.entityDescription?.mainTitle)}
-            renderOption={({ key, ...props }, option, state) => (
+            renderOption={(props, option, state) => (
               <li {...props} key={option.identifier}>
                 <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                   <Typography variant="subtitle1">

--- a/src/pages/registration/resource_type_tab/components/SeriesField.tsx
+++ b/src/pages/registration/resource_type_tab/components/SeriesField.tsx
@@ -110,7 +110,7 @@ export const SeriesField = () => {
             }}
             loading={seriesOptionsQuery.isFetching || seriesQuery.isFetching}
             getOptionLabel={(option) => option.name}
-            renderOption={(props, option, state) => (
+            renderOption={({ key, ...props }, option, state) => (
               <PublicationChannelOption key={option.identifier} props={props} option={option} state={state} />
             )}
             ListboxComponent={AutocompleteListboxWithExpansion}

--- a/src/pages/registration/resource_type_tab/components/SeriesField.tsx
+++ b/src/pages/registration/resource_type_tab/components/SeriesField.tsx
@@ -122,17 +122,14 @@ export const SeriesField = () => {
               } satisfies AutocompleteListboxWithExpansionProps as any
             }
             renderTags={(value, getTagProps) =>
-              value.map((option, index) => {
-                const { key, ...rest } = getTagProps({ index });
-                return (
-                  <Chip
-                    key={index}
-                    {...rest}
-                    data-testid={dataTestId.registrationWizard.resourceType.seriesChip}
-                    label={<PublicationChannelChipLabel value={option} />}
-                  />
-                );
-              })
+              value.map((option, index) => (
+                <Chip
+                  {...getTagProps({ index })}
+                  key={option.identifier}
+                  data-testid={dataTestId.registrationWizard.resourceType.seriesChip}
+                  label={<PublicationChannelChipLabel value={option} />}
+                />
+              ))
             }
             renderInput={(params) => (
               <AutocompleteTextField

--- a/src/pages/registration/resource_type_tab/components/SeriesField.tsx
+++ b/src/pages/registration/resource_type_tab/components/SeriesField.tsx
@@ -110,7 +110,7 @@ export const SeriesField = () => {
             }}
             loading={seriesOptionsQuery.isFetching || seriesQuery.isFetching}
             getOptionLabel={(option) => option.name}
-            renderOption={({ key, ...props }, option, state) => (
+            renderOption={(props, option, state) => (
               <PublicationChannelOption key={option.identifier} props={props} option={option} state={state} />
             )}
             ListboxComponent={AutocompleteListboxWithExpansion}

--- a/src/pages/registration/resource_type_tab/components/SeriesField.tsx
+++ b/src/pages/registration/resource_type_tab/components/SeriesField.tsx
@@ -110,8 +110,8 @@ export const SeriesField = () => {
             }}
             loading={seriesOptionsQuery.isFetching || seriesQuery.isFetching}
             getOptionLabel={(option) => option.name}
-            renderOption={(props, option, state) => (
-              <PublicationChannelOption key={option.id} props={props} option={option} state={state} />
+            renderOption={({ key, ...props }, option, state) => (
+              <PublicationChannelOption key={option.identifier} props={props} option={option} state={state} />
             )}
             ListboxComponent={AutocompleteListboxWithExpansion}
             ListboxProps={

--- a/src/pages/registration/resource_type_tab/sub_type_forms/PresentationForm.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/PresentationForm.tsx
@@ -90,7 +90,7 @@ export const PresentationForm = () => {
             onChange={(_, value) => setFieldValue(field.name, value?.code)}
             isOptionEqualToValue={(option, value) => option.code === value.code}
             getOptionLabel={(option) => option.label}
-            renderOption={({ key, ...props }, option) => (
+            renderOption={(props, option) => (
               <li {...props} key={option.code}>
                 <Box
                   component="img"

--- a/src/pages/registration/resource_type_tab/sub_type_forms/PresentationForm.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/PresentationForm.tsx
@@ -90,8 +90,8 @@ export const PresentationForm = () => {
             onChange={(_, value) => setFieldValue(field.name, value?.code)}
             isOptionEqualToValue={(option, value) => option.code === value.code}
             getOptionLabel={(option) => option.label}
-            renderOption={(props, option) => (
-              <li {...props}>
+            renderOption={({ key, ...props }, option) => (
+              <li {...props} key={option.code}>
                 <Box
                   component="img"
                   sx={{ mr: '1rem' }}

--- a/src/pages/registration/resource_type_tab/sub_type_forms/PresentationForm.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/PresentationForm.tsx
@@ -90,7 +90,7 @@ export const PresentationForm = () => {
             onChange={(_, value) => setFieldValue(field.name, value?.code)}
             isOptionEqualToValue={(option, value) => option.code === value.code}
             getOptionLabel={(option) => option.label}
-            renderOption={(props, option) => (
+            renderOption={({ key, ...props }, option) => (
               <li {...props} key={option.code}>
                 <Box
                   component="img"

--- a/src/pages/registration/resource_type_tab/sub_type_forms/research_data_types/DataManagementPlanForm.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/research_data_types/DataManagementPlanForm.tsx
@@ -69,7 +69,7 @@ export const DataManagementPlanForm = () => {
               loading={searchOptionsQuery.isPending}
               filterOptions={(options) => options}
               getOptionLabel={(option) => getTitleString(option.entityDescription?.mainTitle)}
-              renderOption={(props, option, state) => (
+              renderOption={({ key, ...props }, option, state) => (
                 <li {...props} key={option.identifier}>
                   <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                     <Typography variant="subtitle1">

--- a/src/pages/registration/resource_type_tab/sub_type_forms/research_data_types/DataManagementPlanForm.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/research_data_types/DataManagementPlanForm.tsx
@@ -69,8 +69,8 @@ export const DataManagementPlanForm = () => {
               loading={searchOptionsQuery.isPending}
               filterOptions={(options) => options}
               getOptionLabel={(option) => getTitleString(option.entityDescription?.mainTitle)}
-              renderOption={(props, option, state) => (
-                <li {...props}>
+              renderOption={({ key, ...props }, option, state) => (
+                <li {...props} key={option.identifier}>
                   <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                     <Typography variant="subtitle1">
                       <EmphasizeSubstring

--- a/src/pages/registration/resource_type_tab/sub_type_forms/research_data_types/DataManagementPlanForm.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/research_data_types/DataManagementPlanForm.tsx
@@ -69,7 +69,7 @@ export const DataManagementPlanForm = () => {
               loading={searchOptionsQuery.isPending}
               filterOptions={(options) => options}
               getOptionLabel={(option) => getTitleString(option.entityDescription?.mainTitle)}
-              renderOption={({ key, ...props }, option, state) => (
+              renderOption={(props, option, state) => (
                 <li {...props} key={option.identifier}>
                   <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                     <Typography variant="subtitle1">

--- a/src/pages/registration/resource_type_tab/sub_type_forms/research_data_types/DatasetForm.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/research_data_types/DatasetForm.tsx
@@ -83,7 +83,7 @@ export const DatasetForm = () => {
               loading={relatedRegistrationsOptionsQuery.isPending}
               filterOptions={(options) => options}
               getOptionLabel={(option) => getTitleString(option.entityDescription?.mainTitle)}
-              renderOption={({ key, ...props }, option, state) => (
+              renderOption={(props, option, state) => (
                 <li {...props} key={option.identifier}>
                   <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                     <Typography variant="subtitle1">
@@ -144,7 +144,7 @@ export const DatasetForm = () => {
               loading={relatedDmpOptionsQuery.isPending}
               filterOptions={(options) => options}
               getOptionLabel={(option) => getTitleString(option.entityDescription?.mainTitle)}
-              renderOption={({ key, ...props }, option, state) => (
+              renderOption={(props, option, state) => (
                 <li {...props} key={option.identifier}>
                   <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                     <Typography variant="subtitle1">

--- a/src/pages/registration/resource_type_tab/sub_type_forms/research_data_types/DatasetForm.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/research_data_types/DatasetForm.tsx
@@ -83,7 +83,7 @@ export const DatasetForm = () => {
               loading={relatedRegistrationsOptionsQuery.isPending}
               filterOptions={(options) => options}
               getOptionLabel={(option) => getTitleString(option.entityDescription?.mainTitle)}
-              renderOption={(props, option, state) => (
+              renderOption={({ key, ...props }, option, state) => (
                 <li {...props} key={option.identifier}>
                   <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                     <Typography variant="subtitle1">
@@ -144,7 +144,7 @@ export const DatasetForm = () => {
               loading={relatedDmpOptionsQuery.isPending}
               filterOptions={(options) => options}
               getOptionLabel={(option) => getTitleString(option.entityDescription?.mainTitle)}
-              renderOption={(props, option, state) => (
+              renderOption={({ key, ...props }, option, state) => (
                 <li {...props} key={option.identifier}>
                   <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                     <Typography variant="subtitle1">

--- a/src/pages/search/advanced_search/FundingSourceFilter.tsx
+++ b/src/pages/search/advanced_search/FundingSourceFilter.tsx
@@ -45,7 +45,7 @@ export const FundingSourceFilter = () => {
       }}
       options={fundingSourcesList}
       getOptionLabel={(option) => getLanguageString(option.name)}
-      renderOption={(props, option) => (
+      renderOption={({ key, ...props }, option) => (
         <li {...props} key={option.identifier}>
           {getLanguageString(option.name)}
         </li>

--- a/src/pages/search/advanced_search/FundingSourceFilter.tsx
+++ b/src/pages/search/advanced_search/FundingSourceFilter.tsx
@@ -45,7 +45,7 @@ export const FundingSourceFilter = () => {
       }}
       options={fundingSourcesList}
       getOptionLabel={(option) => getLanguageString(option.name)}
-      renderOption={({ key, ...props }, option) => (
+      renderOption={(props, option) => (
         <li {...props} key={option.identifier}>
           {getLanguageString(option.name)}
         </li>

--- a/src/pages/search/advanced_search/JournalFilter.tsx
+++ b/src/pages/search/advanced_search/JournalFilter.tsx
@@ -73,7 +73,7 @@ export const JournalFilter = () => {
       disableClearable={!journalQuery}
       loading={isFetching}
       getOptionLabel={(option) => option.name}
-      renderOption={(props, option, state) => (
+      renderOption={({ key, ...props }, option, state) => (
         <PublicationChannelOption
           key={option.identifier}
           props={props}

--- a/src/pages/search/advanced_search/JournalFilter.tsx
+++ b/src/pages/search/advanced_search/JournalFilter.tsx
@@ -73,7 +73,7 @@ export const JournalFilter = () => {
       disableClearable={!journalQuery}
       loading={isFetching}
       getOptionLabel={(option) => option.name}
-      renderOption={({ key, ...props }, option, state) => (
+      renderOption={(props, option, state) => (
         <PublicationChannelOption
           key={option.identifier}
           props={props}

--- a/src/pages/search/advanced_search/JournalFilter.tsx
+++ b/src/pages/search/advanced_search/JournalFilter.tsx
@@ -73,8 +73,14 @@ export const JournalFilter = () => {
       disableClearable={!journalQuery}
       loading={isFetching}
       getOptionLabel={(option) => option.name}
-      renderOption={(props, option, state) => (
-        <PublicationChannelOption key={option.id} props={props} option={option} state={state} hideScientificLevel />
+      renderOption={({ key, ...props }, option, state) => (
+        <PublicationChannelOption
+          key={option.identifier}
+          props={props}
+          option={option}
+          state={state}
+          hideScientificLevel
+        />
       )}
       ListboxComponent={AutocompleteListboxWithExpansion}
       ListboxProps={

--- a/src/pages/search/advanced_search/OrganizationFilters.tsx
+++ b/src/pages/search/advanced_search/OrganizationFilters.tsx
@@ -127,9 +127,7 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
         disabled={topLevelOrganizationQuery.isFetching}
         value={topLevelOrganizationQuery.data ?? null}
         loading={isLoading}
-        renderOption={({ key, ...props }, option) => (
-          <OrganizationRenderOption key={option.id} props={props} option={option} />
-        )}
+        renderOption={(props, option) => <OrganizationRenderOption key={option.id} props={props} option={option} />}
         renderInput={(params) => (
           <AutocompleteTextField
             {...params}

--- a/src/pages/search/advanced_search/OrganizationFilters.tsx
+++ b/src/pages/search/advanced_search/OrganizationFilters.tsx
@@ -127,7 +127,9 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
         disabled={topLevelOrganizationQuery.isFetching}
         value={topLevelOrganizationQuery.data ?? null}
         loading={isLoading}
-        renderOption={(props, option) => <OrganizationRenderOption key={option.id} props={props} option={option} />}
+        renderOption={({ key, ...props }, option) => (
+          <OrganizationRenderOption key={option.id} props={props} option={option} />
+        )}
         renderInput={(params) => (
           <AutocompleteTextField
             {...params}

--- a/src/pages/search/advanced_search/OrganizationHierarchyFilter.tsx
+++ b/src/pages/search/advanced_search/OrganizationHierarchyFilter.tsx
@@ -74,9 +74,7 @@ export const OrganizationHierarchyFilter = ({ organization, open, onClose }: Org
             options={allSubUnits}
             inputMode="search"
             getOptionLabel={(option) => getLanguageString(option.labels)}
-            renderOption={({ key, ...props }, option) => (
-              <OrganizationRenderOption key={option.id} props={props} option={option} />
-            )}
+            renderOption={(props, option) => <OrganizationRenderOption key={option.id} props={props} option={option} />}
             filterOptions={(options, state) =>
               options.filter(
                 (option) =>

--- a/src/pages/search/advanced_search/OrganizationHierarchyFilter.tsx
+++ b/src/pages/search/advanced_search/OrganizationHierarchyFilter.tsx
@@ -74,7 +74,9 @@ export const OrganizationHierarchyFilter = ({ organization, open, onClose }: Org
             options={allSubUnits}
             inputMode="search"
             getOptionLabel={(option) => getLanguageString(option.labels)}
-            renderOption={(props, option) => <OrganizationRenderOption key={option.id} props={props} option={option} />}
+            renderOption={({ key, ...props }, option) => (
+              <OrganizationRenderOption key={option.id} props={props} option={option} />
+            )}
             filterOptions={(options, state) =>
               options.filter(
                 (option) =>

--- a/src/pages/search/advanced_search/PublisherFilter.tsx
+++ b/src/pages/search/advanced_search/PublisherFilter.tsx
@@ -73,7 +73,7 @@ export const PublisherFilter = () => {
       disableClearable={!publisherQuery}
       loading={isFetching}
       getOptionLabel={(option) => option.name}
-      renderOption={(props, option, state) => (
+      renderOption={({ key, ...props }, option, state) => (
         <PublicationChannelOption
           key={option.identifier}
           props={props}

--- a/src/pages/search/advanced_search/PublisherFilter.tsx
+++ b/src/pages/search/advanced_search/PublisherFilter.tsx
@@ -73,7 +73,7 @@ export const PublisherFilter = () => {
       disableClearable={!publisherQuery}
       loading={isFetching}
       getOptionLabel={(option) => option.name}
-      renderOption={({ key, ...props }, option, state) => (
+      renderOption={(props, option, state) => (
         <PublicationChannelOption
           key={option.identifier}
           props={props}

--- a/src/pages/search/advanced_search/PublisherFilter.tsx
+++ b/src/pages/search/advanced_search/PublisherFilter.tsx
@@ -73,8 +73,14 @@ export const PublisherFilter = () => {
       disableClearable={!publisherQuery}
       loading={isFetching}
       getOptionLabel={(option) => option.name}
-      renderOption={(props, option, state) => (
-        <PublicationChannelOption key={option.id} props={props} option={option} state={state} hideScientificLevel />
+      renderOption={({ key, ...props }, option, state) => (
+        <PublicationChannelOption
+          key={option.identifier}
+          props={props}
+          option={option}
+          state={state}
+          hideScientificLevel
+        />
       )}
       ListboxComponent={AutocompleteListboxWithExpansion}
       ListboxProps={

--- a/src/pages/search/advanced_search/SeriesFilter.tsx
+++ b/src/pages/search/advanced_search/SeriesFilter.tsx
@@ -73,8 +73,14 @@ export const SeriesFilter = () => {
       disableClearable={!seriesQuery}
       loading={isFetching}
       getOptionLabel={(option) => option.name}
-      renderOption={(props, option, state) => (
-        <PublicationChannelOption key={option.id} props={props} option={option} state={state} hideScientificLevel />
+      renderOption={({ key, ...props }, option, state) => (
+        <PublicationChannelOption
+          key={option.identifier}
+          props={props}
+          option={option}
+          state={state}
+          hideScientificLevel
+        />
       )}
       ListboxComponent={AutocompleteListboxWithExpansion}
       ListboxProps={

--- a/src/pages/search/advanced_search/SeriesFilter.tsx
+++ b/src/pages/search/advanced_search/SeriesFilter.tsx
@@ -73,7 +73,7 @@ export const SeriesFilter = () => {
       disableClearable={!seriesQuery}
       loading={isFetching}
       getOptionLabel={(option) => option.name}
-      renderOption={(props, option, state) => (
+      renderOption={({ key, ...props }, option, state) => (
         <PublicationChannelOption
           key={option.identifier}
           props={props}

--- a/src/pages/search/advanced_search/SeriesFilter.tsx
+++ b/src/pages/search/advanced_search/SeriesFilter.tsx
@@ -73,7 +73,7 @@ export const SeriesFilter = () => {
       disableClearable={!seriesQuery}
       loading={isFetching}
       getOptionLabel={(option) => option.name}
-      renderOption={({ key, ...props }, option, state) => (
+      renderOption={(props, option, state) => (
         <PublicationChannelOption
           key={option.identifier}
           props={props}


### PR DESCRIPTION
Konsollen har tidligere ofte vist warning pga at `key` settes via spread operator, eks:
![bilde](https://github.com/BIBSYSDEV/NVA-Frontend/assets/6313468/c0145e84-96da-4b1e-a52c-d7b27a82181a)

Har nå løst dette ved å alltid sette den manuelt.

Har også gjort noen forenklinger ved å revertere noen av endringene i https://github.com/BIBSYSDEV/NVA-Frontend/pull/5900, ved at vi i stedet for å dele opp i flere steg bare sikrer at `key` settes til noe fornuftig av oss etter spread (selv om det ligger en key der også). Grunnen til at vi må bruke egen key er at vi i mange tilfeller viser options fra eksterne system som ofte har duplikater, og dermed også får samme key. 

