### PR TITLE
Try to simplify NVI validation checks

### DIFF
--- a/src/utils/testfiles/mockJournals.ts
+++ b/src/utils/testfiles/mockJournals.ts
@@ -21,7 +21,7 @@ export const mockJournalsSearch: SearchResponse<Journal> = {
       identifier: 'J0UR-N4L-NUMB3R-2',
       name: 'Journal number 2',
       sameAs: 'http://www.journal2.com/',
-      scientificValue: 'LevelOne',
+      scientificValue: 'LevelTwo',
       onlineIssn: '2222-2222',
     },
     {
@@ -30,7 +30,7 @@ export const mockJournalsSearch: SearchResponse<Journal> = {
       identifier: 'J0UR-N4L-NUMB3R-3',
       name: 'Journal number 3',
       sameAs: 'http://www.journal3.com/',
-      scientificValue: 'LevelOne',
+      scientificValue: 'LevelZero',
       onlineIssn: '3333-3333',
       printIssn: '3333-3334',
     },


### PR DESCRIPTION
Forsøk på å forbedre logikken for når vi skal vise NVI-felter eller ikke: https://github.com/BIBSYSDEV/NVA-Frontend/pull/6011. Må vurdere om vi syns dette er bedre eller verre enn det som var.

Fordel med denne løsningen er at vi kan returnere `null` raskere når man ikke har valgt en kanal. Unngår dermed å kjøre en del kode i komponenter som uansett bare kommer til å returnere `null`. Ulempen er at koden ser litt styggere og komplisert ut.

Usikker på om jeg er mest for eller i mot