### PR TITLE
Use new allowed operation for editing published files

### DIFF
--- a/src/pages/registration/FileList.tsx
+++ b/src/pages/registration/FileList.tsx
@@ -25,7 +25,7 @@ import {
   isEmbargoed,
   isTypeWithFileVersionField,
   isTypeWithRrs,
-  userCanUnpublishRegistration,
+  userCanEditPublishedFile,
 } from '../../utils/registration-helpers';
 import { HelperTextModal } from './HelperTextModal';
 import { FilesTableRow, markForPublishId } from './files_and_license_tab/FilesTableRow';
@@ -72,7 +72,7 @@ export const FileList = ({ title, files, uppy, remove, baseFieldName, archived }
     }
 
     if (file.type === FileType.PublishedFile) {
-      return userCanUnpublishRegistration(values) ?? false;
+      return userCanEditPublishedFile(values);
     }
 
     return true;

--- a/src/types/registration.types.ts
+++ b/src/types/registration.types.ts
@@ -99,7 +99,13 @@ interface ImportSource {
   archive?: string;
 }
 
-type RegistrationOperation = 'update' | 'delete' | 'unpublish' | 'ticket/publish' | 'terminate';
+type RegistrationOperation =
+  | 'update'
+  | 'delete'
+  | 'unpublish'
+  | 'ticket/publish'
+  | 'terminate'
+  | 'update-including-files';
 
 export interface PublicationNote {
   type: 'UnpublishingNote' | 'PublicationNote';

--- a/src/utils/registration-helpers.ts
+++ b/src/utils/registration-helpers.ts
@@ -643,16 +643,19 @@ export const getOutputName = (item: OutputItem): string => {
 };
 
 export const userCanEditRegistration = (registration: Registration) =>
-  registration.allowedOperations?.includes('update');
+  registration.allowedOperations?.includes('update') ?? false;
 
 export const userCanUnpublishRegistration = (registration: Registration) =>
-  registration.allowedOperations?.includes('unpublish');
+  registration.allowedOperations?.includes('unpublish') ?? false;
 
 export const userCanPublishRegistration = (registration: Registration) =>
-  registration.allowedOperations?.includes('ticket/publish');
+  registration.allowedOperations?.includes('ticket/publish') ?? false;
 
 export const userCanDeleteRegistration = (registration: Registration) =>
-  registration.allowedOperations?.includes('delete');
+  registration.allowedOperations?.includes('delete') ?? false;
+
+export const userCanEditPublishedFile = (registration: Registration) =>
+  registration.allowedOperations?.includes('update-including-files') ?? false;
 
 export const hyphenateIsrc = (isrc: string) =>
   isrc ? `${isrc.substring(0, 2)}-${isrc.substring(2, 5)}-${isrc.substring(5, 7)}-${isrc.substring(7, 12)}` : '';


### PR DESCRIPTION
Ta i buk ny `allowedOperation` for å bestemme om bruker har lov til å endre på publiserte filer, som ble implementert her: https://github.com/BIBSYSDEV/nva-publication-api/pull/1770