### PR TITLE
NP-47137 Remove unnecessary check to the second when looking for regi stration created by import

### DIFF
--- a/src/utils/general-helpers.ts
+++ b/src/utils/general-helpers.ts
@@ -74,7 +74,3 @@ export const getCurrentPath = () => {
     return pathname;
   }
 };
-
-export const getSecondsSinceEpoch = (date: Date) => Math.floor(date.getTime() / 1000);
-
-export const isEqualToTheSecond = (a: Date, b: Date) => getSecondsSinceEpoch(a) === getSecondsSinceEpoch(b);

--- a/src/utils/log/registrationEntryGenerator.ts
+++ b/src/utils/log/registrationEntryGenerator.ts
@@ -4,7 +4,6 @@ import { CristinApiPath } from '../../api/apiPaths';
 import { LogEntry } from '../../types/log.types';
 import { Ticket } from '../../types/publication_types/ticket.types';
 import { Registration } from '../../types/registration.types';
-import { isEqualToTheSecond } from '../general-helpers';
 
 export function generateRegistrationLogEntries(
   registration: Registration,

--- a/src/utils/log/registrationEntryGenerator.ts
+++ b/src/utils/log/registrationEntryGenerator.ts
@@ -77,8 +77,6 @@ function generateActorAndOrganizationBasedOnImport(registration: Registration) {
 
 function registrationIsCreatedByImport(registration: Registration) {
   return (
-    registration.importDetails?.some((importDetail) =>
-      isEqualToTheSecond(new Date(importDetail.importDate), new Date(registration.createdDate))
-    ) ?? false
+    registration.importDetails?.some((importDetail) => importDetail.importDate === registration.createdDate) ?? false
   );
 }


### PR DESCRIPTION
# Description

Fjerner unødvendig sjekk på om importDate er fra samme sekund som createdDate da det viste seg at buggen var basert på gammel data. Det er samme timestamp som brukes for createdDate og importDate.
