### PR TITLE
Create the third tab "Project participants" of the "Create Project" view

### DIFF
--- a/src/pages/project/project_wizard/ProjectContributorsForm.tsx
+++ b/src/pages/project/project_wizard/ProjectContributorsForm.tsx
@@ -1,10 +1,21 @@
 import { Box } from '@mui/material';
 import { ErrorBoundary } from '../../../components/ErrorBoundary';
+import { ProjectContributors } from '../../projects/form/ProjectContributors';
 
-export const ProjectContributorsForm = () => {
+interface ProjectContributorsFormProps {
+  suggestedProjectManager?: string;
+  thisIsRekProject: boolean;
+}
+
+export const ProjectContributorsForm = ({
+  thisIsRekProject,
+  suggestedProjectManager,
+}: ProjectContributorsFormProps) => {
   return (
     <ErrorBoundary>
-      <Box sx={{ bgcolor: 'secondary.light', padding: '1.75rem 1.25rem' }}>test 3</Box>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        <ProjectContributors thisIsRekProject={thisIsRekProject} suggestedProjectManager={suggestedProjectManager} />
+      </Box>
     </ErrorBoundary>
   );
 };

--- a/src/pages/project/project_wizard/ProjectForm.tsx
+++ b/src/pages/project/project_wizard/ProjectForm.tsx
@@ -44,7 +44,9 @@ export const ProjectForm = ({ project }: ProjectFormProps) => {
                     <ProjectDescriptionForm thisIsRekProject={thisIsRekProject} />
                   )}
                   {tabNumber === ProjectTabs.Details && <ProjectDetailsForm thisIsRekProject={thisIsRekProject} />}
-                  {tabNumber === ProjectTabs.Contributors && <ProjectContributorsForm />}
+                  {tabNumber === ProjectTabs.Contributors && (
+                    <ProjectContributorsForm thisIsRekProject={thisIsRekProject} />
+                  )}
                   {tabNumber === ProjectTabs.Connections && <ProjectConnectionsForm />}
                 </Box>
                 <p>registration form actions</p>

--- a/src/pages/projects/form/ProjectContributors.tsx
+++ b/src/pages/projects/form/ProjectContributors.tsx
@@ -18,22 +18,21 @@ import { alternatingTableRowColor } from '../../../themes/mainTheme';
 import { CristinProject, emptyProjectContributor, ProjectFieldName } from '../../../types/project.types';
 import { ROWS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 import { dataTestId } from '../../../utils/dataTestIds';
-import { isProjectManager, isRekProject } from '../../registration/description_tab/projects_field/projectHelpers';
+import { isProjectManager } from '../../registration/description_tab/projects_field/projectHelpers';
 import { ContributorRow } from './ContributorRow';
 
 interface ProjectContributorsProps {
-  currentProject?: CristinProject;
+  thisIsRekProject: boolean;
   suggestedProjectManager?: string;
 }
 
-export const ProjectContributors = ({ currentProject, suggestedProjectManager }: ProjectContributorsProps) => {
+export const ProjectContributors = ({ thisIsRekProject, suggestedProjectManager }: ProjectContributorsProps) => {
   const { t } = useTranslation();
   const [rowsPerPage, setRowsPerPage] = useState(ROWS_PER_PAGE_OPTIONS[0]);
   const [currentPage, setCurrentPage] = useState(1);
   const { values } = useFormikContext<CristinProject>();
   const { contributors } = values;
   const contributorsToShow = contributors.slice(rowsPerPage * (currentPage - 1), rowsPerPage * currentPage);
-  const thisIsRekProject = isRekProject(currentProject);
   const hasUnidentifiedContributor = contributors.some((contributor) => !contributor.identity.id);
 
   return (

--- a/src/pages/projects/form/ProjectFormPanel1.tsx
+++ b/src/pages/projects/form/ProjectFormPanel1.tsx
@@ -124,7 +124,7 @@ export const ProjectFormPanel1 = ({ currentProject, suggestedProjectManager }: P
           </Field>
         </Box>
       </Box>
-      <ProjectContributors currentProject={currentProject} suggestedProjectManager={suggestedProjectManager} />
+      <ProjectContributors thisIsRekProject={thisIsRekProject} suggestedProjectManager={suggestedProjectManager} />
       <ProjectFundingsField currentFundings={values.funding} />
     </>
   );


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-47305](https://sikt.atlassian.net/browse/NP-47305)

⚠This is only visible when you have beta toggled to true in local storage ⚠

You get to this view my going to Min Side --> "Prosjektregistreringer" in the left panel -> Choose a project -> Click the edit-button and go to the third tab: Contributors

This is a part of the effort to create a new create project-wizard [(NP-47281)](https://sikt.atlassian.net/browse/NP-47281), and there is a subtask for each of the 4 steps, plus subtasks for some new functionality to add.

In this task we have to create the third tab, using already the new contributor view I have made in earlier tasks.

**What should work after this PR:**

In projects view, it should now be possible to click the edit button and get into the new edit project wizard and navigate to the third panel:

![image](https://github.com/user-attachments/assets/be0eed24-2438-4364-8393-909649bc7e0f)

* It should be possible to see the current contributers and their affiliations, and change them.
* If there are no contributors and you navigate to the forth tab and back, you should get an error message
* You can click on the stepper to change views (the forth view is empty)
* If there are any errors on the page you are leaving, there will be an error icon in the stepper
* This new view should only be visible when beta is toggled to true in localStorage, so verify that it looks as before when this is not the case.

**Things that are not working and will be fixed in later PRs:**
* The last panel is missing
* There is no save-button
* There is no cancel-button
* There is no-next- or previous button
* The stepper is not ready for mobile-view yet
* There is still nothing when you open the new-project view

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [ ] The changes are working as expected
- [ ] The changes are tested OK for different screen sizes
- [ ] The changes are tested OK for a11y
- [ ] Interactive elements have data-testids
- [ ] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
