### PR TITLE
NP-47105 Add confirm dialog when assigning doi without files

### DIFF
--- a/src/pages/public_registration/action_accordions/DoiRequestAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/DoiRequestAccordion.tsx
@@ -272,11 +272,7 @@ export const DoiRequestAccordion = ({
               <Trans
                 t={t}
                 i18nKey="registration.public_page.tasks_panel.no_published_files_on_registration_description"
-                components={[
-                  <Typography paragraph key="1" />,
-                  <Typography paragraph key="2" />,
-                  <Typography paragraph key="3" />,
-                ]}
+                components={[<Typography paragraph key="1" />]}
               />
             </ConfirmDialog>
           </Box>

--- a/src/pages/public_registration/action_accordions/DoiRequestAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/DoiRequestAccordion.tsx
@@ -142,6 +142,10 @@ export const DoiRequestAccordion = ({
   const waitingForRemovalOfDoi = isClosedDoiRequest && !!registration.doi;
   const messages = doiRequestTicket?.messages ?? [];
 
+  const publishedFilesOnRegistration = getAssociatedFiles(registration.associatedArtifacts).filter(
+    (file) => file.type === 'PublishedFile'
+  );
+
   return (
     <Accordion
       data-testid={dataTestId.registrationLandingPage.tasksPanel.doiRequestAccordion}
@@ -240,10 +244,10 @@ export const DoiRequestAccordion = ({
               data-testid={dataTestId.registrationLandingPage.tasksPanel.createDoiButton}
               endIcon={<CheckIcon />}
               onClick={() => {
-                if (getAssociatedFiles(registration.associatedArtifacts).length == 0) {
-                  toggleConfirmDialogAssignDoi();
-                } else {
+                if (publishedFilesOnRegistration.length > 0) {
                   ticketMutation.mutate({ status: 'Completed' });
+                } else {
+                  toggleConfirmDialogAssignDoi();
                 }
               }}
               disabled={isLoadingData || isLoading !== LoadingState.None}>

--- a/src/pages/public_registration/action_accordions/DoiRequestAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/DoiRequestAccordion.tsx
@@ -25,6 +25,7 @@ import {
   updateTicket,
   UpdateTicketData,
 } from '../../../api/registrationApi';
+import { ConfirmDialog } from '../../../components/ConfirmDialog';
 import { MessageForm } from '../../../components/MessageForm';
 import { Modal } from '../../../components/Modal';
 import { setNotification } from '../../../redux/notificationSlice';
@@ -32,11 +33,10 @@ import { Ticket } from '../../../types/publication_types/ticket.types';
 import { Registration, RegistrationStatus } from '../../../types/registration.types';
 import { isErrorStatus, isSuccessStatus } from '../../../utils/constants';
 import { dataTestId } from '../../../utils/dataTestIds';
+import { getAssociatedFiles } from '../../../utils/registration-helpers';
 import { DoiRequestMessagesColumn } from '../../messages/components/DoiRequestMessagesColumn';
 import { TicketMessageList } from '../../messages/components/MessageList';
 import { TicketAssignee } from './TicketAssignee';
-import { ConfirmDialog } from '../../../components/ConfirmDialog';
-import { getAssociatedFiles } from '../../../utils/registration-helpers';
 
 interface DoiRequestAccordionProps {
   registration: Registration;

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1398,6 +1398,8 @@
         "has_rejected_files_publishing_request": "<0>Beskrivelse (metadata) er publisert og offentlig tilgjengelig.</0><0>Kurator har avvist filen, og den er fjernet fra visningen av forskningsresultatet.</0>",
         "has_reserved_doi": "Du har reservert en DOI til denne registreringen. Den kan deles med de som ønsker å sitere dette resultatet. Når registreringen blir publisert og blir offentlig tilgjengelig, må en kurator validere metadata før DOI blir offentlig tilgjengelig.",
         "metadata_published_waiting_for_files": "<0>Beskrivelse av (metadata) er publisert og synlig for andre, men kurator må godkjenne filene som er lastet opp før de blir synlige.</0><0>Du får beskjed når fil(er) og valgt lisens er godkjent av kurator og er offentlig tilgjengelig. Statusen er alltid synlig på Min Side.</0>",
+        "no_published_files_on_registration": "Ingen publiserte filer på resultatet",
+        "no_published_files_on_registration_description": "<0>Resultatet har ingen publiserte filer.</0><0>Sjekk med registrator om det er korrekt at resultatet ikke skal ha publiserte filer i NVA.</0><0>Ønsker du å tildele DOI på resultat uten fil?</0>",
         "publish_registration": "Publiser registrering",
         "published_registration": "Registreringen er publisert.",
         "registration_is_published": "Forskningsresultatet er publisert og offentlig tilgjengelig i NVA.",


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-47105](https://sikt.atlassian.net/browse/NP-47105)

Legger til en confirm dialog når man prøver å tildele doi på en registrering som mangler publisert fil.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-47105]: https://sikt.atlassian.net/browse/NP-47105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ