### PR TITLE
NP-47251-prioritise-cristin-id-from-cristin

### DIFF
--- a/src/pages/public_registration/PublicGeneralContent.tsx
+++ b/src/pages/public_registration/PublicGeneralContent.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 import { useFetchNviCandidateQuery } from '../../api/hooks/useFetchNviCandidateQuery';
 import { StyledGeneralInfo } from '../../components/styled/Wrappers';
 import disciplines from '../../resources/disciplines.json';
-import { ArtisticType, DegreeType, JournalType } from '../../types/publicationFieldNames';
 import { ArtisticPublicationInstance } from '../../types/publication_types/artisticRegistration.types';
 import {
   BookPublicationContext,
@@ -36,6 +35,8 @@ import {
   ReportPublicationInstance,
   ReportRegistration,
 } from '../../types/publication_types/reportRegistration.types';
+import { ArtisticType, DegreeType, JournalType } from '../../types/publicationFieldNames';
+import { AdditionalIdentifier } from '../../types/registration.types';
 import { dataTestId } from '../../utils/dataTestIds';
 import { displayDate } from '../../utils/date-helpers';
 import {
@@ -77,6 +78,16 @@ import {
 import { PublicRegistrationContentProps } from './PublicRegistrationContent';
 import { RegistrationSummary } from './RegistrationSummary';
 
+const prioritiseIdentifiersFromCristin = (a: AdditionalIdentifier, b: AdditionalIdentifier): number => {
+  if (a.sourceName === 'Cristin') {
+    return -1;
+  }
+  if (b.sourceName === 'Cristin') {
+    return 1;
+  }
+  return 0;
+};
+
 export const PublicGeneralContent = ({ registration }: PublicRegistrationContentProps) => {
   const { t, i18n } = useTranslation();
   const { entityDescription, id, status } = registration;
@@ -90,9 +101,10 @@ export const PublicGeneralContent = ({ registration }: PublicRegistrationContent
 
   const language = entityDescription?.language ? getLanguageByUri(entityDescription.language) : null;
 
-  const cristinIdentifier = registration.additionalIdentifiers?.find(
-    (identifier) => identifier.type === 'CristinIdentifier' || identifier.sourceName === 'Cristin'
-  )?.value;
+  const cristinIdentifier = registration.additionalIdentifiers
+    ?.filter((identifier) => identifier.type === 'CristinIdentifier' || identifier.sourceName === 'Cristin')
+    .sort((a, b) => prioritiseIdentifiersFromCristin(a, b))
+    .shift()?.value;
   const scopusIdentifier = registration.additionalIdentifiers?.find(
     (identifier) => identifier.type === 'ScopusIdentifier' || identifier.sourceName === 'Scopus'
   )?.value;

--- a/src/types/registration.types.ts
+++ b/src/types/registration.types.ts
@@ -83,7 +83,7 @@ interface RegistrationPublisher {
 type AdditionalIdentifierType = 'CristinIdentifier' | 'ScopusIdentifier';
 type ImportSourceName = 'Cristin' | 'Scopus';
 
-interface AdditionalIdentifier {
+export interface AdditionalIdentifier {
   type: AdditionalIdentifierType;
   sourceName: ImportSourceName;
   value: string;


### PR DESCRIPTION

# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47251

Ved flere cristin-id på samme publikasjon, skal den vise frem Cristin-id'en som kommer fra Cristin og ikke den som evt. kommer fra Brage.

Eks. post med problem: https://dev.nva.sikt.no/registration/019054bb5bfb-7f200da9-40b8-4bc3-95db-646bc860d9f1
Her vises  id'en fra brage (som forøvrig er feil).


Til senere: vurdér om vi ønsker å vise frem cristin-id fra Brage i det hele tatt.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [ ] The changes are tested OK for a11y
- [ ] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
