### PR TITLE
Fix layout of files in log

### DIFF
--- a/src/components/Log/LogActionItem.tsx
+++ b/src/components/Log/LogActionItem.tsx
@@ -14,7 +14,14 @@ export const LogActionItem = ({ description, date, fileIcon }: LogActionItemType
   const itemIsFile = !!fileIcon;
   return (
     <>
-      <Box sx={{ display: 'grid', gridTemplateColumns: 'auto 1fr', columnGap: '0.5rem', alignItems: 'center' }}>
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: 'auto 1fr',
+          columnGap: '0.5rem',
+          alignItems: 'center',
+          gridColumn: date ? undefined : 'span 2',
+        }}>
         {fileIcon && <LogActionItemIcon fileIcon={fileIcon} />}
         <Box sx={{ display: 'grid', gridTemplateColumns: '1fr' }}>
           {itemIsFile ? (


### PR DESCRIPTION
# Description

Fiks feil for layout i loggen introdusert her: https://github.com/BIBSYSDEV/NVA-Frontend/pull/6033

I stedet for å legge inn `<div>`-en som ble fjernet, gir jeg elementet hele raden med `gridColumn: date ? undefined : 'span 2'` om det ikke skal vises noen dato bak. Da vil filnavnet få mer plass om det trengs også.

Før:
![bilde](https://github.com/user-attachments/assets/0f754a35-46e4-4e7d-9ed0-a21564146436)

Etter:
![bilde](https://github.com/user-attachments/assets/23e92dd9-58ce-492c-b296-2f1d4c3fbc24)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
