### PR TITLE
NP-47303 Add helper texts to DOI panel

### DIFF
--- a/src/pages/public_registration/action_accordions/DoiRequestAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/DoiRequestAccordion.tsx
@@ -1,6 +1,7 @@
 import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import LaunchIcon from '@mui/icons-material/Launch';
 import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import { LoadingButton } from '@mui/lab';
@@ -11,6 +12,7 @@ import {
   Box,
   Button,
   DialogActions,
+  Link as MuiLink,
   TextField,
   Typography,
 } from '@mui/material';
@@ -194,16 +196,35 @@ export const DoiRequestAccordion = ({
               </LoadingButton>
             )}
             {isDraftRegistration && (
-              <LoadingButton
-                variant="outlined"
-                endIcon={<LocalOfferIcon />}
-                loadingPosition="end"
-                loading={isLoadingData || isLoading === LoadingState.DraftDoi}
-                disabled={isLoading !== LoadingState.None}
-                data-testid={dataTestId.registrationLandingPage.tasksPanel.reserveDoiButton}
-                onClick={addDraftDoi}>
-                {t('registration.public_page.reserve_doi')}
-              </LoadingButton>
+              <>
+                <Trans
+                  t={t}
+                  i18nKey="registration.public_page.tasks_panel.draft_doi_description"
+                  values={{ buttonText: t('registration.public_page.reserve_doi') }}
+                  components={[
+                    <Typography paragraph key="1" />,
+                    <Typography paragraph key="2">
+                      <MuiLink
+                        href="https://sikt.no/tjenester/doi"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        sx={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+                        <LaunchIcon fontSize="small" />
+                      </MuiLink>
+                    </Typography>,
+                  ]}
+                />
+                <LoadingButton
+                  variant="outlined"
+                  endIcon={<LocalOfferIcon />}
+                  loadingPosition="end"
+                  loading={isLoadingData || isLoading === LoadingState.DraftDoi}
+                  disabled={isLoading !== LoadingState.None}
+                  data-testid={dataTestId.registrationLandingPage.tasksPanel.reserveDoiButton}
+                  onClick={addDraftDoi}>
+                  {t('registration.public_page.reserve_doi')}
+                </LoadingButton>
+              </>
             )}
 
             <Modal

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1425,6 +1425,7 @@
         "assign_curator": "Sett kurator",
         "assign_doi": "Tildel DOI",
         "assign_doi_about": "For at andre skal kunne benytte DOI, må du tildele denne. Metadata må være publisert.",
+        "draft_doi_description": "<0>En reservert DOI gjør at du (og de du deler DOI med) kan sitere forskningsresultatet i andre arbeid før det publiseres.</0><1><0>Les mer om DOI<0></0></0></1><0>Ønsker du DOI på dette resultatet, trykk på \"{{buttonText}}\".</0>",
         "duplicate_title_description_details": "<0>Det skal ikke opprettes duplikater i NVA. Sjekk om din registrering tilsvarer det som alt er publisert.</0><0>Om resultatet som er publisert har feil eller mangler så be registrator eller bidragsyter som er tilknyttet resultatet om å endre det.</0>",
         "duplicate_title_description_introduction": "Denne registreringen har samme tittel og år som følgende publikasjon:",
         "edit_publishing_request_description": "Er det noen av filene til publiseringen som ikke skal publiseres så kan du endre publiseringsstatus på disse ved å redigere registreringen.",


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47303

Legger til hjelpetekster for å reservere DOI. Første av mange PR-er for bedring av DOI-flyt.

![bilde](https://github.com/user-attachments/assets/ac5d4b30-afc4-45d2-a3ff-4c2adc46d860)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
