### PR TITLE
Raise channel search default size to 50

### DIFF
--- a/src/api/publicationChannelApi.ts
+++ b/src/api/publicationChannelApi.ts
@@ -71,7 +71,7 @@ export const fetchSeries = async (identifier: string) => {
   return fetchSeriesResponse.data;
 };
 
-export const defaultChannelSearchSize = 5;
+export const defaultChannelSearchSize = 50;
 
 export const searchForSeries = async (query: string, year: string, size = defaultChannelSearchSize) => {
   const searchForSeriesResponse = await apiRequest2<SearchResponse2<Series>>({


### PR DESCRIPTION
# Description

Vi har tidliger lagt inn mulighet for å hente flere treff for kanalsøket. Etter testing er tilbakemeldingnen at de ikke gidder trykke "Vis flere" så mange ganger som nå, hvor de bare får 5 nye treff for hver gang. Etter samtale med PO setter vi opp denne til 50. Dette er for å bøte på problemet inntil det blir løst i eksternt API, men ingen løsning i sikte der per i dag.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
