### PR TITLE
Create the initial "New project" view

### DIFF
--- a/src/components/styled/Wrappers.tsx
+++ b/src/components/styled/Wrappers.tsx
@@ -14,6 +14,12 @@ export const StyledRightAlignedWrapper = styled(Box)({
   justifyContent: 'flex-end',
 });
 
+export const HorizontalBox = styled(Box)({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+});
+
 export const StyledSelectWrapper = styled(Box)(({ theme }) => ({
   maxWidth: theme.breakpoints.values.lg,
   [theme.breakpoints.down('sm')]: {

--- a/src/pages/project/project_wizard/CreateProject.tsx
+++ b/src/pages/project/project_wizard/CreateProject.tsx
@@ -16,7 +16,7 @@ const CreateProject = () => {
           maxWidth: '55rem',
           display: 'flex',
           flexDirection: 'column',
-          gap: '2rem',
+          gap: '1.25rem',
         }}>
         <NFRProject />
         <EmptyProjectForm />

--- a/src/pages/project/project_wizard/CreateProjectAccordion.tsx
+++ b/src/pages/project/project_wizard/CreateProjectAccordion.tsx
@@ -1,0 +1,37 @@
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { Accordion, AccordionDetails, AccordionSummary, Box, SvgIconProps, Typography } from '@mui/material';
+import { ReactElement, ReactNode } from 'react';
+import { HorizontalBox } from '../../../components/styled/Wrappers';
+
+interface CreateProjectAccordionProps {
+  headline: string;
+  description?: string;
+  icon: ReactElement<SvgIconProps>;
+  children: ReactNode;
+  testId: string;
+}
+
+export const CreateProjectAccordion = ({
+  headline,
+  description,
+  icon,
+  testId,
+  children,
+}: CreateProjectAccordionProps) => {
+  return (
+    <Accordion data-testid={testId} elevation={3} sx={{ bgcolor: 'secondary.main' }}>
+      <AccordionSummary
+        sx={{ px: '1.25rem', py: '0.75rem' }}
+        expandIcon={<ExpandMoreIcon sx={{ color: 'primary.dark', height: '2.5rem', width: '2.5rem' }} />}>
+        <HorizontalBox>
+          {icon}
+          <Box>
+            <Typography sx={{ fontWeight: 'bold', pb: '0.25rem' }}>{headline}</Typography>
+            <Typography>{description}</Typography>
+          </Box>
+        </HorizontalBox>
+      </AccordionSummary>
+      <AccordionDetails sx={{ px: '1.25rem' }}>{children}</AccordionDetails>
+    </Accordion>
+  );
+};

--- a/src/pages/project/project_wizard/EmptyProjectForm.tsx
+++ b/src/pages/project/project_wizard/EmptyProjectForm.tsx
@@ -1,3 +1,46 @@
+import EastOutlinedIcon from '@mui/icons-material/EastOutlined';
+import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutlined';
+import { LoadingButton } from '@mui/lab';
+import { Box, TextField } from '@mui/material';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { dataTestId } from '../../../utils/dataTestIds';
+import { CreateProjectAccordion } from './CreateProjectAccordion';
+
 export const EmptyProjectForm = () => {
-  return <p>Empty project</p>;
+  const { t } = useTranslation();
+  const [title, setTitle] = useState('');
+  const isSaving = false;
+  const disabled = false;
+
+  return (
+    <CreateProjectAccordion
+      headline={t('project.form.start_with_empty_form_headline')}
+      description={t('project.form.start_with_empty_form')}
+      testId={dataTestId.newProjectPage.createEmptyProjectAccordion}
+      icon={<InsertDriveFileOutlinedIcon sx={{ height: '3rem', width: '3rem', mr: '0.75rem' }} />}>
+      <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+        <TextField
+          value={title}
+          data-testid={dataTestId.newProjectPage.titleInput}
+          variant="filled"
+          onChange={(event) => setTitle(event.target.value)}
+          fullWidth
+          placeholder={t('project.form.write_project_title')}
+          label={t('common.title')}
+        />
+        <LoadingButton
+          variant="contained"
+          sx={{ height: '2rem', width: 'fit-content', alignSelf: 'end', mt: '1rem' }}
+          loading={isSaving}
+          disabled={disabled}
+          data-testid={dataTestId.newProjectPage.startEmptyProjectButton}>
+          <>
+            {t('project.form.start_empty_project')}
+            <EastOutlinedIcon sx={{ width: '1rem', ml: '0.5rem' }} />
+          </>
+        </LoadingButton>
+      </Box>
+    </CreateProjectAccordion>
+  );
 };

--- a/src/pages/project/project_wizard/NFRProject.tsx
+++ b/src/pages/project/project_wizard/NFRProject.tsx
@@ -1,3 +1,17 @@
+import PaidOutlinedIcon from '@mui/icons-material/PaidOutlined';
+import { useTranslation } from 'react-i18next';
+import { dataTestId } from '../../../utils/dataTestIds';
+import { CreateProjectAccordion } from './CreateProjectAccordion';
+
 export const NFRProject = () => {
-  return <p>NFR Project</p>;
+  const { t } = useTranslation();
+  return (
+    <CreateProjectAccordion
+      headline={t('project.form.start_with_nfr_financing')}
+      description={t('project.form.start_with_nfr_financing_details')}
+      testId={dataTestId.newProjectPage.createNFRProjectAccordion}
+      icon={<PaidOutlinedIcon sx={{ height: '3rem', width: '3rem', mr: '0.75rem' }} />}>
+      test
+    </CreateProjectAccordion>
+  );
 };

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1144,7 +1144,6 @@
       "empty_registration": "Tom registrering",
       "here_you_can_create_project": "Her kan du enkelt opprette prosjekt:",
       "keywords": "Nøkkelord",
-      "project_manager_cannot_be_removed": "Prosjektleder kan ikke fjernes",
       "related_projects": "Relaterte prosjekt",
       "related_projects_description": "Legg til andre prosjekter som er relatert til dette prosjektet",
       "remove_affiliation": "Fjern tilknytning",
@@ -1153,9 +1152,14 @@
       "remove_project": "Fjern prosjekt",
       "search_for_person": "Søk etter person",
       "select_project_role": "Velg rolle i prosjektet",
+      "start_empty_project": "Start tomt prosjekt",
+      "start_with_empty_form_headline": "Start i tomt registreringsskjema",
       "start_with_empty_form": "Start uten noen ferdig utfylte opplysninger.",
       "start_with_nfr_project": "Hvis du har finansiering fra Norges Forskningsråd (NFR), så kan du starte med den og få noen felt ferdig utfylt.",
-      "title_and_description": "Tittel og beskrivelse"
+      "start_with_nfr_financing": "Start med finansiering fra Norges Forskningsråd (NFR)",
+      "start_with_nfr_financing_details": "Hvis du har finansiering fra Norges Forskningsråd (NFR), så kan du starte med dem og få noen felt ferdig utfylt",
+      "title_and_description": "Tittel og beskrivelse",
+      "write_project_title": "Skriv inn tittel på prosjekt"
     },
     "grant_id": "Tilskudds-ID",
     "heading": {

--- a/src/utils/dataTestIds.ts
+++ b/src/utils/dataTestIds.ts
@@ -219,6 +219,12 @@ export const dataTestId = {
     titleField: 'project-title-field',
     selectContributorButton: 'select-contributor-button',
   },
+  newProjectPage: {
+    titleInput: 'project-title-input',
+    startEmptyProjectButton: 'start-empty-project-button',
+    createEmptyProjectAccordion: 'create-empty-project-accordion',
+    createNFRProjectAccordion: 'create-nfr-project-accordion',
+  },
   projectLandingPage: {
     editProjectButton: 'edit-project-button',
     generalInfoBox: 'general-info',


### PR DESCRIPTION
# Description

Link to Jira issue: [https://sikt.atlassian.net/browse/NP-47283](https://sikt.atlassian.net/browse/NP-47283)

**⚠This is only visible when you have beta toggled to true in local storage ⚠**

You get to this view my going to Min Side --> "Prosjektregistreringer" in the left panel -> click "Nytt prosjekt"

This is a part of the effort to create a new create project-wizard [(NP-47281)](https://sikt.atlassian.net/browse/NP-47281), and there is a subtask for all the functionality to add.

In this PR we are adding the initial form for creating a new project:


**What should work after this PR:**
* You can start a new project, either through the NFR-view or the "Empty project"-view
* When you click the next button you should get into the normal edit-form with the values you pre-filled on the page before
* When you click save, the new project is created
* It is not possible to click save until all mandatory values are filled
* This new view should only be visible when beta is toggled to true in localStorage, so verify that it looks as before when this is not the case.
* You can cancel edit and will then return to where you came from

**Things that are not working and will be fixed in later PRs:**
* The stepper on top is not ready for mobile-view yet

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [ ] The changes are working as expected
- [ ] The changes are tested OK for different screen sizes
- [ ] The changes are tested OK for a11y
- [ ] Interactive elements have data-testids
- [ ] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
