### PR TITLE
Fixed date handler

### DIFF
--- a/src/utils/date-helpers.ts
+++ b/src/utils/date-helpers.ts
@@ -23,8 +23,8 @@ export const getRegistrationDate = (date: Omit<RegistrationDate, 'type'> | undef
     return null;
   }
   const year = date.year.padStart(4, '0'); // Values are padded to handle (erronuous) dates like year=2 etc.
-  const month = date?.month ? date.month : '1'.padStart(2, '0');
-  const day = date?.day ? date.day : '1'.padStart(2, '0');
+  const month = (date?.month ? date.month : '1').padStart(2, '0');
+  const day = (date?.day ? date.day : '1').padStart(2, '0');
 
   return new Date(`${year}-${month}-${day}T12:00:00.000Z`);
 };

--- a/src/utils/date-helpers.ts
+++ b/src/utils/date-helpers.ts
@@ -23,8 +23,8 @@ export const getRegistrationDate = (date: Omit<RegistrationDate, 'type'> | undef
     return null;
   }
   const year = date.year.padStart(4, '0'); // Values are padded to handle (erronuous) dates like year=2 etc.
-  const month = (date?.month ?? '1').padStart(2, '0');
-  const day = (date?.day ?? '1').padStart(2, '0');
+  const month = date?.month ? date.month : '1'.padStart(2, '0');
+  const day = date?.day ? date.day : '1'.padStart(2, '0');
 
   return new Date(`${year}-${month}-${day}T12:00:00.000Z`);
 };


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-47344](https://sikt.atlassian.net/browse/NP-47344)

Fix for issue where a change on date on registration to only a year would appear to reset the date-field when navigating away from the tab and back.

The problem was that in the `getRegistrationDate` helper, we used Nullish Coalescing operator (??) to see if the month or day field was empty: `date?.month ?? '1'`. This will return '1' **only** if date?.month is null or undefined.  Thus it returned an empty string instead of 1, which made the date invalid. 

Fix was to change to Conditional (Ternary) operator: `date?.month ? date.month : '1'`. Here it returns 1 if date.month is any falsy value.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-47344]: https://sikt.atlassian.net/browse/NP-47344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ