### PR TITLE
NP-47200 Disable all NVI relevant contributor actions if it is NVI reported

### DIFF
--- a/src/components/institution/UnconfirmedOrganizationBox.tsx
+++ b/src/components/institution/UnconfirmedOrganizationBox.tsx
@@ -8,7 +8,7 @@ import { StyledOrganizationBox } from './OrganizationBox';
 
 interface UnconfirmedOrganizationBoxProps extends Pick<BoxProps, 'sx'> {
   name: string;
-  onIdentifyAffiliationClick: (name: string) => void;
+  onIdentifyAffiliationClick?: (name: string) => void;
   removeAffiliation?: () => void;
 }
 
@@ -39,7 +39,8 @@ export const UnconfirmedOrganizationBox = ({
           sx={{ padding: '0.1rem 0.5rem', maxWidth: '14rem', bgcolor: 'secondary.light' }}
           data-testid={dataTestId.registrationWizard.contributors.verifyAffiliationButton}
           startIcon={<SearchIcon />}
-          onClick={() => name && onIdentifyAffiliationClick(name)}>
+          disabled={!onIdentifyAffiliationClick}
+          onClick={() => name && onIdentifyAffiliationClick?.(name)}>
           {t('registration.contributors.verify_affiliation')}
         </Button>
       </Box>

--- a/src/pages/registration/contributors_tab/Contributors.tsx
+++ b/src/pages/registration/contributors_tab/Contributors.tsx
@@ -15,10 +15,11 @@ import {
   Tooltip,
 } from '@mui/material';
 import { FieldArrayRenderProps, move, useFormikContext } from 'formik';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { ListPagination } from '../../../components/ListPagination';
+import { NviCandidateContext } from '../../../context/NviCandidateContext';
 import { setNotification } from '../../../redux/notificationSlice';
 import { alternatingTableRowColor } from '../../../themes/mainTheme';
 import {
@@ -54,6 +55,8 @@ export const Contributors = ({ contributorRoles, push, replace }: ContributorsPr
   const [rowsPerPage, setRowsPerPage] = useState(ROWS_PER_PAGE_OPTIONS[0]);
   const [currentPage, setCurrentPage] = useState(1);
   const [filterInput, setFilterInput] = useState('');
+
+  const { disableNviCriticalFields } = useContext(NviCandidateContext);
 
   const contributors = values.entityDescription?.contributors ?? [];
 
@@ -261,6 +264,7 @@ export const Contributors = ({ contributorRoles, push, replace }: ContributorsPr
       />
 
       <Button
+        disabled={disableNviCriticalFields}
         sx={{ marginBottom: '1rem', borderRadius: '1rem' }}
         onClick={() => setOpenAddContributor(true)}
         variant="contained"

--- a/src/pages/registration/contributors_tab/components/AffiliationsCell.tsx
+++ b/src/pages/registration/contributors_tab/components/AffiliationsCell.tsx
@@ -1,10 +1,11 @@
 import AddIcon from '@mui/icons-material/AddCircleOutline';
 import { Box, Button } from '@mui/material';
 import { useFormikContext } from 'formik';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { OrganizationBox } from '../../../../components/institution/OrganizationBox';
 import { UnconfirmedOrganizationBox } from '../../../../components/institution/UnconfirmedOrganizationBox';
+import { NviCandidateContext } from '../../../../context/NviCandidateContext';
 import { Affiliation } from '../../../../types/contributor.types';
 import { SpecificContributorFieldNames } from '../../../../types/publicationFieldNames';
 import { Registration } from '../../../../types/registration.types';
@@ -22,6 +23,8 @@ export const AffiliationsCell = ({ affiliations = [], authorName, baseFieldName 
   const { setFieldValue } = useFormikContext<Registration>();
   const [openAffiliationModal, setOpenAffiliationModal] = useState(false);
   const [affiliationToVerify, setAffiliationToVerify] = useState('');
+
+  const { disableNviCriticalFields } = useContext(NviCandidateContext);
 
   const toggleAffiliationModal = () => setOpenAffiliationModal(!openAffiliationModal);
 
@@ -61,15 +64,15 @@ export const AffiliationsCell = ({ affiliations = [], authorName, baseFieldName 
               authorName={authorName}
               affiliations={affiliations}
               baseFieldName={baseFieldName}
-              removeAffiliation={() => removeAffiliation(index)}
+              removeAffiliation={disableNviCriticalFields ? undefined : () => removeAffiliation(index)}
               sx={{ width: '100%' }}
-              canEdit
+              canEdit={!disableNviCriticalFields}
             />
           )}
           {affiliation.type === 'UnconfirmedOrganization' && (
             <UnconfirmedOrganizationBox
               name={affiliation.name}
-              onIdentifyAffiliationClick={onIdentifyAffiliationClick}
+              onIdentifyAffiliationClick={disableNviCriticalFields ? undefined : onIdentifyAffiliationClick}
               removeAffiliation={() => removeAffiliation(index)}
               sx={{ width: '100%' }}
             />
@@ -77,6 +80,7 @@ export const AffiliationsCell = ({ affiliations = [], authorName, baseFieldName 
         </Box>
       ))}
       <Button
+        disabled={disableNviCriticalFields}
         variant="outlined"
         sx={{ padding: '0.1rem 0.75rem' }}
         data-testid={dataTestId.registrationWizard.contributors.addAffiliationButton}

--- a/src/pages/registration/contributors_tab/components/ContributorRow.tsx
+++ b/src/pages/registration/contributors_tab/components/ContributorRow.tsx
@@ -9,8 +9,8 @@ import {
   Button,
   Checkbox,
   IconButton,
-  Link as MuiLink,
   MenuItem,
+  Link as MuiLink,
   TableCell,
   TableRow,
   TextField,
@@ -18,10 +18,11 @@ import {
   Typography,
 } from '@mui/material';
 import { ErrorMessage, Field, FieldProps } from 'formik';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { ConfirmDialog } from '../../../../components/ConfirmDialog';
+import { NviCandidateContext } from '../../../../context/NviCandidateContext';
 import OrcidLogo from '../../../../resources/images/orcid_logo.svg';
 import { Contributor, ContributorRole } from '../../../../types/contributor.types';
 import { ContributorFieldNames, SpecificContributorFieldNames } from '../../../../types/publicationFieldNames';
@@ -54,6 +55,8 @@ export const ContributorRow = ({
   const { t } = useTranslation();
   const [openRemoveContributor, setOpenRemoveContributor] = useState(false);
   const [openVerifyContributor, setOpenVerifyContributor] = useState(false);
+
+  const { disableNviCriticalFields } = useContext(NviCandidateContext);
 
   const baseFieldName = `${ContributorFieldNames.Contributors}[${contributorIndex}]`;
   const [sequenceValue, setSequenceValue] = useState(`${contributor.sequence}`);
@@ -182,6 +185,7 @@ export const ContributorRow = ({
           </Box>
           {!contributor.identity.id && (
             <Button
+              disabled={disableNviCriticalFields}
               variant="outlined"
               sx={{ padding: '0.1rem 0.75rem' }}
               data-testid={dataTestId.registrationWizard.contributors.verifyContributorButton(
@@ -194,10 +198,11 @@ export const ContributorRow = ({
           )}
 
           <Button
+            disabled={disableNviCriticalFields}
             size="small"
             data-testid={dataTestId.registrationWizard.contributors.removeContributorButton(contributor.identity.name)}
             onClick={() => setOpenRemoveContributor(true)}
-            startIcon={<RemoveIcon color="primary" />}>
+            startIcon={<RemoveIcon />}>
             {t('registration.contributors.remove_contributor')}
           </Button>
         </Box>


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47200

Disable actions for bidragsytere/tilknytninger som kan påvirke NVI om resultatet er godkjent av alle institusjoner, og det er i en åpen NVI-periode.

Før:
![bilde](https://github.com/user-attachments/assets/25cfb5c9-2e83-450b-b5ab-2b5f554c1468)


Etter:
![bilde](https://github.com/user-attachments/assets/b991b724-2462-4cbc-aa65-c9c1f56d7c80)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [ ] The changes are tested OK for a11y
 Ett problem med denne: "Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds". Men ser ikke noen enkel løsning uten å bloate ting ved å style denne annerledes enn alt annet 🤔 
![bilde](https://github.com/user-attachments/assets/4660f13d-ef15-4ed1-9ca9-f0b636c3a781)
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
