### PR TITLE
Added warning message on category

### DIFF
--- a/src/api/hooks/useDuplicateRegistrationSearch.ts
+++ b/src/api/hooks/useDuplicateRegistrationSearch.ts
@@ -2,7 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { fetchResults, FetchResultsParams } from '../searchApi';
 
-export const useDuplicateRegistrationSearch = (title: string, publishedYear?: string) => {
+export const useDuplicateRegistrationSearch = (
+  title: string | undefined,
+  identifier?: string,
+  publishedYear?: string
+) => {
   const { t } = useTranslation();
 
   const searchConfig: FetchResultsParams = {
@@ -10,6 +14,7 @@ export const useDuplicateRegistrationSearch = (title: string, publishedYear?: st
   };
 
   const titleSearch = useQuery({
+    enabled: !!title,
     queryKey: ['registrations', searchConfig],
     queryFn: () => fetchResults(searchConfig),
     meta: { errorMessage: t('feedback.error.get_registrations') },
@@ -17,9 +22,14 @@ export const useDuplicateRegistrationSearch = (title: string, publishedYear?: st
 
   const registrationsWithSimilarName = titleSearch.data?.hits ?? [];
   const duplicateRegistration = registrationsWithSimilarName.find((reg) => {
+    if (!title) {
+      return false;
+    }
+
+    const isSameRegistration = reg.identifier === identifier;
     const hasSameName = reg.entityDescription?.mainTitle.toLowerCase() === title.toLowerCase();
 
-    if (!hasSameName) {
+    if (!hasSameName || isSameRegistration) {
       return false;
     }
 

--- a/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
@@ -80,6 +80,7 @@ export const PublishingAccordion = ({
 
   const { titleSearchPending, duplicateRegistration } = useDuplicateRegistrationSearch(
     registration.entityDescription?.mainTitle || '',
+    registration.identifier,
     registration.entityDescription?.publicationDate?.year
   );
 

--- a/src/pages/registration/DescriptionPanel.tsx
+++ b/src/pages/registration/DescriptionPanel.tsx
@@ -223,17 +223,13 @@ export const DescriptionPanel = () => {
           )}
         </Field>
       </Box>
-      {duplicateRegistration &&
-        registrationsHaveSamePublicationDate(
-          duplicateRegistration?.entityDescription?.publicationDate,
-          values.entityDescription?.publicationDate
-        ) && (
-          <DuplicateWarning
-            name={duplicateRegistration.entityDescription?.mainTitle}
-            identifier={duplicateRegistration.identifier}
-            warning={t('registration.description.duplicate_publication_date_warning')}
-          />
-        )}
+      {duplicateRegistration && registrationsHaveSamePublicationDate(duplicateRegistration, values) && (
+        <DuplicateWarning
+          name={duplicateRegistration.entityDescription?.mainTitle}
+          identifier={duplicateRegistration.identifier}
+          warning={t('registration.description.duplicate_publication_date_warning')}
+        />
+      )}
       <ProjectsField />
       <Divider />
       <RegistrationFunding currentFundings={values.fundings} />

--- a/src/pages/registration/DescriptionPanel.tsx
+++ b/src/pages/registration/DescriptionPanel.tsx
@@ -23,7 +23,10 @@ export const DescriptionPanel = () => {
   const { values, setFieldValue } = useFormikContext<Registration>();
   const [title, setTitle] = useState('');
   const debouncedTitle = useDebounce(title);
-  const { titleSearchPending, duplicateRegistration } = useDuplicateRegistrationSearch(debouncedTitle);
+  const { titleSearchPending, duplicateRegistration } = useDuplicateRegistrationSearch(
+    debouncedTitle || values.entityDescription?.mainTitle,
+    values.identifier
+  );
 
   return (
     <InputContainerBox>

--- a/src/pages/registration/ResourceTypePanel.tsx
+++ b/src/pages/registration/ResourceTypePanel.tsx
@@ -1,16 +1,17 @@
 import { useFormikContext } from 'formik';
+import { useTranslation } from 'react-i18next';
+import { useDuplicateRegistrationSearch } from '../../api/hooks/useDuplicateRegistrationSearch';
 import { InputContainerBox } from '../../components/styled/Wrappers';
 import { ArtisticType, PublicationType, ResearchDataType } from '../../types/publicationFieldNames';
 import { Registration } from '../../types/registration.types';
-import { getMainRegistrationType, isPeriodicalMediaContribution } from '../../utils/registration-helpers';
+import {
+  getMainRegistrationType,
+  isPeriodicalMediaContribution,
+  registrationsHaveSameCategory,
+  registrationsHaveSamePublicationDate,
+} from '../../utils/registration-helpers';
+import { DuplicateWarning } from './DuplicateWarning';
 import { SelectRegistrationTypeField } from './resource_type_tab/SelectRegistrationTypeField';
-import { BookForm } from './resource_type_tab/sub_type_forms/BookForm';
-import { ChapterForm } from './resource_type_tab/sub_type_forms/ChapterForm';
-import { DegreeForm } from './resource_type_tab/sub_type_forms/DegreeForm';
-import { JournalForm } from './resource_type_tab/sub_type_forms/JournalForm';
-import { MapForm } from './resource_type_tab/sub_type_forms/MapForm';
-import { PresentationForm } from './resource_type_tab/sub_type_forms/PresentationForm';
-import { ReportForm } from './resource_type_tab/sub_type_forms/ReportForm';
 import { ArtisticArchitectureForm } from './resource_type_tab/sub_type_forms/artistic_types/architecture/ArtisticArchitectureForm';
 import { ArtisticDesignForm } from './resource_type_tab/sub_type_forms/artistic_types/design/ArtisticDesignForm';
 import { ArtisticLiteraryArtForm } from './resource_type_tab/sub_type_forms/artistic_types/literary_art/ArtisticLiteraryArtForm';
@@ -18,21 +19,40 @@ import { ArtisticMovingPictureForm } from './resource_type_tab/sub_type_forms/ar
 import { ArtisticMusicPerformanceForm } from './resource_type_tab/sub_type_forms/artistic_types/music_performance/ArtisticMusicPerformanceForm';
 import { ArtisticPerformingArtsForm } from './resource_type_tab/sub_type_forms/artistic_types/performing_arts/ArtisticPerformingArtsForm';
 import { ArtisticVisualArtForm } from './resource_type_tab/sub_type_forms/artistic_types/visual_arts/ArtisticVisualArtForm';
+import { BookForm } from './resource_type_tab/sub_type_forms/BookForm';
+import { ChapterForm } from './resource_type_tab/sub_type_forms/ChapterForm';
+import { DegreeForm } from './resource_type_tab/sub_type_forms/DegreeForm';
 import { ExhibitionProductionForm } from './resource_type_tab/sub_type_forms/exhibition_types/ExhibitionProductionForm';
+import { JournalForm } from './resource_type_tab/sub_type_forms/JournalForm';
+import { MapForm } from './resource_type_tab/sub_type_forms/MapForm';
 import { MediaContributionForm } from './resource_type_tab/sub_type_forms/media_types/MediaContributionForm';
 import { MediaContributionPeriodicalForm } from './resource_type_tab/sub_type_forms/media_types/MediaContributionPeriodicalForm';
+import { PresentationForm } from './resource_type_tab/sub_type_forms/PresentationForm';
+import { ReportForm } from './resource_type_tab/sub_type_forms/ReportForm';
 import { DataManagementPlanForm } from './resource_type_tab/sub_type_forms/research_data_types/DataManagementPlanForm';
 import { DatasetForm } from './resource_type_tab/sub_type_forms/research_data_types/DatasetForm';
 
 export const ResourceTypePanel = () => {
+  const { t } = useTranslation();
   const { values } = useFormikContext<Registration>();
   const instanceType = values.entityDescription?.reference?.publicationInstance?.type ?? '';
   const mainType = getMainRegistrationType(instanceType);
+  const { duplicateRegistration } = useDuplicateRegistrationSearch(values.entityDescription?.mainTitle || '');
 
   return (
     <InputContainerBox>
       <SelectRegistrationTypeField />
-
+      {duplicateRegistration && registrationsHaveSameCategory(values, duplicateRegistration) && (
+        <DuplicateWarning
+          name={duplicateRegistration.entityDescription?.mainTitle}
+          identifier={duplicateRegistration.identifier}
+          warning={t('registration.resource_type.duplicate_category_warning', {
+            sameFields: registrationsHaveSamePublicationDate(values, duplicateRegistration)
+              ? t('registration.resource_type.same_title_and_date').toLowerCase()
+              : t('registration.resource_type.same_title').toLowerCase(),
+          })}
+        />
+      )}
       {mainType === PublicationType.PublicationInJournal ? (
         <JournalForm />
       ) : mainType === PublicationType.Book ? (

--- a/src/pages/registration/ResourceTypePanel.tsx
+++ b/src/pages/registration/ResourceTypePanel.tsx
@@ -37,7 +37,10 @@ export const ResourceTypePanel = () => {
   const { values } = useFormikContext<Registration>();
   const instanceType = values.entityDescription?.reference?.publicationInstance?.type ?? '';
   const mainType = getMainRegistrationType(instanceType);
-  const { duplicateRegistration } = useDuplicateRegistrationSearch(values.entityDescription?.mainTitle || '');
+  const { duplicateRegistration } = useDuplicateRegistrationSearch(
+    values.entityDescription?.mainTitle || '',
+    values.identifier
+  );
 
   return (
     <InputContainerBox>

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1717,6 +1717,9 @@
       "create_series": "Opprett serie",
       "date_from": "Dato fra",
       "date_to": "Dato til",
+      "duplicate_category_warning": "Det finnes alt en publikasjon med {{sameFields}} som er publisert med denne kategorien. Hvis dette er det samme resultatet som du prøver å registrere, må du avbryte registreringen slik at du ikke oppretter duplikater.",
+      "same_title_and_date": "samme tittel og dato",
+      "same_title": "samme tittel",
       "exhibition_production": {
         "add_exhibition_basic": "Legg til visningssted",
         "add_exhibition_catalog": "Legg til utstillingskatalog",

--- a/src/utils/registration-helpers.ts
+++ b/src/utils/registration-helpers.ts
@@ -53,7 +53,6 @@ import {
   PublicationInstanceType,
   Publisher,
   Registration,
-  RegistrationDate,
   RelatedDocument,
   Series,
 } from '../types/registration.types';
@@ -777,23 +776,36 @@ export const registrationLanguageOptions = [
   getLanguageByIso6393Code('mis'),
 ];
 
-export const registrationsHaveSamePublicationDate = (
-  duplicatePublicationDate: RegistrationDate | undefined,
-  publicationDate: RegistrationDate | undefined
-) => {
-  if (!duplicatePublicationDate || !publicationDate) {
+export const registrationsHaveSamePublicationDate = (reg1: Registration, reg2: Registration) => {
+  if (!reg1.entityDescription?.publicationDate || !reg2.entityDescription?.publicationDate) {
     return false;
   }
-  let isSame = duplicatePublicationDate.year === publicationDate.year;
+  let isSame = reg1.entityDescription?.publicationDate.year === reg2.entityDescription?.publicationDate.year;
 
   if (
-    (duplicatePublicationDate.month || publicationDate.month) &&
-    duplicatePublicationDate.month !== publicationDate.month
+    (reg1.entityDescription?.publicationDate.month || reg2.entityDescription?.publicationDate.month) &&
+    reg1.entityDescription?.publicationDate.month !== reg2.entityDescription?.publicationDate.month
   ) {
     isSame = false;
   }
-  if ((duplicatePublicationDate.day || publicationDate.day) && duplicatePublicationDate.day !== publicationDate.day) {
+  if (
+    (reg1.entityDescription?.publicationDate.day || reg2.entityDescription?.publicationDate.day) &&
+    reg1.entityDescription?.publicationDate.day !== reg2.entityDescription?.publicationDate.day
+  ) {
     isSame = false;
   }
   return isSame;
+};
+
+export const registrationsHaveSameCategory = (reg1: Registration, reg2: Registration) => {
+  if (
+    reg1.entityDescription?.reference?.publicationInstance?.type &&
+    reg2.entityDescription?.reference?.publicationInstance?.type
+  ) {
+    return (
+      reg1.entityDescription?.reference?.publicationInstance?.type ===
+      reg2.entityDescription?.reference?.publicationInstance?.type
+    );
+  }
+  return false;
 };

--- a/src/utils/registration-helpers.ts
+++ b/src/utils/registration-helpers.ts
@@ -780,21 +780,27 @@ export const registrationsHaveSamePublicationDate = (reg1: Registration, reg2: R
   if (!reg1.entityDescription?.publicationDate || !reg2.entityDescription?.publicationDate) {
     return false;
   }
-  let isSame = reg1.entityDescription?.publicationDate.year === reg2.entityDescription?.publicationDate.year;
+
+  if (reg1.entityDescription.publicationDate.year !== reg2.entityDescription.publicationDate.year) {
+    return false;
+  }
 
   if (
-    (reg1.entityDescription?.publicationDate.month || reg2.entityDescription?.publicationDate.month) &&
-    reg1.entityDescription?.publicationDate.month !== reg2.entityDescription?.publicationDate.month
+    // Sometimes month or day can be an empty string, and then the comparison of '' and undefined will falsely say that they are not the same
+    (reg1.entityDescription.publicationDate.month || reg2.entityDescription.publicationDate.month) &&
+    reg1.entityDescription.publicationDate.month !== reg2.entityDescription.publicationDate.month
   ) {
-    isSame = false;
+    return false;
   }
+
   if (
-    (reg1.entityDescription?.publicationDate.day || reg2.entityDescription?.publicationDate.day) &&
-    reg1.entityDescription?.publicationDate.day !== reg2.entityDescription?.publicationDate.day
+    (reg1.entityDescription.publicationDate.day || reg2.entityDescription.publicationDate.day) &&
+    reg1.entityDescription.publicationDate.day !== reg2.entityDescription.publicationDate.day
   ) {
-    isSame = false;
+    return false;
   }
-  return isSame;
+
+  return true;
 };
 
 export const registrationsHaveSameCategory = (reg1: Registration, reg2: Registration) => {
@@ -803,8 +809,8 @@ export const registrationsHaveSameCategory = (reg1: Registration, reg2: Registra
     reg2.entityDescription?.reference?.publicationInstance?.type
   ) {
     return (
-      reg1.entityDescription?.reference?.publicationInstance?.type ===
-      reg2.entityDescription?.reference?.publicationInstance?.type
+      reg1.entityDescription.reference.publicationInstance.type ===
+      reg2.entityDescription.reference.publicationInstance.type
     );
   }
   return false;


### PR DESCRIPTION
# Description

Link to Jira issue: [https://sikt.atlassian.net/browse/NP-47316](https://sikt.atlassian.net/browse/NP-47316)

When user creates a new registration and writes a title, we do a search to see if the same title is already registered in NVA. If it is, we display a warning message under the input field.

In this task, we are adding a similar warning field under the category field, if the registration has both the same title (and potentially the same publication date) AND the same category as another registration.

Change:

![image](https://github.com/user-attachments/assets/7e007fcf-de88-4b22-9b68-c24e4a687b57)

When the date is also the same, we add that into the warning:

![image](https://github.com/user-attachments/assets/a1393903-aee6-4d89-8e0f-ae31c8e02599)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
