### PR TITLE
Show all handles on landing page

### DIFF
--- a/src/pages/public_registration/PublicGeneralContent.tsx
+++ b/src/pages/public_registration/PublicGeneralContent.tsx
@@ -55,6 +55,7 @@ import {
 } from '../../utils/registration-helpers';
 import { ChapterPublisherInfo } from './ChapterPublisherInfo';
 import { PublicDoi } from './PublicDoi';
+import { PublicHandles } from './PublicHandles';
 import {
   PublicJournal,
   PublicOutputs,
@@ -184,20 +185,8 @@ export const PublicGeneralContent = ({ registration }: PublicRegistrationContent
             />
           ) : null)}
         <PublicDoi registration={registration} />
-        {registration.handle && (
-          <>
-            <Typography variant="overline">{t('registration.public_page.handle')}</Typography>
-            <Typography>
-              <Link
-                data-testid={dataTestId.registrationLandingPage.handleLink}
-                href={registration.handle}
-                target="_blank"
-                rel="noopener noreferrer">
-                {registration.handle}
-              </Link>
-            </Typography>
-          </>
-        )}
+        <PublicHandles registration={registration} />
+
         {(cristinIdentifier || scopusIdentifier) && (
           <Box sx={{ display: 'flex', columnGap: '2rem', flexWrap: 'wrap' }}>
             {cristinIdentifier && (

--- a/src/pages/public_registration/PublicHandles.tsx
+++ b/src/pages/public_registration/PublicHandles.tsx
@@ -1,0 +1,37 @@
+import { Box, Link as MuiLink, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { dataTestId } from '../../utils/dataTestIds';
+import { PublicRegistrationContentProps } from './PublicRegistrationContent';
+
+export const PublicHandles = ({ registration }: PublicRegistrationContentProps) => {
+  const { t } = useTranslation();
+
+  const additionalHandles =
+    registration.additionalIdentifiers
+      ?.filter((identifier) => identifier.type === 'HandleIdentifier' || identifier.sourceName === 'handle')
+      .map((identifier) => identifier.value) ?? [];
+  const handles = [...new Set([registration.handle, ...additionalHandles].filter(Boolean))];
+
+  if (handles.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <Typography variant="overline">{t('registration.public_page.handle')}</Typography>
+      <Box component="ul" sx={{ p: 0, m: 0, listStyleType: 'none' }}>
+        {handles.map((handle) => (
+          <li key={handle}>
+            <MuiLink
+              data-testid={dataTestId.registrationLandingPage.handleLink}
+              href={handle}
+              target="_blank"
+              rel="noopener noreferrer">
+              {handle}
+            </MuiLink>
+          </li>
+        ))}
+      </Box>
+    </>
+  );
+};

--- a/src/types/registration.types.ts
+++ b/src/types/registration.types.ts
@@ -80,8 +80,8 @@ interface RegistrationPublisher {
   id: string;
 }
 
-type AdditionalIdentifierType = 'CristinIdentifier' | 'ScopusIdentifier';
-type ImportSourceName = 'Cristin' | 'Scopus';
+type AdditionalIdentifierType = 'CristinIdentifier' | 'ScopusIdentifier' | 'HandleIdentifier';
+type ImportSourceName = 'Cristin' | 'Scopus' | 'handle';
 
 export interface AdditionalIdentifier {
   type: AdditionalIdentifierType;


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47328

Vis alle handles på landing page. I dag brukes `sourceName: "handle"` men det skal endres til `type: "HandleIdentifier"` i nær fremtid, gjør derfor dette future-proof ved å sjekke for begge.

![bilde](https://github.com/user-attachments/assets/3e1c4982-27ec-4661-96c6-646db140d598)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
