### PR TITLE
Create the third tab "Project participants" of the "Create Project" view

### DIFF
--- a/src/pages/project/project_wizard/ProjectContributorsForm.tsx
+++ b/src/pages/project/project_wizard/ProjectContributorsForm.tsx
@@ -1,16 +1,21 @@
 import { Box } from '@mui/material';
 import { ErrorBoundary } from '../../../components/ErrorBoundary';
+import { ProjectTabs } from '../../../types/project.types';
 import { ProjectContributors } from '../../projects/form/ProjectContributors';
 
 interface ProjectContributorsFormProps {
   suggestedProjectManager?: string;
+  maxVisitedTab: ProjectTabs;
 }
 
-export const ProjectContributorsForm = ({ suggestedProjectManager }: ProjectContributorsFormProps) => {
+export const ProjectContributorsForm = ({ suggestedProjectManager, maxVisitedTab }: ProjectContributorsFormProps) => {
   return (
     <ErrorBoundary>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-        <ProjectContributors suggestedProjectManager={suggestedProjectManager} />
+        <ProjectContributors
+          suggestedProjectManager={suggestedProjectManager}
+          isVisited={maxVisitedTab > ProjectTabs.Contributors}
+        />
       </Box>
     </ErrorBoundary>
   );

--- a/src/pages/project/project_wizard/ProjectContributorsForm.tsx
+++ b/src/pages/project/project_wizard/ProjectContributorsForm.tsx
@@ -1,10 +1,17 @@
 import { Box } from '@mui/material';
 import { ErrorBoundary } from '../../../components/ErrorBoundary';
+import { ProjectContributors } from '../../projects/form/ProjectContributors';
 
-export const ProjectContributorsForm = () => {
+interface ProjectContributorsFormProps {
+  suggestedProjectManager?: string;
+}
+
+export const ProjectContributorsForm = ({ suggestedProjectManager }: ProjectContributorsFormProps) => {
   return (
     <ErrorBoundary>
-      <Box sx={{ bgcolor: 'secondary.light', padding: '1.75rem 1.25rem' }}>test 3</Box>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        <ProjectContributors suggestedProjectManager={suggestedProjectManager} />
+      </Box>
     </ErrorBoundary>
   );
 };

--- a/src/pages/project/project_wizard/ProjectForm.tsx
+++ b/src/pages/project/project_wizard/ProjectForm.tsx
@@ -22,6 +22,7 @@ interface ProjectFormProps {
 export const ProjectForm = ({ project }: ProjectFormProps) => {
   const { t } = useTranslation();
   const [tabNumber, setTabNumber] = useState(ProjectTabs.Description);
+  const [maxVisitedTab, setMaxVisitedTab] = useState(ProjectTabs.Description);
   const [initialValues] = useState<InitialProjectFormData>({ project: project });
   const thisIsRekProject = isRekProject(project);
 
@@ -36,7 +37,12 @@ export const ProjectForm = ({ project }: ProjectFormProps) => {
           return (
             <Form noValidate>
               <PageHeader variant="h1">{project.title}</PageHeader>
-              <ProjectFormStepper tabNumber={tabNumber} setTabNumber={setTabNumber} />
+              <ProjectFormStepper
+                tabNumber={tabNumber}
+                setTabNumber={setTabNumber}
+                maxVisitedTab={maxVisitedTab}
+                setMaxVisitedTab={setMaxVisitedTab}
+              />
               <RequiredDescription />
               <Box sx={{ bgcolor: 'secondary.dark', padding: '0' }}>
                 <Box id="form" sx={{ bgcolor: 'secondary.main', mb: '2rem', padding: '1.5rem 1.25rem' }}>
@@ -44,7 +50,7 @@ export const ProjectForm = ({ project }: ProjectFormProps) => {
                     <ProjectDescriptionForm thisIsRekProject={thisIsRekProject} />
                   )}
                   {tabNumber === ProjectTabs.Details && <ProjectDetailsForm thisIsRekProject={thisIsRekProject} />}
-                  {tabNumber === ProjectTabs.Contributors && <ProjectContributorsForm />}
+                  {tabNumber === ProjectTabs.Contributors && <ProjectContributorsForm maxVisitedTab={maxVisitedTab} />}
                   {tabNumber === ProjectTabs.Connections && <ProjectConnectionsForm />}
                 </Box>
                 <p>registration form actions</p>

--- a/src/pages/project/project_wizard/ProjectFormStepper.tsx
+++ b/src/pages/project/project_wizard/ProjectFormStepper.tsx
@@ -1,6 +1,5 @@
 import { Step, StepButton, StepLabel, Stepper } from '@mui/material';
 import { useFormikContext } from 'formik';
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CristinProject, ProjectTabs } from '../../../types/project.types';
 import { dataTestId } from '../../../utils/dataTestIds';
@@ -9,17 +8,23 @@ import { getProjectTabErrors } from '../../../utils/formik-helpers/project-form-
 interface ProjectFormStepperProps {
   setTabNumber: (newTab: ProjectTabs) => void;
   tabNumber: ProjectTabs;
+  maxVisitedTab: ProjectTabs;
+  setMaxVisitedTab: (val: ProjectTabs) => void;
 }
 
-export const ProjectFormStepper = ({ tabNumber, setTabNumber }: ProjectFormStepperProps) => {
+export const ProjectFormStepper = ({
+  tabNumber,
+  setTabNumber,
+  maxVisitedTab,
+  setMaxVisitedTab,
+}: ProjectFormStepperProps) => {
   const { t } = useTranslation();
   const { errors, touched } = useFormikContext<CristinProject>();
-  const [maxVisitedTab, setMaxVisitedTab] = useState(ProjectTabs.Description);
 
   const tabErrors = getProjectTabErrors(errors, touched);
   const descriptionTabHasError = tabErrors[ProjectTabs.Description].length > 0;
   const detailsTabHasError = tabErrors[ProjectTabs.Details].length > 0;
-  const contributorTabHasError = false;
+  const contributorTabHasError = tabErrors[ProjectTabs.Contributors].length > 0;
   const connectionTabHasError = false;
 
   const onClickStep = (stepNumber: ProjectTabs) => {
@@ -58,7 +63,7 @@ export const ProjectFormStepper = ({ tabNumber, setTabNumber }: ProjectFormStepp
           data-testid={dataTestId.projectWizard.stepper.projectContributorsStepButton}
           onClick={() => onClickStep(ProjectTabs.Contributors)}>
           <StepLabel
-            error={contributorTabHasError}
+            error={contributorTabHasError && maxVisitedTab > ProjectTabs.Contributors}
             data-testid={contributorTabHasError ? dataTestId.projectWizard.stepper.projectErrorStep : undefined}>
             {t('project.heading.project_participants')}
           </StepLabel>

--- a/src/pages/projects/form/ProjectContributors.tsx
+++ b/src/pages/projects/form/ProjectContributors.tsx
@@ -24,9 +24,10 @@ import { ContributorRow } from './ContributorRow';
 interface ProjectContributorsProps {
   suggestedProjectManager?: string;
   isVisited: boolean;
+  showHeader: boolean;
 }
 
-export const ProjectContributors = ({ suggestedProjectManager, isVisited }: ProjectContributorsProps) => {
+export const ProjectContributors = ({ suggestedProjectManager, isVisited, showHeader }: ProjectContributorsProps) => {
   const { t } = useTranslation();
   const [rowsPerPage, setRowsPerPage] = useState(ROWS_PER_PAGE_OPTIONS[0]);
   const [currentPage, setCurrentPage] = useState(1);
@@ -43,9 +44,11 @@ export const ProjectContributors = ({ suggestedProjectManager, isVisited }: Proj
 
   return (
     <>
-      <Typography variant="h3" gutterBottom sx={{ marginTop: '2rem', marginBottom: '1rem' }}>
-        {t('project.project_participants')}
-      </Typography>
+      {showHeader && (
+        <Typography variant="h3" gutterBottom sx={{ marginTop: '2rem', marginBottom: '1rem' }}>
+          {t('project.project_participants')}
+        </Typography>
+      )}
       {suggestedProjectManager && (
         <Typography sx={{ marginBottom: '1rem' }}>
           {t('project.project_manager_from_nfr', { name: suggestedProjectManager })}

--- a/src/pages/projects/form/ProjectContributors.tsx
+++ b/src/pages/projects/form/ProjectContributors.tsx
@@ -24,7 +24,7 @@ import { ContributorRow } from './ContributorRow';
 interface ProjectContributorsProps {
   suggestedProjectManager?: string;
   isVisited: boolean;
-  showHeader: boolean;
+  showHeader?: boolean;
 }
 
 export const ProjectContributors = ({ suggestedProjectManager, isVisited, showHeader }: ProjectContributorsProps) => {

--- a/src/pages/projects/form/ProjectContributors.tsx
+++ b/src/pages/projects/form/ProjectContributors.tsx
@@ -23,14 +23,15 @@ import { ContributorRow } from './ContributorRow';
 
 interface ProjectContributorsProps {
   suggestedProjectManager?: string;
+  isVisited: boolean;
 }
 
-export const ProjectContributors = ({ suggestedProjectManager }: ProjectContributorsProps) => {
+export const ProjectContributors = ({ suggestedProjectManager, isVisited }: ProjectContributorsProps) => {
   const { t } = useTranslation();
   const [rowsPerPage, setRowsPerPage] = useState(ROWS_PER_PAGE_OPTIONS[0]);
   const [currentPage, setCurrentPage] = useState(1);
   const [openAddContributorView, setOpenAddContributorView] = useState(false);
-  const { values, errors, touched } = useFormikContext<CristinProject>();
+  const { values, errors } = useFormikContext<CristinProject>();
   const { contributors } = values;
   const contributorsToShow = contributors.slice(rowsPerPage * (currentPage - 1), rowsPerPage * currentPage);
   const contributorError = errors?.contributors;
@@ -103,7 +104,7 @@ export const ProjectContributors = ({ suggestedProjectManager }: ProjectContribu
                 </TableContainer>
               </ListPagination>
             )}
-            {contributorError && typeof contributorError === 'string' && touched.contributors && (
+            {contributorError && typeof contributorError === 'string' && isVisited && (
               <Typography
                 sx={{ color: 'error.main', marginTop: '0.25rem', letterSpacing: '0.03333em', marginBottom: '1rem' }}>
                 {contributorError}

--- a/src/pages/projects/form/ProjectFormPanel1.tsx
+++ b/src/pages/projects/form/ProjectFormPanel1.tsx
@@ -124,7 +124,11 @@ export const ProjectFormPanel1 = ({ currentProject, suggestedProjectManager }: P
           </Field>
         </Box>
       </Box>
-      <ProjectContributors suggestedProjectManager={suggestedProjectManager} isVisited={!!touched.contributors} />
+      <ProjectContributors
+        suggestedProjectManager={suggestedProjectManager}
+        isVisited={!!touched.contributors}
+        showHeader
+      />
       <ProjectFundingsField currentFundings={values.funding} />
     </>
   );

--- a/src/pages/projects/form/ProjectFormPanel1.tsx
+++ b/src/pages/projects/form/ProjectFormPanel1.tsx
@@ -124,7 +124,7 @@ export const ProjectFormPanel1 = ({ currentProject, suggestedProjectManager }: P
           </Field>
         </Box>
       </Box>
-      <ProjectContributors suggestedProjectManager={suggestedProjectManager} />
+      <ProjectContributors suggestedProjectManager={suggestedProjectManager} isVisited={!!touched.contributors} />
       <ProjectFundingsField currentFundings={values.funding} />
     </>
   );

--- a/src/pages/projects/form/ProjectFunding.tsx
+++ b/src/pages/projects/form/ProjectFunding.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { VerifiedFundingApiPath } from '../../../api/apiPaths';
 import { FundingSourceField } from '../../../components/FundingSourceField';
 import { NfrProjectSearch } from '../../../components/NfrProjectSearch';
-import { ProjectFieldName, ProjectFunding, emptyProjectFunding } from '../../../types/project.types';
+import { emptyProjectFunding, ProjectFieldName, ProjectFunding } from '../../../types/project.types';
 import { SpecificFundingFieldNames } from '../../../types/publicationFieldNames';
 import { API_URL } from '../../../utils/constants';
 import { dataTestId } from '../../../utils/dataTestIds';
@@ -22,7 +22,7 @@ export const ProjectFundingsField = ({ currentFundings }: FundingsFieldProps) =>
 
   return (
     <div>
-      <Typography variant="h2" gutterBottom>
+      <Typography variant="h2" sx={{ mt: '2rem' }} gutterBottom>
         {t('common.funding')}
       </Typography>
 

--- a/src/utils/formik-helpers/project-form-helpers.ts
+++ b/src/utils/formik-helpers/project-form-helpers.ts
@@ -1,11 +1,16 @@
 import { FormikErrors, FormikTouched } from 'formik';
 import { CristinProject, ProjectTabs } from '../../types/project.types';
-import { ProjectDescriptionFieldNames, ProjectDetailsFieldNames } from '../projectFormikFieldNames';
+import {
+  ProjectContributorsFieldNames,
+  ProjectDescriptionFieldNames,
+  ProjectDetailsFieldNames,
+} from '../projectFormikFieldNames';
 import { getErrorMessages } from './formik-helpers';
 
 interface ProjectTabErrors {
   [ProjectTabs.Description]: string[];
   [ProjectTabs.Details]: string[];
+  [ProjectTabs.Contributors]: string[];
 }
 
 export const getProjectTabErrors = (errors: FormikErrors<CristinProject>, touched?: FormikTouched<CristinProject>) => {
@@ -16,6 +21,7 @@ export const getProjectTabErrors = (errors: FormikErrors<CristinProject>, touche
       touched
     ),
     [ProjectTabs.Details]: getErrorMessages<CristinProject>(Object.values(ProjectDetailsFieldNames), errors, touched),
+    [ProjectTabs.Contributors]: getErrorMessages<CristinProject>(Object.values(ProjectContributorsFieldNames), errors),
   };
 
   return tabErrors;

--- a/src/utils/projectFormikFieldNames.ts
+++ b/src/utils/projectFormikFieldNames.ts
@@ -14,3 +14,7 @@ export enum ProjectDetailsFieldNames {
   Categories = 'projectCategories',
   Funding = 'funding',
 }
+
+export enum ProjectContributorsFieldNames {
+  Contributors = 'contributors',
+}


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-47305](https://sikt.atlassian.net/browse/NP-47305)

**⚠This is only visible when you have beta toggled to true in local storage ⚠**

You get to this view my going to Min Side --> "Prosjektregistreringer" in the left panel -> Choose a project -> Click the edit-button and go to the third tab: Contributors

This is a part of the effort to create a new create project-wizard [(NP-47281)](https://sikt.atlassian.net/browse/NP-47281), and there is a subtask for each of the 4 steps, plus subtasks for some new functionality to add.

In this task we have to create the third tab, using already the new contributor view I have made in earlier tasks.

**What should work after this PR:**

In projects view, it should now be possible to click the edit button and get into the new edit project wizard and navigate to the third panel:

![image](https://github.com/user-attachments/assets/d906a093-f275-4180-bc35-ab1a8553534f)


* It should be possible to see the current contributors and their affiliations, and change them.
* You can click on the stepper to change views (the forth view is empty)
* This new view should only be visible when beta is toggled to true in localStorage, so verify that it looks as before when this is not the case.
* Error check between tabs

**Things that are not working and will be fixed in later PRs:**
* The last panel is missing
* There is no save-button
* There is no cancel-button
* There is no-next- or previous button
* The stepper is not ready for mobile-view yet
* There is still nothing when you open the new-project view

Note: There will be a new design for project contributors where they are divided into roles instead, so this will all be changed pretty soon. But since this design is already approved and ready from recent iterations in the non-beta-version, it can be used for now.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-47305]: https://sikt.atlassian.net/browse/NP-47305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ