### PR TITLE
Handle error for project lookup on landing page

### DIFF
--- a/src/pages/public_registration/PublicProjectsContent.tsx
+++ b/src/pages/public_registration/PublicProjectsContent.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { fetchProject } from '../../api/cristinApi';
+import { ErrorBoundary } from '../../components/ErrorBoundary';
 import { ResearchProject } from '../../types/project.types';
 import { dataTestId } from '../../utils/dataTestIds';
 import { getProjectPath, getResearchProfilePath } from '../../utils/urlPaths';
@@ -46,7 +47,9 @@ export const PublicProjectsContent = ({ projects }: PublicProjectsContentProps) 
       </StyledProjectGridRow>
 
       {projects.map((project) => (
-        <ProjectRow key={project.id} project={project} />
+        <ErrorBoundary key={project.id}>
+          <ProjectRow project={project} />
+        </ErrorBoundary>
       ))}
     </>
   );
@@ -67,7 +70,8 @@ const ProjectRow = ({ project }: ProjectRowProps) => {
   });
   const fetchedProject = projectQuery.data;
   const projectTitle = fetchedProject?.title ?? project.name;
-  const projectManager = getProjectManagers(fetchedProject?.contributors ?? [])?.[0];
+  const projectManagers = getProjectManagers(fetchedProject?.contributors ?? []);
+  const projectManager = projectManagers.length > 0 ? projectManagers[0] : null;
 
   return (
     <StyledProjectGridRow sx={{ ':not(:last-of-type)': { mb: '1rem' } }}>
@@ -98,9 +102,11 @@ const ProjectRow = ({ project }: ProjectRowProps) => {
       {projectQuery.isPending ? (
         <Skeleton />
       ) : (
-        <MuiLink component={Link} to={getResearchProfilePath(projectManager.identity.id)}>
-          {projectManager.identity.firstName} {projectManager.identity.lastName}
-        </MuiLink>
+        projectManager && (
+          <MuiLink component={Link} to={getResearchProfilePath(projectManager.identity.id)}>
+            {projectManager.identity.firstName} {projectManager.identity.lastName}
+          </MuiLink>
+        )
       )}
       <Divider component="span" orientation="vertical" />
       {projectQuery.isPending ? (


### PR DESCRIPTION
# Description

Håndter tilfelle hvor det er noen prosjekter vi ikke får til å hente

Før:
![bilde](https://github.com/user-attachments/assets/2f451984-5ddc-4b6f-827c-c41e32c0aecd)

Etter (prosjektet som ikke kunne hentes vises ikke):
![bilde](https://github.com/user-attachments/assets/131c156e-0a23-4109-9436-cae14e411898)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
