### PR TITLE
Np 47345 validate published result text

### DIFF
--- a/src/components/RegistrationErrorActions.tsx
+++ b/src/components/RegistrationErrorActions.tsx
@@ -25,7 +25,11 @@ export const RegistrationErrorActions = ({
 
   return (
     <Box {...boxProps}>
-      <Typography>{isPublished ? 'Denne har feil' : t('registration.public_page.error_description')}</Typography>
+      <Typography>
+        {isPublished
+          ? t('registration.public_page.error_description_published_result')
+          : t('registration.public_page.error_description')}
+      </Typography>
       <ErrorList tabErrors={tabErrors} />
       <Button
         sx={{ bgcolor: 'white', width: '100%' }}

--- a/src/components/RegistrationErrorActions.tsx
+++ b/src/components/RegistrationErrorActions.tsx
@@ -10,11 +10,13 @@ import { getRegistrationWizardPath } from '../utils/urlPaths';
 interface RegistrationErrorActionsProps extends BoxProps {
   tabErrors: TabErrors;
   registrationIdentifier: string;
+  isPublished: boolean;
 }
 
 export const RegistrationErrorActions = ({
   tabErrors,
   registrationIdentifier,
+  isPublished,
   ...boxProps
 }: RegistrationErrorActionsProps) => {
   const { t } = useTranslation();
@@ -23,7 +25,7 @@ export const RegistrationErrorActions = ({
 
   return (
     <Box {...boxProps}>
-      <Typography>{t('registration.public_page.error_description')}</Typography>
+      <Typography>{isPublished ? 'Denne har feil' : t('registration.public_page.error_description')}</Typography>
       <ErrorList tabErrors={tabErrors} />
       <Button
         sx={{ bgcolor: 'white', width: '100%' }}

--- a/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
@@ -253,6 +253,7 @@ export const PublishingAccordion = ({
           <RegistrationErrorActions
             tabErrors={tabErrors}
             registrationIdentifier={registration.identifier}
+            isPublished={isPublishedRegistration}
             sx={{ mb: lastPublishingRequest ? '1rem' : undefined }}
           />
         )}

--- a/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
@@ -254,7 +254,7 @@ export const PublishingAccordion = ({
             tabErrors={tabErrors}
             registrationIdentifier={registration.identifier}
             isPublished={isPublishedRegistration}
-            sx={{ mb: lastPublishingRequest ? '1rem' : undefined }}
+            sx={{ mb: '0.5rem' }}
           />
         )}
 

--- a/src/pages/public_registration/action_accordions/SupportAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/SupportAccordion.tsx
@@ -9,7 +9,7 @@ import { MessageForm } from '../../../components/MessageForm';
 import { RegistrationErrorActions } from '../../../components/RegistrationErrorActions';
 import { setNotification } from '../../../redux/notificationSlice';
 import { Ticket } from '../../../types/publication_types/ticket.types';
-import { Registration } from '../../../types/registration.types';
+import { Registration, RegistrationStatus } from '../../../types/registration.types';
 import { isErrorStatus, isSuccessStatus } from '../../../utils/constants';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { getTabErrors, validateRegistrationForm } from '../../../utils/formik-helpers/formik-helpers';
@@ -95,7 +95,11 @@ export const SupportAccordion = ({
             )}
 
             {isOnTasksPage && tabErrors && (
-              <RegistrationErrorActions tabErrors={tabErrors} registrationIdentifier={registration.identifier} />
+              <RegistrationErrorActions
+                tabErrors={tabErrors}
+                registrationIdentifier={registration.identifier}
+                isPublished={registration.status === RegistrationStatus.Published}
+              />
             )}
 
             {supportTicket.messages.length > 0 && (

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -301,10 +301,6 @@
     "yes": "Ja"
   },
   "disciplines": {
-    "0001": "Humaniora",
-    "0002": "Samfunnsvitenskap",
-    "0003": "Medisin og helsefag",
-    "0004": "Realfag og teknologi",
     "1003": "Arkeologi og konservering",
     "1005": "Asiatiske og afrikanske studier",
     "1007": "Engelsk",
@@ -376,7 +372,11 @@
     "1162": "Konstruksjonsfag",
     "1166": "Filosofi",
     "1168": "Historie og idéhistorie",
-    "1170": "Kunst, design og arkitektur"
+    "1170": "Kunst, design og arkitektur",
+    "0001": "Humaniora",
+    "0002": "Samfunnsvitenskap",
+    "0003": "Medisin og helsefag",
+    "0004": "Realfag og teknologi"
   },
   "editor": {
     "categories_with_files": "Kategorier med filopplasting",
@@ -1403,6 +1403,7 @@
         "publication_already_exists": "Det finnes allerede en publikasjon med samme tittel, år og kategori som din registrering."
       },
       "error_description": "Følgende feil må rettes opp før publisering av resultat:",
+      "error_description_published_result": "Registreringen er publisert. Ved redigering må følgende mangler rettes opp:",
       "find_in_channel_registry": "Finn i kanalregisteret",
       "go_back_to_wizard": "Gå tilbake til skjema",
       "handle": "Handle",


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47345

Vis tilpasset streng når resultat med valideringsfeil allerede er publisert.

Før:
![bilde](https://github.com/user-attachments/assets/fb955886-1e6a-446f-b1f7-e00741522c92)

Etter:
![bilde](https://github.com/user-attachments/assets/26c6bccc-770f-4f55-8a1b-6c164c9411c4)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
