### PR TITLE
Skip NVI warning in wizard when no one has approved it yet

### DIFF
--- a/src/pages/registration/RegistrationForm.tsx
+++ b/src/pages/registration/RegistrationForm.tsx
@@ -68,7 +68,7 @@ export const RegistrationForm = ({ identifier }: RegistrationFormProps) => {
   });
   const isNviCandidate =
     nviCandidateQuery.data?.period.status === 'OpenPeriod' &&
-    nviCandidateQuery.data.approvals.some((status) => status.status !== 'Pending');
+    nviCandidateQuery.data.approvals.some((approval) => approval.status === 'Approved');
 
   const initialTabNumber = new URLSearchParams(history.location.search).get('tab');
   const [tabNumber, setTabNumber] = useState(initialTabNumber ? +initialTabNumber : RegistrationTab.Description);


### PR DESCRIPTION
Ikke vis advarsel for at man endrer en NVI-post om ingen har godkjent den enda. For øyeblikket vil den vises om status = `New`
![bilde](https://github.com/user-attachments/assets/a5c510d7-15b4-4c5e-a32e-462cb4dfaa33)
