### PR TITLE
NP-47394 Allow thesis curator to edit embargoed files that are not published yet

### DIFF
--- a/src/pages/public_registration/public_files/FileRow.tsx
+++ b/src/pages/public_registration/public_files/FileRow.tsx
@@ -128,7 +128,9 @@ export const FileRow = ({
 
       <Box sx={{ gridArea: 'download' }}>
         {file.embargoDate && fileIsEmbargoed ? (
-          <Typography data-testid={dataTestId.registrationLandingPage.fileEmbargoDate}>
+          <Typography
+            data-testid={dataTestId.registrationLandingPage.fileEmbargoDate}
+            sx={{ display: 'flex', alignItems: 'center' }}>
             <LockIcon />
             {t('common.will_be_available')} {toDateString(file.embargoDate)}
           </Typography>

--- a/src/pages/registration/FileList.tsx
+++ b/src/pages/registration/FileList.tsx
@@ -59,7 +59,7 @@ export const FileList = ({ title, files, uppy, remove, baseFieldName, archived }
   const showFileVersion = isTypeWithFileVersionField(publicationInstanceType);
 
   function canEditFile(file: AssociatedFile) {
-    if (isProtectedDegree && isEmbargoed(file.embargoDate)) {
+    if (isProtectedDegree && isEmbargoed(file.embargoDate) && file.type === FileType.PublishedFile) {
       return !!user?.isEmbargoThesisCurator;
     }
 


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47394

Tillat `CuratorThesis` å endre på filer for studentoppgaver med embargo i fremtiden, så lenge fila ikke enda er publisert.

Inkluderer også en liten fiks for visning av embargo.
Før:
![bilde](https://github.com/user-attachments/assets/f0cb513d-b079-413f-9720-55c0c40a5e3f)

Etter:
![bilde](https://github.com/user-attachments/assets/1eb7fe1e-ad8f-4e38-9535-26617046eff7)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
