### PR TITLE
Ensure that the assignee selector field always has a margin

### DIFF
--- a/src/components/AssigneeSelector.tsx
+++ b/src/components/AssigneeSelector.tsx
@@ -56,54 +56,58 @@ export const AssigneeSelector = ({
   const assigneeName = getFullName(assigneeQuery.data?.givenName, assigneeQuery.data?.familyName);
   const assigneeInitials = getInitials(assigneeName);
 
-  return showCuratorSearch ? (
-    <Autocomplete
-      options={curatorOptions}
-      renderOption={({ key, ...props }, option) => (
-        <li {...props} key={option.username}>
-          {getFullName(option.givenName, option.familyName)}
-        </li>
-      )}
-      disabled={isLoading}
-      onChange={async (_, value) => {
-        try {
-          await onSelectAssignee(value?.username ?? '');
-        } finally {
-          setShowCuratorSearch(false);
-        }
-      }}
-      onBlur={() => setShowCuratorSearch(false)}
-      getOptionLabel={(option) => getFullName(option.givenName, option.familyName)}
-      isOptionEqualToValue={(option, value) => option.username === value?.username}
-      value={assigneeQuery.data ?? null}
-      loading={isUpdating || curatorsQuery.isPending}
-      renderInput={(params) => (
-        <AutocompleteTextField
-          data-testid={dataTestId.registrationLandingPage.tasksPanel.assigneeSearchField}
-          {...params}
-          label={t('my_page.roles.curator')}
-          isLoading={isLoading}
-          placeholder={t('common.search')}
-          showSearchIcon
+  return (
+    <Box sx={{ mb: '0.5rem' }}>
+      {showCuratorSearch ? (
+        <Autocomplete
+          options={curatorOptions}
+          renderOption={({ key, ...props }, option) => (
+            <li {...props} key={option.username}>
+              {getFullName(option.givenName, option.familyName)}
+            </li>
+          )}
+          disabled={isLoading}
+          onChange={async (_, value) => {
+            try {
+              await onSelectAssignee(value?.username ?? '');
+            } finally {
+              setShowCuratorSearch(false);
+            }
+          }}
+          onBlur={() => setShowCuratorSearch(false)}
+          getOptionLabel={(option) => getFullName(option.givenName, option.familyName)}
+          isOptionEqualToValue={(option, value) => option.username === value?.username}
+          value={assigneeQuery.data ?? null}
+          loading={isUpdating || curatorsQuery.isPending}
+          renderInput={(params) => (
+            <AutocompleteTextField
+              data-testid={dataTestId.registrationLandingPage.tasksPanel.assigneeSearchField}
+              {...params}
+              label={t('my_page.roles.curator')}
+              isLoading={isLoading}
+              placeholder={t('common.search')}
+              showSearchIcon
+            />
+          )}
         />
-      )}
-    />
-  ) : (
-    <Box sx={{ height: '1.75rem', display: 'flex', gap: '0.5rem', mb: '0.5rem' }}>
-      <Tooltip title={`${t('my_page.roles.curator')}: ${assignee ? assigneeName : t('common.none')}`}>
-        <StyledBaseContributorIndicator
-          sx={{ bgcolor: iconBackgroundColor }}
-          data-testid={dataTestId.registrationLandingPage.tasksPanel.assigneeIndicator}>
-          {assignee ? assigneeInitials : ''}
-        </StyledBaseContributorIndicator>
-      </Tooltip>
-      {canSetAssignee && (
-        <IconButton
-          data-testid={dataTestId.registrationLandingPage.tasksPanel.assigneeButton}
-          title={t('registration.public_page.tasks_panel.assign_curator')}
-          onClick={() => setShowCuratorSearch(true)}>
-          <MoreHorizIcon />
-        </IconButton>
+      ) : (
+        <Box sx={{ height: '1.75rem', display: 'flex', gap: '0.5rem' }}>
+          <Tooltip title={`${t('my_page.roles.curator')}: ${assignee ? assigneeName : t('common.none')}`}>
+            <StyledBaseContributorIndicator
+              sx={{ bgcolor: iconBackgroundColor }}
+              data-testid={dataTestId.registrationLandingPage.tasksPanel.assigneeIndicator}>
+              {assignee ? assigneeInitials : ''}
+            </StyledBaseContributorIndicator>
+          </Tooltip>
+          {canSetAssignee && (
+            <IconButton
+              data-testid={dataTestId.registrationLandingPage.tasksPanel.assigneeButton}
+              title={t('registration.public_page.tasks_panel.assign_curator')}
+              onClick={() => setShowCuratorSearch(true)}>
+              <MoreHorizIcon />
+            </IconButton>
+          )}
+        </Box>
       )}
     </Box>
   );


### PR DESCRIPTION
# Description

Kunstig stor diff pga endring av innrykk. I praksis er bare `<Box sx={{ mb: '0.5rem' }}>` flyttet til toppen sånn at det alltid gjelder.

Før:
![bilde](https://github.com/user-attachments/assets/f5c31557-2b71-46a4-8e20-4ae3c821a4fd)

Etter:
![bilde](https://github.com/user-attachments/assets/0031cbd3-4244-498d-b5b0-fda41c3ed1c4)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
