### PR TITLE
Np 47401 inform about disabled nvi fields

### DIFF
--- a/src/components/styled/Wrappers.tsx
+++ b/src/components/styled/Wrappers.tsx
@@ -81,3 +81,10 @@ export const StyledTruncatableTypography = styled(Typography)({
   overflow: 'hidden',
   textOverflow: 'ellipsis',
 });
+
+export const StyledInfoBanner = styled(Box)(({ theme }) => ({
+  backgroundColor: theme.palette.primary.light,
+  padding: '0.75rem',
+  borderRadius: '0.25rem',
+  color: 'white',
+}));

--- a/src/context/NviCandidateContext.ts
+++ b/src/context/NviCandidateContext.ts
@@ -2,11 +2,11 @@ import { createContext } from 'react';
 import { NviCandidate } from '../types/nvi.types';
 
 interface NviCandidateContextType {
-  nviCandiadate?: NviCandidate;
+  nviCandidate?: NviCandidate;
   disableNviCriticalFields: boolean;
 }
 
 export const NviCandidateContext = createContext<NviCandidateContextType>({
-  nviCandiadate: undefined,
+  nviCandidate: undefined,
   disableNviCriticalFields: false,
 });

--- a/src/pages/registration/ContributorsPanel.tsx
+++ b/src/pages/registration/ContributorsPanel.tsx
@@ -1,11 +1,15 @@
 import WarningIcon from '@mui/icons-material/Warning';
 import { Box, FormHelperText, Typography } from '@mui/material';
 import { ErrorMessage, FieldArray, FieldArrayRenderProps, FormikErrors, FormikTouched, useFormikContext } from 'formik';
+import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
+import { StyledInfoBanner } from '../../components/styled/Wrappers';
+import { NviCandidateContext } from '../../context/NviCandidateContext';
 import { ContributorFieldNames } from '../../types/publicationFieldNames';
 import { EntityDescription, Registration } from '../../types/registration.types';
 import { contributorConfig } from '../../utils/registration-helpers';
 import { Contributors } from './contributors_tab/Contributors';
+import { LockedNviFieldDescription } from './LockedNviFieldDescription';
 
 export const ContributorsPanel = () => {
   const { t } = useTranslation();
@@ -18,6 +22,8 @@ export const ContributorsPanel = () => {
   const contributorsTouched = (touched.entityDescription as unknown as FormikTouched<EntityDescription>)?.contributors;
   const publicationInstanceType = entityDescription?.reference?.publicationInstance?.type;
 
+  const { disableNviCriticalFields } = useContext(NviCandidateContext);
+
   const contributorConfigResult = publicationInstanceType ? contributorConfig[publicationInstanceType] : null;
   const primaryRoles = contributorConfigResult?.primaryRoles ?? [];
   const secondaryRoles = contributorConfigResult?.secondaryRoles ?? [];
@@ -25,6 +31,11 @@ export const ContributorsPanel = () => {
 
   return (
     <>
+      {disableNviCriticalFields && (
+        <StyledInfoBanner sx={{ mb: '1rem' }}>
+          <LockedNviFieldDescription fieldLabel={t('registration.heading.contributors')} />
+        </StyledInfoBanner>
+      )}
       <FieldArray name={ContributorFieldNames.Contributors}>
         {({ push, replace }: FieldArrayRenderProps) =>
           publicationInstanceType ? (

--- a/src/pages/registration/DuplicateWarning.tsx
+++ b/src/pages/registration/DuplicateWarning.tsx
@@ -2,6 +2,7 @@ import OpenInNewOutlinedIcon from '@mui/icons-material/OpenInNewOutlined';
 import { Box, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { StyledInfoBanner } from '../../components/styled/Wrappers';
 import { dataTestId } from '../../utils/dataTestIds';
 import { getRegistrationLandingPagePath } from '../../utils/urlPaths';
 
@@ -24,7 +25,7 @@ export const DuplicateWarning = ({ name, identifier, warning }: DuplicateWarning
         flexDirection: 'column',
         gap: '0.5rem',
       }}>
-      <Box sx={{ bgcolor: 'primary.light', color: 'white', p: '0.5rem', borderRadius: '0.25rem' }}>{warning}</Box>
+      <StyledInfoBanner>{warning}</StyledInfoBanner>
       {name && identifier && (
         <>
           <Typography sx={{ fontWeight: 'bold' }}>{t('common.result')}</Typography>

--- a/src/pages/registration/LockedNviFieldDescription.tsx
+++ b/src/pages/registration/LockedNviFieldDescription.tsx
@@ -1,0 +1,23 @@
+import ErrorIcon from '@mui/icons-material/Error';
+import { Box, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+interface LockedNviFieldDescriptionProps {
+  fieldLabel: string;
+}
+
+export const LockedNviFieldDescription = ({ fieldLabel }: LockedNviFieldDescriptionProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Box sx={{ display: 'flex', gap: '0.5rem', alignItems: 'center', mb: '0.25rem' }}>
+        <ErrorIcon />
+        <Typography variant="h2" color="inherit">
+          {t('common.nvi')}
+        </Typography>
+      </Box>
+      <Typography color="inherit">{t('registration.locked_nvi_field_description', { field: fieldLabel })}</Typography>
+    </>
+  );
+};

--- a/src/pages/registration/LockedNviFieldDescription.tsx
+++ b/src/pages/registration/LockedNviFieldDescription.tsx
@@ -17,7 +17,9 @@ export const LockedNviFieldDescription = ({ fieldLabel }: LockedNviFieldDescript
           {t('common.nvi')}
         </Typography>
       </Box>
-      <Typography color="inherit">{t('registration.locked_nvi_field_description', { field: fieldLabel })}</Typography>
+      <Typography color="inherit">
+        {t('registration.locked_nvi_field_description', { field: fieldLabel.toLocaleLowerCase() })}
+      </Typography>
     </>
   );
 };

--- a/src/pages/registration/RegistrationForm.tsx
+++ b/src/pages/registration/RegistrationForm.tsx
@@ -82,7 +82,7 @@ export const RegistrationForm = ({ identifier }: RegistrationFormProps) => {
   ) : registration ? (
     <NviCandidateContext.Provider
       value={{
-        nviCandiadate: nviCandidateQuery.data,
+        nviCandidate: nviCandidateQuery.data,
         disableNviCriticalFields:
           !!nviCandidateQuery.data && isApprovedAndOpenNviCandidate(nviCandidateQuery.data) && !user?.isNviCurator,
       }}>

--- a/src/pages/registration/description_tab/DatePickerField.tsx
+++ b/src/pages/registration/description_tab/DatePickerField.tsx
@@ -3,11 +3,13 @@ import { DatePicker } from '@mui/x-date-pickers';
 import { FormikErrors, FormikTouched, useFormikContext } from 'formik';
 import { useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { StyledInfoBanner } from '../../../components/styled/Wrappers';
 import { NviCandidateContext } from '../../../context/NviCandidateContext';
 import { DescriptionFieldNames } from '../../../types/publicationFieldNames';
 import { EntityDescription, Registration, RegistrationDate } from '../../../types/registration.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { getRegistrationDate } from '../../../utils/date-helpers';
+import { LockedNviFieldDescription } from '../LockedNviFieldDescription';
 
 export const DatePickerField = () => {
   const { t } = useTranslation();
@@ -48,6 +50,12 @@ export const DatePickerField = () => {
 
   return (
     <>
+      {disableNviCriticalFields && (
+        <StyledInfoBanner sx={{ gridColumn: '1/3' }}>
+          <LockedNviFieldDescription fieldLabel={t('registration.description.date_published')} />
+        </StyledInfoBanner>
+      )}
+
       <DatePicker
         label={t('registration.description.date_published')}
         value={date}
@@ -55,6 +63,7 @@ export const DatePickerField = () => {
           updateDateValues(newDate, yearOnly);
           setDate(newDate);
         }}
+        sx={{ gridColumn: '1/2' }}
         disabled={disableNviCriticalFields}
         views={yearOnly ? ['year'] : ['year', 'month', 'day']}
         maxDate={new Date(new Date().getFullYear() + 5, 11, 31)}

--- a/src/pages/registration/resource_type_tab/SelectRegistrationTypeField.tsx
+++ b/src/pages/registration/resource_type_tab/SelectRegistrationTypeField.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { CategorySelector } from '../../../components/CategorySelector';
 import { ConfirmDialog } from '../../../components/ConfirmDialog';
+import { StyledInfoBanner } from '../../../components/styled/Wrappers';
 import { NviCandidateContext } from '../../../context/NviCandidateContext';
 import { RootState } from '../../../redux/store';
 import { emptyArtisticPublicationInstance } from '../../../types/publication_types/artisticRegistration.types';
@@ -52,6 +53,7 @@ import {
   isPeriodicalMediaContribution,
   nviApplicableTypes,
 } from '../../../utils/registration-helpers';
+import { LockedNviFieldDescription } from '../LockedNviFieldDescription';
 
 export const SelectRegistrationTypeField = () => {
   const { t } = useTranslation();
@@ -351,6 +353,12 @@ export const SelectRegistrationTypeField = () => {
     </>
   ) : (
     <div>
+      {disableNviCriticalFields && (
+        <StyledInfoBanner sx={{ mb: '0.5rem' }}>
+          <LockedNviFieldDescription fieldLabel={t('registration.resource_type.resource_type')} />
+        </StyledInfoBanner>
+      )}
+
       <FormLabel sx={{ display: 'block' }}>{t('registration.resource_type.resource_type')}</FormLabel>
       <Chip
         data-testid={dataTestId.registrationWizard.resourceType.resourceTypeChip(currentInstanceType)}
@@ -367,7 +375,7 @@ export const SelectRegistrationTypeField = () => {
         color="primary"
         label={t(`registration.publication_types.${currentInstanceType}`)}
         onClick={() => setOpenSelectType(true)}
-        sx={{ mt: '0.5rem', width: 'max-content' }}
+        sx={{ mt: '0.25rem', width: 'max-content' }}
       />
       <FormHelperText>{t('registration.resource_type.click_to_change_resource_type')}</FormHelperText>
     </div>

--- a/src/pages/registration/resource_type_tab/components/JournalField.tsx
+++ b/src/pages/registration/resource_type_tab/components/JournalField.tsx
@@ -10,6 +10,7 @@ import {
   AutocompleteListboxWithExpansionProps,
 } from '../../../../components/AutocompleteListboxWithExpansion';
 import { AutocompleteTextField } from '../../../../components/AutocompleteTextField';
+import { StyledInfoBanner } from '../../../../components/styled/Wrappers';
 import { NviCandidateContext } from '../../../../context/NviCandidateContext';
 import { ResourceFieldNames, contextTypeBaseFieldName } from '../../../../types/publicationFieldNames';
 import {
@@ -20,6 +21,7 @@ import { Journal, PublicationChannelType } from '../../../../types/registration.
 import { dataTestId } from '../../../../utils/dataTestIds';
 import { useDebounce } from '../../../../utils/hooks/useDebounce';
 import { keepSimilarPreviousData } from '../../../../utils/searchHelpers';
+import { LockedNviFieldDescription } from '../../LockedNviFieldDescription';
 import { JournalFormDialog } from './JournalFormDialog';
 import { PublicationChannelChipLabel } from './PublicationChannelChipLabel';
 import { PublicationChannelOption } from './PublicationChannelOption';
@@ -33,7 +35,7 @@ interface JournalFieldProps {
 
 export const StyledChannelContainerBox = styled(Box)(({ theme }) => ({
   display: 'grid',
-  columnGap: '1rem',
+  gap: '1rem',
 
   gridTemplateColumns: '4fr 1fr',
   [theme.breakpoints.down('md')]: {
@@ -119,6 +121,11 @@ export const JournalField = ({ confirmedContextType, unconfirmedContextType }: J
 
   return (
     <StyledChannelContainerBox>
+      {disableNviCriticalFields && (
+        <StyledInfoBanner sx={{ gridColumn: '1/-1' }}>
+          <LockedNviFieldDescription fieldLabel={t('registration.resource_type.journal')} />
+        </StyledInfoBanner>
+      )}
       <Field name={ResourceFieldNames.PublicationContextId}>
         {({ field, meta }: FieldProps<string>) => (
           <Autocomplete

--- a/src/pages/registration/resource_type_tab/components/PublisherField.tsx
+++ b/src/pages/registration/resource_type_tab/components/PublisherField.tsx
@@ -10,6 +10,7 @@ import {
   AutocompleteListboxWithExpansionProps,
 } from '../../../../components/AutocompleteListboxWithExpansion';
 import { AutocompleteTextField } from '../../../../components/AutocompleteTextField';
+import { StyledInfoBanner } from '../../../../components/styled/Wrappers';
 import { NviCandidateContext } from '../../../../context/NviCandidateContext';
 import { ResourceFieldNames } from '../../../../types/publicationFieldNames';
 import { BookEntityDescription } from '../../../../types/publication_types/bookRegistration.types';
@@ -17,6 +18,7 @@ import { PublicationChannelType, Publisher, Registration } from '../../../../typ
 import { dataTestId } from '../../../../utils/dataTestIds';
 import { useDebounce } from '../../../../utils/hooks/useDebounce';
 import { keepSimilarPreviousData } from '../../../../utils/searchHelpers';
+import { LockedNviFieldDescription } from '../../LockedNviFieldDescription';
 import { StyledChannelContainerBox, StyledCreateChannelButton } from './JournalField';
 import { PublicationChannelChipLabel } from './PublicationChannelChipLabel';
 import { PublicationChannelOption } from './PublicationChannelOption';
@@ -75,6 +77,11 @@ export const PublisherField = () => {
 
   return (
     <StyledChannelContainerBox>
+      {disableNviCriticalFields && (
+        <StyledInfoBanner sx={{ gridColumn: '1/-1' }}>
+          <LockedNviFieldDescription fieldLabel={t('common.publisher')} />
+        </StyledInfoBanner>
+      )}
       <Field name={ResourceFieldNames.PublicationContextPublisherId}>
         {({ field, meta }: FieldProps<string>) => (
           <Autocomplete

--- a/src/pages/registration/resource_type_tab/components/SearchContainerField.tsx
+++ b/src/pages/registration/resource_type_tab/components/SearchContainerField.tsx
@@ -8,6 +8,7 @@ import { fetchResults } from '../../../../api/searchApi';
 import { AutocompleteTextField } from '../../../../components/AutocompleteTextField';
 import { EmphasizeSubstring } from '../../../../components/EmphasizeSubstring';
 import { NpiLevelTypography } from '../../../../components/NpiLevelTypography';
+import { StyledInfoBanner } from '../../../../components/styled/Wrappers';
 import { NviCandidateContext } from '../../../../context/NviCandidateContext';
 import { Contributor } from '../../../../types/contributor.types';
 import { BookPublicationContext } from '../../../../types/publication_types/bookRegistration.types';
@@ -24,6 +25,7 @@ import { useDebounce } from '../../../../utils/hooks/useDebounce';
 import { useFetchResource } from '../../../../utils/hooks/useFetchResource';
 import { stringIncludesMathJax, typesetMathJax } from '../../../../utils/mathJaxHelpers';
 import { getTitleString } from '../../../../utils/registration-helpers';
+import { LockedNviFieldDescription } from '../../LockedNviFieldDescription';
 
 interface SearchContainerFieldProps {
   fieldName: string;
@@ -73,6 +75,12 @@ export const SearchContainerField = ({
     <Field name={fieldName}>
       {({ field, meta }: FieldProps<string>) => (
         <>
+          {disableNviCriticalFields && (
+            <StyledInfoBanner sx={{ mb: '1rem' }}>
+              <LockedNviFieldDescription fieldLabel={t('registration.resource_type.journal')} />
+            </StyledInfoBanner>
+          )}
+
           <Autocomplete
             disabled={disableNviCriticalFields}
             multiple

--- a/src/pages/registration/resource_type_tab/components/SeriesField.tsx
+++ b/src/pages/registration/resource_type_tab/components/SeriesField.tsx
@@ -10,6 +10,7 @@ import {
   AutocompleteListboxWithExpansionProps,
 } from '../../../../components/AutocompleteListboxWithExpansion';
 import { AutocompleteTextField } from '../../../../components/AutocompleteTextField';
+import { StyledInfoBanner } from '../../../../components/styled/Wrappers';
 import { NviCandidateContext } from '../../../../context/NviCandidateContext';
 import { ResourceFieldNames } from '../../../../types/publicationFieldNames';
 import { BookEntityDescription } from '../../../../types/publication_types/bookRegistration.types';
@@ -17,6 +18,7 @@ import { PublicationChannelType, Registration, Series } from '../../../../types/
 import { dataTestId } from '../../../../utils/dataTestIds';
 import { useDebounce } from '../../../../utils/hooks/useDebounce';
 import { keepSimilarPreviousData } from '../../../../utils/searchHelpers';
+import { LockedNviFieldDescription } from '../../LockedNviFieldDescription';
 import { StyledChannelContainerBox, StyledCreateChannelButton } from './JournalField';
 import { JournalFormDialog } from './JournalFormDialog';
 import { PublicationChannelChipLabel } from './PublicationChannelChipLabel';
@@ -77,6 +79,11 @@ export const SeriesField = () => {
 
   return (
     <StyledChannelContainerBox>
+      {disableNviCriticalFields && (
+        <StyledInfoBanner sx={{ gridColumn: '1/-1' }}>
+          <LockedNviFieldDescription fieldLabel={t('registration.resource_type.series')} />
+        </StyledInfoBanner>
+      )}
       <Field name={ResourceFieldNames.SeriesId}>
         {({ field, meta }: FieldProps<string>) => (
           <Autocomplete

--- a/src/pages/registration/resource_type_tab/sub_type_forms/ChapterForm.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/ChapterForm.tsx
@@ -34,9 +34,9 @@ export const ChapterForm = () => {
   return (
     <>
       <div>
-        <Box sx={{ display: 'flex', justifyContent: 'center', gap: '1rem' }}>
+        <Box sx={{ display: 'flex', justifyContent: 'center', gap: '0.5rem', mb: '0.25rem', alignItems: 'center' }}>
           <InfoIcon color="primary" />
-          <Typography variant="body1" gutterBottom>
+          <Typography variant="body1">
             {generalChapterTypes.includes(instanceType)
               ? t('registration.resource_type.chapter.info_anthology')
               : instanceType === ChapterType.ConferenceAbstract

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1378,6 +1378,7 @@
       "resource_type": "Kategori"
     },
     "is_revision": "Arbeidet er en revisjon",
+    "locked_nvi_field_description": "Publikasjonen er godkjent til årets NVI-rapportering. Du kan derfor ikke endre {{field}}. Om informasjonen er feil må du ta kontakt med kurator for å få endret.",
     "missing_name": "Mangler navn",
     "missing_title": "Mangler tittel",
     "modal_unsaved_changes_description": "Du har gjort endringer som ikke er lagret. Er du sikker på at du vil forlate denne siden?",
@@ -1882,8 +1883,7 @@
         "header": "Veiledning for å registrere et forskningsresultat"
       }
     },
-    "year_published": "Publiseringsår",
-    "locked_nvi_field_description": "Publikasjonen er godkjent til årets NVI-rapportering. Du kan derfor ikke endre {{field}}. Om informasjonen er feil må du ta kontakt med kurator for å få endret."
+    "year_published": "Publiseringsår"
   },
   "search": {
     "additional_participants_one": "+{{count}} deltaker",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1882,7 +1882,8 @@
         "header": "Veiledning for å registrere et forskningsresultat"
       }
     },
-    "year_published": "Publiseringsår"
+    "year_published": "Publiseringsår",
+    "locked_nvi_field_description": "Publikasjonen er godkjent til årets NVI-rapportering. Du kan derfor ikke endre {{field}}. Om informasjonen er feil må du ta kontakt med kurator for å få endret."
   },
   "search": {
     "additional_participants_one": "+{{count}} deltaker",


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47401

Vis grunnen til hvorfor et felt som påvirker NVI låses når alle institusjoner har godkjent en kandidat, og den fortsatt er i en åpen kandidat. Feltene vil fortsatt være enabled for NVI-kurator, men disabled for alle andre.
Eksempelpost for testing: http://localhost:3000/registration/01905dc6a204-93833649-22c7-4fbd-95ad-b54d0d618761/edit

![bilde](https://github.com/user-attachments/assets/b3611597-8880-4001-a143-4cfaa4fce0e8)

![bilde](https://github.com/user-attachments/assets/de64847d-8194-4fa6-bdc5-6cc02284eb57)

![bilde](https://github.com/user-attachments/assets/bdc4c841-5e3e-455f-83e0-7cf714797ff9)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
