### PR TITLE
NP-47286 Update date for pending publishing ticket in log

### DIFF
--- a/src/utils/log/publishingRequestGenerator.ts
+++ b/src/utils/log/publishingRequestGenerator.ts
@@ -1,8 +1,8 @@
 import { TFunction } from 'i18next';
-import { getPublishedFiles, getUnpublishableFiles } from '../registration-helpers';
 import { AssociatedFile } from '../../types/associatedArtifact.types';
 import { LogAction, LogActionItem, LogEntry } from '../../types/log.types';
 import { PublishingTicket } from '../../types/publication_types/ticket.types';
+import { getPublishedFiles, getUnpublishableFiles } from '../registration-helpers';
 
 export function generatePublishingRequestLogEntry(
   ticket: PublishingTicket,
@@ -148,7 +148,7 @@ function generateFilesUploadedLogEntry(
   return {
     type: 'PublishingRequest',
     title: t('log.titles.files_uploaded', { count: ticket.filesForApproval.length }),
-    modifiedDate: ticket.modifiedDate,
+    modifiedDate: ticket.createdDate,
     actions: logActions,
   };
 }


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47286

Unngå at dato til "Filer lastet opp" oppdateres for alle endringer på ticket. Tidligere ble den bl.a. oppdatert om kurator satte seg som assignee. Nå vil den heller gjenspeile når ticket ble opprettet, som ser ut til å samsvare med den siste opplastede fila.

Før:
![bilde](https://github.com/user-attachments/assets/5eb0c283-7e34-49d2-a46e-a113cb3638ee)

Etter:
![bilde](https://github.com/user-attachments/assets/6de308c9-4d33-4243-bba0-93b60f45be46)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
