### PR TITLE
Np 47284 registration log time

### DIFF
--- a/src/components/Log/LogActionItem.tsx
+++ b/src/components/Log/LogActionItem.tsx
@@ -30,13 +30,11 @@ export const LogActionItem = ({ description, date, fileIcon }: LogActionItemType
           {fileIcon === 'archivedFile' && <Typography fontSize="x-small">{t('log.archived_afterwards')}</Typography>}
         </Box>
       </Box>
-      <div>
-        {date && (
-          <Tooltip title={new Date(date).toLocaleTimeString()}>
-            <Typography>{toDateString(new Date(date))}</Typography>
-          </Tooltip>
-        )}
-      </div>
+      {date && (
+        <Tooltip title={new Date(date).toLocaleTimeString()}>
+          <Typography>{toDateString(new Date(date))}</Typography>
+        </Tooltip>
+      )}
     </>
   );
 };

--- a/src/components/Log/LogHeader.tsx
+++ b/src/components/Log/LogHeader.tsx
@@ -5,10 +5,10 @@ import {
   InsertDriveFileOutlined,
   LocalOfferOutlined,
 } from '@mui/icons-material';
-import { Avatar as AvatarMui, Box, Tooltip, Typography } from '@mui/material';
-import { LogEntry as LogEntryType } from '../../types/log.types';
-import { toDateString } from '../../utils/date-helpers';
+import { Avatar as AvatarMui, Box, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { LogEntry as LogEntryType } from '../../types/log.types';
+import { toDateStringWithTime } from '../../utils/date-helpers';
 
 export const LogHeader = ({ title, type, modifiedDate }: Pick<LogEntryType, 'title' | 'type' | 'modifiedDate'>) => {
   const date = new Date(modifiedDate);
@@ -17,9 +17,7 @@ export const LogHeader = ({ title, type, modifiedDate }: Pick<LogEntryType, 'tit
       <LogHeaderIcon type={type} />
       <Box sx={{ display: 'flex', flexDirection: 'column' }}>
         <Typography fontWeight={900}>{title.toUpperCase()}</Typography>
-        <Tooltip title={date.toLocaleTimeString()}>
-          <Typography>{toDateString(date)}</Typography>
-        </Tooltip>
+        <Typography>{toDateStringWithTime(date)}</Typography>
       </Box>
     </Box>
   );

--- a/src/components/Log/RegistrationLog.tsx
+++ b/src/components/Log/RegistrationLog.tsx
@@ -1,7 +1,7 @@
-import { Box, Divider, Tooltip, Typography } from '@mui/material';
+import { Box, Divider, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { Log as LogType } from '../../types/log.types';
-import { toDateString } from '../../utils/date-helpers';
+import { toDateStringWithTime } from '../../utils/date-helpers';
 import { LogEntry } from './LogEntry';
 
 interface LogProps {
@@ -25,12 +25,12 @@ const MetaDataLastUpdatedEntry = ({ metadataUpdated }: Pick<LogType, 'metadataUp
   const lastUpdated = new Date(metadataUpdated);
 
   return (
-    <Box sx={{ display: 'flex', justifyContent: 'center', px: '0.5rem' }}>
-      <Typography color="grey.700">
+    <Box sx={{ px: '0.5rem' }}>
+      <Typography color="grey.700" sx={{ textAlign: 'center' }}>
         {t('log.metadata_last_updated')}
-        <Tooltip title={lastUpdated.toLocaleTimeString()}>
-          <span>{toDateString(lastUpdated)}</span>
-        </Tooltip>
+      </Typography>
+      <Typography color="grey.700" sx={{ textAlign: 'center' }}>
+        {toDateStringWithTime(lastUpdated)}
       </Typography>
     </Box>
   );

--- a/src/components/Log/RegistrationLog.tsx
+++ b/src/components/Log/RegistrationLog.tsx
@@ -1,8 +1,8 @@
 import { Box, Divider, Tooltip, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { LogEntry } from './LogEntry';
 import { Log as LogType } from '../../types/log.types';
 import { toDateString } from '../../utils/date-helpers';
+import { LogEntry } from './LogEntry';
 
 interface LogProps {
   log: LogType;
@@ -11,7 +11,7 @@ interface LogProps {
 export const RegistrationLog = ({ log }: LogProps) => {
   return (
     <>
-      <MetaDataLUpdatedEntry metadataUpdated={log.metadataUpdated} />
+      <MetaDataLastUpdatedEntry metadataUpdated={log.metadataUpdated} />
       <ArchivedFilesEntry numberOfArchivedFiles={log.numberOfArchivedFiles} />
       {log.entries.map((entry, index) => (
         <LogEntry {...entry} key={index} />
@@ -20,7 +20,7 @@ export const RegistrationLog = ({ log }: LogProps) => {
   );
 };
 
-const MetaDataLUpdatedEntry = ({ metadataUpdated }: Pick<LogType, 'metadataUpdated'>) => {
+const MetaDataLastUpdatedEntry = ({ metadataUpdated }: Pick<LogType, 'metadataUpdated'>) => {
   const { t } = useTranslation();
   const lastUpdated = new Date(metadataUpdated);
 

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -274,6 +274,7 @@
     "start_page": "Startside",
     "tasks": "Oppgaver",
     "test_environment": "Testmiljø",
+    "time_string": "{{date}}, kl. {{time}}",
     "title": "Tittel",
     "today": "I dag",
     "total_number": "Totalt antall",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -672,7 +672,7 @@
     "header_icon": "Log header icon {{type}}",
     "imported_from_source": "Importert fra {{source}}",
     "imported_from_source_and_archive": "Importert fra {{source}} ({{archive}})",
-    "metadata_last_updated": "Metadata sist oppdatert: ",
+    "metadata_last_updated": "Metadata sist oppdatert:",
     "number_of_archivedFiles_on_registration_one": "Registreringen har {{count}} arkivert fil",
     "number_of_archivedFiles_on_registration_other": "Registreringen har {{count}} arkiverte filer",
     "titles": {

--- a/src/utils/date-helpers.ts
+++ b/src/utils/date-helpers.ts
@@ -1,5 +1,6 @@
 import { enUS as englishPickerLocale, nbNO as norwegianPickerLocale } from '@mui/x-date-pickers/locales';
 import { enGB as englishDateLocale, nb as norwegianDateLocale } from 'date-fns/locale';
+import { t } from 'i18next';
 import { RegistrationDate } from '../types/registration.types';
 
 export const displayDate = (date: Omit<RegistrationDate, 'type'> | undefined) => {
@@ -54,4 +55,16 @@ export const toDateString = (date: Date | string | number) => {
   const dateObject = date instanceof Date ? date : new Date(date);
 
   return dateObject.toLocaleDateString('nb-NO', { year: 'numeric', month: '2-digit', day: '2-digit' });
+};
+
+export const toDateStringWithTime = (date: Date | string | number) => {
+  if (!date) {
+    return '';
+  }
+  const dateObject = date instanceof Date ? date : new Date(date);
+
+  const dateString = dateObject.toLocaleDateString('nb-NO', { year: 'numeric', month: '2-digit', day: '2-digit' });
+  const timeString = dateObject.toLocaleTimeString('nb-NO', { hour: '2-digit', minute: '2-digit' });
+
+  return t('common.time_string', { date: dateString, time: timeString });
 };


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47284

Vis tidspunkt for noen loggelementer som standard, uten at man må hovre over dato for å få en tooltip.

Før:
![bilde](https://github.com/user-attachments/assets/28e88c50-42c9-4e89-a166-e60642905c32)

Etter:
![bilde](https://github.com/user-attachments/assets/5db4a9c6-6479-486d-bc69-c567b79ce7bd)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [ ] The changes are working as expected
- [ ] The changes are tested OK for different screen sizes
- [ ] The changes are tested OK for a11y
- [ ] Interactive elements have data-testids
- [ ] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
