### PR TITLE
Use new project contributor API-model in frontend

### DIFF
--- a/src/pages/projects/ProjectContributors.tsx
+++ b/src/pages/projects/ProjectContributors.tsx
@@ -31,13 +31,13 @@ export const ProjectContributors = ({ contributors }: ProjectContributorsProps) 
           {projectManagers.length > 0 && (
             <div>
               <Typography variant="h3">{t('project.project_manager')}</Typography>
-              <ContributorList contributors={projectManagers} />
+              <ContributorList contributors={projectManagers} projectRole="ProjectManager" />
             </div>
           )}
           {projectParticipants.length > 0 && (
             <div>
               <Typography variant="h3">{t('project.project_participants')}</Typography>
-              <ContributorList contributors={projectParticipants} />
+              <ContributorList contributors={projectParticipants} projectRole="ProjectParticipant" />
             </div>
           )}
         </>
@@ -48,9 +48,10 @@ export const ProjectContributors = ({ contributors }: ProjectContributorsProps) 
 
 interface ContributorListProps {
   contributors: ProjectContributor[];
+  projectRole: 'ProjectManager' | 'ProjectParticipant';
 }
 
-const ContributorList = ({ contributors }: ContributorListProps) => (
+const ContributorList = ({ contributors, projectRole }: ContributorListProps) => (
   <Box
     sx={{
       display: 'grid',
@@ -62,7 +63,18 @@ const ContributorList = ({ contributors }: ContributorListProps) => (
         <Typography variant="subtitle1" component="p">
           {contributor.identity.firstName} {contributor.identity.lastName}
         </Typography>
-        <Typography variant="body2">{getLanguageString(contributor.affiliation?.labels)}</Typography>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+          {contributor.roles.map((contributorRole, j) => {
+            if (contributorRole.type === projectRole) {
+              return (
+                <Typography variant="body2" key={j}>
+                  {getLanguageString(contributorRole.affiliation.labels)}
+                </Typography>
+              );
+            }
+            return null;
+          })}
+        </Box>
       </div>
     ))}
   </Box>

--- a/src/pages/projects/ProjectContributors.tsx
+++ b/src/pages/projects/ProjectContributors.tsx
@@ -1,6 +1,6 @@
 import { Box, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { ProjectContributor } from '../../types/project.types';
+import { ProjectContributor, ProjectContributorType } from '../../types/project.types';
 import { getLanguageString } from '../../utils/translation-helpers';
 import {
   getProjectManagers,
@@ -48,7 +48,7 @@ export const ProjectContributors = ({ contributors }: ProjectContributorsProps) 
 
 interface ContributorListProps {
   contributors: ProjectContributor[];
-  projectRole: 'ProjectManager' | 'ProjectParticipant';
+  projectRole: ProjectContributorType;
 }
 
 const ContributorList = ({ contributors, projectRole }: ContributorListProps) => (
@@ -63,7 +63,7 @@ const ContributorList = ({ contributors, projectRole }: ContributorListProps) =>
         <Typography variant="subtitle1" component="p">
           {contributor.identity.firstName} {contributor.identity.lastName}
         </Typography>
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
           {contributor.roles.map((contributorRole, j) => {
             if (contributorRole.type === projectRole) {
               return (

--- a/src/pages/projects/form/ProjectFormPanel1.tsx
+++ b/src/pages/projects/form/ProjectFormPanel1.tsx
@@ -5,15 +5,15 @@ import { ErrorMessage, Field, FieldArray, FieldArrayRenderProps, FieldProps, use
 import { useTranslation } from 'react-i18next';
 import {
   CristinProject,
+  emptyProjectContributor,
   ProjectFieldName,
   ProjectOrganization,
   SaveCristinProject,
-  emptyProjectContributor,
 } from '../../../types/project.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { OrganizationSearchField } from '../../basic_data/app_admin/OrganizationSearchField';
 import { ProjectContributorRow } from '../../registration/description_tab/projects_field/ProjectContributorRow';
-import { isRekProject } from '../../registration/description_tab/projects_field/projectHelpers';
+import { isProjectManager, isRekProject } from '../../registration/description_tab/projects_field/projectHelpers';
 import { ProjectFundingsField } from './ProjectFunding';
 
 interface ProjectFormPanel1Props {
@@ -155,7 +155,7 @@ export const ProjectFormPanel1 = ({ currentProject, suggestedProjectManager }: P
                     contributorIndex={index}
                     baseFieldName={`${name}[${index}]`}
                     contributor={thisContributor}
-                    removeContributor={contributor.type === 'ProjectManager' ? undefined : () => remove(index)}
+                    removeContributor={isProjectManager(contributor) ? undefined : () => remove(index)}
                     isRekProject={thisIsRekProject}
                   />
                 );

--- a/src/pages/registration/description_tab/projects_field/ProjectContributorRow.tsx
+++ b/src/pages/registration/description_tab/projects_field/ProjectContributorRow.tsx
@@ -1,7 +1,7 @@
 import RemoveIcon from '@mui/icons-material/HighlightOff';
 import { Autocomplete, Box, IconButton, TextField, Typography } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
-import { Field, FieldProps, FormikErrors, useFormikContext } from 'formik';
+import { Field, FieldProps, useFormikContext } from 'formik';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { apiRequest } from '../../../../api/apiRequest';
@@ -26,9 +26,9 @@ import { OrganizationSearchField } from '../../../basic_data/app_admin/Organizat
 import { projectContributorToCristinPerson } from './projectHelpers';
 
 enum ProjectContributorFieldName {
-  Type = 'type',
+  Type = 'roles[0].type',
   Identity = 'identity',
-  Affiliation = 'affiliation',
+  Affiliation = 'roles[0].affiliation',
 }
 
 interface ProjectContributorRowProps {
@@ -100,9 +100,8 @@ export const ProjectContributorRow = ({
     setIsLoadingDefaultOptions(false);
   };
 
-  const contributorErrors = errors.contributors?.[contributorIndex] as FormikErrors<ProjectContributor>;
-
-  const isRekProjectManager = isRekProject && contributor?.type === 'ProjectManager';
+  const contributorErrors = errors?.contributors?.[contributorIndex] as ProjectContributor;
+  const isRekProjectManager = isRekProject && contributor?.roles?.some((role) => role.type === 'ProjectManager');
 
   return (
     <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '150px 2fr 3fr auto' }, gap: '0.25rem 0.75rem' }}>
@@ -195,6 +194,7 @@ export const ProjectContributorRow = ({
                 id: institution?.id ?? '',
                 labels: institution?.labels ?? {},
               };
+              setFieldTouched(`${field.name}.id`);
               setFieldValue(field.name, selectedCoordinatingInstitution);
             }}
             fieldInputProps={{
@@ -204,12 +204,13 @@ export const ProjectContributorRow = ({
               },
             }}
             errorMessage={
-              touched.contributors?.[contributorIndex]?.affiliation?.id && !!contributorErrors?.affiliation?.id
-                ? contributorErrors?.affiliation?.id
+              touched.contributors?.[contributorIndex]?.roles?.[0]?.affiliation?.id &&
+              contributorErrors?.roles?.[0].affiliation?.id
+                ? contributorErrors?.roles?.[0].affiliation?.id
                 : ''
             }
             isLoadingDefaultOptions={isLoadingDefaultOptions}
-            defaultOptions={defaultInstitutionOptions.filter((institution) => institution.id !== field.value.id)}
+            defaultOptions={defaultInstitutionOptions.filter((institution) => institution.id !== field.value?.id)}
             selectedValue={field.value}
             customDataTestId={dataTestId.registrationWizard.description.projectForm.contributorAffiliationField}
           />

--- a/src/pages/registration/description_tab/projects_field/ProjectContributorRow.tsx
+++ b/src/pages/registration/description_tab/projects_field/ProjectContributorRow.tsx
@@ -23,7 +23,7 @@ import { useDebounce } from '../../../../utils/hooks/useDebounce';
 import { getTopLevelOrganization, getUnitTopLevelCode } from '../../../../utils/institutions-helpers';
 import { getFullCristinName, getValueByKey } from '../../../../utils/user-helpers';
 import { OrganizationSearchField } from '../../../basic_data/app_admin/OrganizationSearchField';
-import { projectContributorToCristinPerson } from './projectHelpers';
+import { isProjectManager, projectContributorToCristinPerson } from './projectHelpers';
 
 enum ProjectContributorFieldName {
   Type = 'roles[0].type',
@@ -101,7 +101,7 @@ export const ProjectContributorRow = ({
   };
 
   const contributorErrors = errors?.contributors?.[contributorIndex] as ProjectContributor;
-  const isRekProjectManager = isRekProject && contributor?.roles?.some((role) => role.type === 'ProjectManager');
+  const isRekProjectManager = isRekProject && contributor && isProjectManager(contributor);
 
   return (
     <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '150px 2fr 3fr auto' }, gap: '0.25rem 0.75rem' }}>

--- a/src/pages/registration/description_tab/projects_field/projectHelpers.ts
+++ b/src/pages/registration/description_tab/projects_field/projectHelpers.ts
@@ -7,11 +7,10 @@ export const getProjectCoordinatingInstitutionName = (project?: CristinProject) 
   project ? getLanguageString(project.coordinatingInstitution.labels) : '';
 
 export const getProjectManagerName = (project?: CristinProject) => {
-  const projectManager = project?.contributors.find((contributor) => contributor.type === 'ProjectManager');
-  const projectManagerName = projectManager
-    ? `${projectManager.identity.firstName} ${projectManager.identity.lastName}`
-    : '';
-  return projectManagerName;
+  const projectManager = project?.contributors.find((contributor) =>
+    contributor.roles.some((role) => role.type === 'ProjectManager')
+  );
+  return projectManager ? `${projectManager.identity.firstName} ${projectManager.identity.lastName}` : '';
 };
 
 export const getProjectPeriod = (project?: CristinProject) => {
@@ -29,10 +28,10 @@ export const getProjectPeriod = (project?: CristinProject) => {
 };
 
 export const getProjectManagers = (contributors: ProjectContributor[]) =>
-  contributors.filter((contributor) => contributor.type === 'ProjectManager');
+  contributors.filter((contributor) => contributor.roles.some((role) => role.type === 'ProjectManager'));
 
 export const getProjectParticipants = (contributors: ProjectContributor[]) =>
-  contributors.filter((contributor) => contributor.type === 'ProjectParticipant');
+  contributors.filter((contributor) => contributor.roles.some((role) => role.type === 'ProjectParticipant'));
 
 export const getNfrProjectUrl = (identifier: string) => {
   const splittedIdentifier = identifier ? identifier.split('/') : []; // Some identifiers have a slash for some reason, eg: project 558223

--- a/src/pages/registration/description_tab/projects_field/projectHelpers.ts
+++ b/src/pages/registration/description_tab/projects_field/projectHelpers.ts
@@ -7,9 +7,7 @@ export const getProjectCoordinatingInstitutionName = (project?: CristinProject) 
   project ? getLanguageString(project.coordinatingInstitution.labels) : '';
 
 export const getProjectManagerName = (project?: CristinProject) => {
-  const projectManager = project?.contributors.find((contributor) =>
-    contributor.roles.some((role) => role.type === 'ProjectManager')
-  );
+  const projectManager = project?.contributors.find((contributor) => isProjectManager(contributor));
   return projectManager ? `${projectManager.identity.firstName} ${projectManager.identity.lastName}` : '';
 };
 
@@ -31,7 +29,7 @@ export const isProjectManager = (contributor: ProjectContributor) =>
   contributor.roles.some((role) => role.type === 'ProjectManager');
 
 export const getProjectManagers = (contributors: ProjectContributor[]) =>
-  contributors.filter((contributor) => contributor.roles.some((role) => role.type === 'ProjectManager'));
+  contributors.filter((contributor) => isProjectManager(contributor));
 
 export const getProjectParticipants = (contributors: ProjectContributor[]) =>
   contributors.filter((contributor) => contributor.roles.some((role) => role.type === 'ProjectParticipant'));

--- a/src/pages/registration/description_tab/projects_field/projectHelpers.ts
+++ b/src/pages/registration/description_tab/projects_field/projectHelpers.ts
@@ -27,6 +27,9 @@ export const getProjectPeriod = (project?: CristinProject) => {
   return dateInterval;
 };
 
+export const isProjectManager = (contributor: ProjectContributor) =>
+  contributor.roles.some((role) => role.type === 'ProjectManager');
+
 export const getProjectManagers = (contributors: ProjectContributor[]) =>
   contributors.filter((contributor) => contributor.roles.some((role) => role.type === 'ProjectManager'));
 

--- a/src/types/project.types.ts
+++ b/src/types/project.types.ts
@@ -48,14 +48,21 @@ export interface ProjectContributorIdentity {
 
 export type ProjectContributorType = 'ProjectManager' | 'ProjectParticipant';
 
-export interface ProjectContributor {
+export interface ProjectContributorRole {
   type: ProjectContributorType;
   affiliation: ProjectOrganization;
+}
+export interface ProjectContributor {
   identity: ProjectContributorIdentity;
+  roles: ProjectContributorRole[];
 }
 
-interface ProjectCreator extends Omit<ProjectContributor, 'type'> {
+export interface CreatorRole extends Omit<ProjectContributorRole, 'type'> {
   type: 'ProjectCreator';
+}
+
+interface ProjectCreator extends Omit<ProjectContributor, 'roles'> {
+  roles: [CreatorRole];
 }
 
 export interface ProjectFunding extends Pick<Funding, 'identifier' | 'source' | 'labels'> {
@@ -131,9 +138,8 @@ export interface NfrProject {
 }
 
 export const emptyProjectContributor: ProjectContributor = {
-  type: 'ProjectParticipant',
   identity: { type: 'Person', id: '', firstName: '', lastName: '' },
-  affiliation: { type: 'Organization', id: '', labels: {} },
+  roles: [],
 };
 
 export const emptyProject: SaveCristinProject = {
@@ -142,7 +148,7 @@ export const emptyProject: SaveCristinProject = {
   language: 'http://lexvo.org/id/iso639-3/nob',
   startDate: '',
   endDate: '',
-  contributors: [{ ...emptyProjectContributor, type: 'ProjectManager' }],
+  contributors: [{ ...emptyProjectContributor, roles: [] }],
   coordinatingInstitution: {
     type: 'Organization',
     id: '',

--- a/src/types/project.types.ts
+++ b/src/types/project.types.ts
@@ -145,9 +145,15 @@ export interface NfrProject {
   activeTo: string;
 }
 
-export const emptyProjectContributor: EmptyProjectContributor = {
+export const emptyAffiliation: ProjectOrganization = {
+  type: 'Organization',
+  id: '',
+  labels: { no: '' },
+};
+
+export const emptyProjectContributor: ProjectContributor = {
   identity: { type: 'Person', id: '', firstName: '', lastName: '' },
-  roles: [{ type: 'ProjectParticipant', affiliation: { type: 'Organization' } }],
+  roles: [{ type: 'ProjectParticipant', affiliation: emptyAffiliation }],
 };
 
 export const emptyProject: SaveCristinProject = {
@@ -156,7 +162,12 @@ export const emptyProject: SaveCristinProject = {
   language: 'http://lexvo.org/id/iso639-3/nob',
   startDate: '',
   endDate: '',
-  contributors: [{ ...emptyProjectContributor, roles: [] }],
+  contributors: [
+    {
+      ...emptyProjectContributor,
+      roles: [{ type: 'ProjectManager', affiliation: emptyAffiliation }],
+    },
+  ],
   coordinatingInstitution: {
     type: 'Organization',
     id: '',

--- a/src/types/project.types.ts
+++ b/src/types/project.types.ts
@@ -48,7 +48,7 @@ export interface ProjectContributorIdentity {
 
 export type ProjectContributorType = 'ProjectManager' | 'ProjectParticipant';
 
-export interface ProjectContributorRole {
+interface ProjectContributorRole {
   type: ProjectContributorType;
   affiliation: ProjectOrganization;
 }
@@ -75,14 +75,6 @@ export const emptyProjectFunding: ProjectFunding = {
   source: '',
   labels: {},
 };
-
-interface EmptyProjectContributorRole extends Omit<ProjectContributorRole, 'affiliation'> {
-  affiliation: { type: 'Organization' };
-}
-
-export interface EmptyProjectContributor extends Omit<ProjectContributor, 'roles'> {
-  roles: EmptyProjectContributorRole[];
-}
 
 export interface SaveCristinProject {
   type: 'Project';
@@ -148,7 +140,7 @@ export interface NfrProject {
 export const emptyAffiliation: ProjectOrganization = {
   type: 'Organization',
   id: '',
-  labels: { no: '' },
+  labels: {},
 };
 
 export const emptyProjectContributor: ProjectContributor = {
@@ -168,11 +160,7 @@ export const emptyProject: SaveCristinProject = {
       roles: [{ type: 'ProjectManager', affiliation: emptyAffiliation }],
     },
   ],
-  coordinatingInstitution: {
-    type: 'Organization',
-    id: '',
-    labels: {},
-  },
+  coordinatingInstitution: emptyAffiliation,
   academicSummary: {},
   popularScientificSummary: {},
   projectCategories: [],

--- a/src/types/project.types.ts
+++ b/src/types/project.types.ts
@@ -76,6 +76,14 @@ export const emptyProjectFunding: ProjectFunding = {
   labels: {},
 };
 
+interface EmptyProjectContributorRole extends Omit<ProjectContributorRole, 'affiliation'> {
+  affiliation: { type: 'Organization' };
+}
+
+export interface EmptyProjectContributor extends Omit<ProjectContributor, 'roles'> {
+  roles: EmptyProjectContributorRole[];
+}
+
 export interface SaveCristinProject {
   type: 'Project';
   title: string;
@@ -137,9 +145,9 @@ export interface NfrProject {
   activeTo: string;
 }
 
-export const emptyProjectContributor: ProjectContributor = {
+export const emptyProjectContributor: EmptyProjectContributor = {
   identity: { type: 'Person', id: '', firstName: '', lastName: '' },
-  roles: [],
+  roles: [{ type: 'ProjectParticipant', affiliation: { type: 'Organization' } }],
 };
 
 export const emptyProject: SaveCristinProject = {

--- a/src/utils/testfiles/mockProjects.ts
+++ b/src/utils/testfiles/mockProjects.ts
@@ -14,20 +14,24 @@ export const mockProject: CristinProject = {
     sourceShortName: 'NVA',
   },
   creator: {
-    type: 'ProjectCreator',
     identity: {
       type: 'Person',
       id: 'https://api.dev.nva.aws.unit.no/cristin/person/1',
       firstName: 'Bob',
       lastName: 'Boffaloe',
     },
-    affiliation: {
-      id: 'https://api.dev.nva.aws.unit.no/cristin/organization/1.0.0.0',
-      type: 'Organization',
-      labels: {
-        nb: 'Jamaica',
+    roles: [
+      {
+        type: 'ProjectCreator',
+        affiliation: {
+          id: 'https://api.dev.nva.aws.unit.no/cristin/organization/1.0.0.0',
+          type: 'Organization',
+          labels: {
+            nb: 'Jamaica',
+          },
+        },
       },
-    },
+    ],
   },
   funding: [],
   academicSummary: {},
@@ -51,52 +55,64 @@ export const mockProject: CristinProject = {
   },
   contributors: [
     {
-      type: 'ProjectManager',
       identity: {
         id: 'https://api.dev.nva.aws.unit.no/cristin/person/328549',
         type: 'Person',
         firstName: 'Name',
         lastName: 'Nameson',
       },
-      affiliation: {
-        id: 'https://api.dev.nva.aws.unit.no/cristin/organization/186.0.0.0',
-        type: 'Organization',
-        labels: {
-          nb: 'UiT Norges arktiske universitet',
+      roles: [
+        {
+          type: 'ProjectManager',
+          affiliation: {
+            id: 'https://api.dev.nva.aws.unit.no/cristin/organization/186.0.0.0',
+            type: 'Organization',
+            labels: {
+              nb: 'UiT Norges arktiske universitet',
+            },
+          },
         },
-      },
+      ],
     },
     {
-      type: 'ProjectParticipant',
       identity: {
         id: 'https://api.dev.nva.aws.unit.no/cristin/person/53368',
         type: 'Person',
         firstName: 'arvid',
         lastName: 'viken',
       },
-      affiliation: {
-        id: 'https://api.dev.nva.aws.unit.no/cristin/organization/186.0.0.0',
-        type: 'Organization',
-        labels: {
-          nb: 'UiT Norges arktiske universitet',
+      roles: [
+        {
+          type: 'ProjectParticipant',
+          affiliation: {
+            id: 'https://api.dev.nva.aws.unit.no/cristin/organization/186.0.0.0',
+            type: 'Organization',
+            labels: {
+              nb: 'UiT Norges arktiske universitet',
+            },
+          },
         },
-      },
+      ],
     },
     {
-      type: 'ProjectParticipant',
       identity: {
         id: 'https://api.dev.nva.aws.unit.no/cristin/person/1',
         type: 'Person',
         firstName: 'Peder',
         lastName: 'Pedersen',
       },
-      affiliation: {
-        id: 'https://api.dev.nva.aws.unit.no/cristin/organization/186.0.0.0',
-        type: 'Organization',
-        labels: {
-          nb: 'UiT Norges arktiske universitet',
+      roles: [
+        {
+          type: 'ProjectParticipant',
+          affiliation: {
+            id: 'https://api.dev.nva.aws.unit.no/cristin/organization/186.0.0.0',
+            type: 'Organization',
+            labels: {
+              nb: 'UiT Norges arktiske universitet',
+            },
+          },
         },
-      },
+      ],
     },
   ],
   projectCategories: [],
@@ -119,20 +135,24 @@ const mockProjects: CristinProject[] = [
       sourceShortName: 'NVA',
     },
     creator: {
-      type: 'ProjectCreator',
       identity: {
         type: 'Person',
         id: 'https://api.dev.nva.aws.unit.no/cristin/person/1',
         firstName: 'Bob',
         lastName: 'Boffaloe',
       },
-      affiliation: {
-        id: 'https://api.dev.nva.aws.unit.no/cristin/organization/1.0.0.0',
-        type: 'Organization',
-        labels: {
-          nb: 'Jamaica',
+      roles: [
+        {
+          type: 'ProjectCreator',
+          affiliation: {
+            id: 'https://api.dev.nva.aws.unit.no/cristin/organization/1.0.0.0',
+            type: 'Organization',
+            labels: {
+              nb: 'Jamaica',
+            },
+          },
         },
-      },
+      ],
     },
     funding: [],
     academicSummary: {},
@@ -156,20 +176,24 @@ const mockProjects: CristinProject[] = [
     },
     contributors: [
       {
-        type: 'ProjectManager',
         identity: {
           id: 'https://api.dev.nva.aws.unit.no/cristin/person/319749',
           type: 'Person',
           firstName: 'Kari',
           lastName: 'Karisen',
         },
-        affiliation: {
-          id: 'https://api.dev.nva.aws.unit.no/cristin/organization/222.0.0.0',
-          type: 'Organization',
-          labels: {
-            nb: 'Universitetet i Sørøst-Norge',
+        roles: [
+          {
+            type: 'ProjectManager',
+            affiliation: {
+              id: 'https://api.dev.nva.aws.unit.no/cristin/organization/222.0.0.0',
+              type: 'Organization',
+              labels: {
+                nb: 'Universitetet i Sørøst-Norge',
+              },
+            },
           },
-        },
+        ],
       },
     ],
     projectCategories: [],
@@ -189,20 +213,24 @@ const mockProjects: CristinProject[] = [
       sourceShortName: 'NVA',
     },
     creator: {
-      type: 'ProjectCreator',
       identity: {
         type: 'Person',
         id: 'https://api.dev.nva.aws.unit.no/cristin/person/1',
         firstName: 'Bob',
         lastName: 'Boffaloe',
       },
-      affiliation: {
-        id: 'https://api.dev.nva.aws.unit.no/cristin/organization/1.0.0.0',
-        type: 'Organization',
-        labels: {
-          nb: 'Jamaica',
+      roles: [
+        {
+          type: 'ProjectCreator',
+          affiliation: {
+            id: 'https://api.dev.nva.aws.unit.no/cristin/organization/1.0.0.0',
+            type: 'Organization',
+            labels: {
+              nb: 'Jamaica',
+            },
+          },
         },
-      },
+      ],
     },
     funding: [],
     academicSummary: {},
@@ -226,20 +254,24 @@ const mockProjects: CristinProject[] = [
     },
     contributors: [
       {
-        type: 'ProjectManager',
         identity: {
           id: 'https://api.dev.nva.aws.unit.no/cristin/person/27546',
           type: 'Person',
           firstName: 'Anonym',
           lastName: 'Person',
         },
-        affiliation: {
-          id: 'https://api.dev.nva.aws.unit.no/cristin/organization/222.0.0.0',
-          type: 'Organization',
-          labels: {
-            nb: 'Universitetet i Sørøst-Norge',
+        roles: [
+          {
+            type: 'ProjectManager',
+            affiliation: {
+              id: 'https://api.dev.nva.aws.unit.no/cristin/organization/222.0.0.0',
+              type: 'Organization',
+              labels: {
+                nb: 'Universitetet i Sørøst-Norge',
+              },
+            },
           },
-        },
+        ],
       },
     ],
     projectCategories: [],
@@ -259,20 +291,24 @@ const mockProjects: CristinProject[] = [
       sourceShortName: 'NVA',
     },
     creator: {
-      type: 'ProjectCreator',
       identity: {
         type: 'Person',
         id: 'https://api.dev.nva.aws.unit.no/cristin/person/1',
         firstName: 'Bob',
         lastName: 'Boffaloe',
       },
-      affiliation: {
-        id: 'https://api.dev.nva.aws.unit.no/cristin/organization/1.0.0.0',
-        type: 'Organization',
-        labels: {
-          nb: 'Jamaica',
+      roles: [
+        {
+          type: 'ProjectCreator',
+          affiliation: {
+            id: 'https://api.dev.nva.aws.unit.no/cristin/organization/1.0.0.0',
+            type: 'Organization',
+            labels: {
+              nb: 'Jamaica',
+            },
+          },
         },
-      },
+      ],
     },
     funding: [],
     academicSummary: {},
@@ -296,52 +332,64 @@ const mockProjects: CristinProject[] = [
     },
     contributors: [
       {
-        type: 'ProjectManager',
         identity: {
           id: 'https://api.dev.nva.aws.unit.no/cristin/person/43310',
           type: 'Person',
           firstName: 'Guri',
           lastName: 'Malla',
         },
-        affiliation: {
-          id: 'https://api.dev.nva.aws.unit.no/cristin/organization/222.0.0.0',
-          type: 'Organization',
-          labels: {
-            nb: 'Universitetet i Sørøst-Norge',
+        roles: [
+          {
+            type: 'ProjectManager',
+            affiliation: {
+              id: 'https://api.dev.nva.aws.unit.no/cristin/organization/222.0.0.0',
+              type: 'Organization',
+              labels: {
+                nb: 'Universitetet i Sørøst-Norge',
+              },
+            },
           },
-        },
+        ],
       },
       {
-        type: 'ProjectParticipant',
         identity: {
           id: 'https://api.dev.nva.aws.unit.no/cristin/person/26002',
           type: 'Person',
           firstName: 'Sopp',
           lastName: 'Soppesen',
         },
-        affiliation: {
-          id: 'https://api.dev.nva.aws.unit.no/cristin/organization/222.0.0.0',
-          type: 'Organization',
-          labels: {
-            nb: 'Universitetet i Sørøst-Norge',
+        roles: [
+          {
+            type: 'ProjectParticipant',
+            affiliation: {
+              id: 'https://api.dev.nva.aws.unit.no/cristin/organization/222.0.0.0',
+              type: 'Organization',
+              labels: {
+                nb: 'Universitetet i Sørøst-Norge',
+              },
+            },
           },
-        },
+        ],
       },
       {
-        type: 'ProjectParticipant',
         identity: {
           id: 'https://api.dev.nva.aws.unit.no/cristin/person/26022',
           type: 'Person',
           firstName: 'Ost',
           lastName: 'Loff',
         },
-        affiliation: {
-          id: 'https://api.dev.nva.aws.unit.no/cristin/organization/222.0.0.0',
-          type: 'Organization',
-          labels: {
-            nb: 'Universitetet i Sørøst-Norge',
+        roles: [
+          {
+            type: 'ProjectParticipant',
+            affiliation: {
+              id: 'https://api.dev.nva.aws.unit.no/cristin/organization/222.0.0.0',
+              type: 'Organization',
+              labels: {
+                nb: 'Universitetet i Sørøst-Norge',
+              },
+            },
           },
-        },
+        ],
       },
     ],
     projectCategories: [],
@@ -361,20 +409,24 @@ const mockProjects: CristinProject[] = [
       sourceShortName: 'NVA',
     },
     creator: {
-      type: 'ProjectCreator',
       identity: {
         type: 'Person',
         id: 'https://api.dev.nva.aws.unit.no/cristin/person/1',
         firstName: 'Bob',
         lastName: 'Boffaloe',
       },
-      affiliation: {
-        id: 'https://api.dev.nva.aws.unit.no/cristin/organization/1.0.0.0',
-        type: 'Organization',
-        labels: {
-          nb: 'Jamaica',
+      roles: [
+        {
+          type: 'ProjectCreator',
+          affiliation: {
+            id: 'https://api.dev.nva.aws.unit.no/cristin/organization/1.0.0.0',
+            type: 'Organization',
+            labels: {
+              nb: 'Jamaica',
+            },
+          },
         },
-      },
+      ],
     },
     funding: [],
     academicSummary: {},
@@ -398,20 +450,24 @@ const mockProjects: CristinProject[] = [
     },
     contributors: [
       {
-        type: 'ProjectManager',
         identity: {
           id: 'https://api.dev.nva.aws.unit.no/cristin/person/319632',
           type: 'Person',
           firstName: 'Knut',
           lastName: 'Kebab',
         },
-        affiliation: {
-          id: 'https://api.dev.nva.aws.unit.no/cristin/organization/222.0.0.0',
-          type: 'Organization',
-          labels: {
-            nb: 'Universitetet i Sørøst-Norge',
+        roles: [
+          {
+            type: 'ProjectManager',
+            affiliation: {
+              id: 'https://api.dev.nva.aws.unit.no/cristin/organization/222.0.0.0',
+              type: 'Organization',
+              labels: {
+                nb: 'Universitetet i Sørøst-Norge',
+              },
+            },
           },
-        },
+        ],
       },
     ],
     projectCategories: [],

--- a/src/utils/validation/project/BasicProjectValidation.ts
+++ b/src/utils/validation/project/BasicProjectValidation.ts
@@ -38,10 +38,14 @@ const basicProjectErrorMessage = {
   }),
 };
 
-const contributorValidationSchema = Yup.object().shape({
+const roleValidationSchema = Yup.object().shape({
   type: Yup.string().required(basicProjectErrorMessage.roleRequired),
-  identity: Yup.object().shape({ id: Yup.string().required(basicProjectErrorMessage.personRequired) }),
   affiliation: Yup.object().shape({ id: Yup.string().required(basicProjectErrorMessage.institutionRequired) }),
+});
+
+const contributorValidationSchema = Yup.object().shape({
+  identity: Yup.object().shape({ id: Yup.string().required(basicProjectErrorMessage.personRequired) }),
+  roles: Yup.array().of(roleValidationSchema),
 });
 
 export const basicProjectValidationSchema = Yup.object<YupShape<SaveCristinProject>>().shape({


### PR DESCRIPTION
# Description

Link to Jira issue: [https://sikt.atlassian.net/browse/NP-47147](https://sikt.atlassian.net/browse/NP-47147)

Earlier each contributor to a project would have the following attributes:

**type**: such as project manager or project contributor
**identity**: Information about the person, such as first- and last name
**affiliation**: Organization the person belongs to, such as Sikt

Now each contributor keeps the **identity**, but has a list of **roles** that contain the information of type and affiliation. 

Thus each contributor can have several roles in the project, and each role can be tied to a different organization.

**### Example**:

**Earlier**:

![image](https://github.com/user-attachments/assets/a4c04d27-4e43-4f13-9700-945b8485860a)
Each user is listed several times with different roles and / or affiliations. They were also counted several times.

**Now**:

![image](https://github.com/user-attachments/assets/5eb397e8-5874-4255-b201-2b2d35df46b3)

Each user is counted once for each role, and if they have several instances of the same role with different affiliations, each affiliation is listed under the same name. They are also only counted once.

**The tasks included in this issue was to**:

* Update our frontend types to match the new API
* Resolve any issues that would arise. I hade to update two views with corresponding helpers and code:
* The contributor accordion on the project landing page (see pictures above)
* The new- and edit project modal.


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
