### PR TITLE
Fixed bug in project form

### DIFF
--- a/src/pages/projects/form/ProjectContributors.tsx
+++ b/src/pages/projects/form/ProjectContributors.tsx
@@ -34,6 +34,7 @@ export const ProjectContributors = ({ currentProject, suggestedProjectManager }:
   const { contributors } = values;
   const contributorsToShow = contributors.slice(rowsPerPage * (currentPage - 1), rowsPerPage * currentPage);
   const thisIsRekProject = isRekProject(currentProject);
+  const hasUnidentifiedContributor = contributors.some((contributor) => !contributor.identity.id);
 
   return (
     <>
@@ -53,6 +54,7 @@ export const ProjectContributors = ({ currentProject, suggestedProjectManager }:
               onClick={() => push(emptyProjectContributor)}
               variant="contained"
               startIcon={<AddIcon />}
+              disabled={hasUnidentifiedContributor}
               data-testid={dataTestId.registrationWizard.description.projectForm.addParticipantButton}>
               {t('project.add_project_contributor')}
             </Button>


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-47383](https://sikt.atlassian.net/browse/NP-47383)

Fixed bug where when we add several contributors on a project without identifying them (selecting name), the form acts buggy and the dropdown refuses to close, by disabling the add-button if there ar unidentified contributers in the form.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-47383]: https://sikt.atlassian.net/browse/NP-47383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ