### PR TITLE
Np 47433 adjust contributors display

### DIFF
--- a/src/pages/public_registration/PublicRegistrationContributors.tsx
+++ b/src/pages/public_registration/PublicRegistrationContributors.tsx
@@ -54,11 +54,7 @@ export const PublicRegistrationContributors = ({
             hiddenCount={showAll ? undefined : hiddenContributorsCount.current}
           />
           {showAll && secondaryContributorsToShow.length > 0 && (
-            <ContributorsRow
-              contributors={secondaryContributorsToShow}
-              distinctUnits={distinctUnits}
-              label={t('registration.heading.contributors')}
-            />
+            <ContributorsRow contributors={secondaryContributorsToShow} distinctUnits={distinctUnits} />
           )}
         </Box>
         {hiddenContributorsCount.current > 0 && (
@@ -86,16 +82,14 @@ export const PublicRegistrationContributors = ({
 interface ContributorsRowProps {
   contributors: Contributor[];
   distinctUnits: string[];
-  label?: string;
   hiddenCount?: number;
 }
 
-const ContributorsRow = ({ contributors, distinctUnits, label, hiddenCount }: ContributorsRowProps) => {
+const ContributorsRow = ({ contributors, distinctUnits, hiddenCount }: ContributorsRowProps) => {
   const { t } = useTranslation();
 
   return (
     <div>
-      {label && <Typography sx={{ display: 'inline', mr: '0.5rem' }}>{label}:</Typography>}
       <Box
         component="ul"
         sx={{

--- a/src/pages/public_registration/PublicRegistrationContributors.tsx
+++ b/src/pages/public_registration/PublicRegistrationContributors.tsx
@@ -89,60 +89,58 @@ const ContributorsRow = ({ contributors, distinctUnits, hiddenCount }: Contribut
   const { t } = useTranslation();
 
   return (
-    <div>
-      <Box
-        component="ul"
-        sx={{
-          listStyleType: 'none',
-          margin: 0,
-          padding: 0,
-          display: 'inline-flex',
-          flexWrap: 'wrap',
-          alignItems: 'flex-end',
-          '> :not(:first-of-type)': {
-            ml: '1rem', // Use margin instead of gap to indent wrapped elements
-          },
-        }}>
-        {contributors.map((contributor, index) => {
-          const {
-            identity: { id, name },
-          } = contributor;
-          const affiliationIndexes = contributor.affiliations
-            ?.map((affiliation) => affiliation.type === 'Organization' && distinctUnits.indexOf(affiliation.id) + 1)
-            .filter((affiliationIndex) => affiliationIndex)
-            .sort();
+    <Box
+      component="ul"
+      sx={{
+        listStyleType: 'none',
+        margin: 0,
+        padding: 0,
+        display: 'inline-flex',
+        flexWrap: 'wrap',
+        alignItems: 'flex-end',
+        '> :not(:first-of-type)': {
+          ml: '1rem', // Use margin instead of gap to indent wrapped elements
+        },
+      }}>
+      {contributors.map((contributor, index) => {
+        const {
+          identity: { id, name },
+        } = contributor;
+        const affiliationIndexes = contributor.affiliations
+          ?.map((affiliation) => affiliation.type === 'Organization' && distinctUnits.indexOf(affiliation.id) + 1)
+          .filter((affiliationIndex) => affiliationIndex)
+          .sort();
 
-          const showRole = contributor.role.type !== ContributorRole.Creator;
+        const showRole = contributor.role.type !== ContributorRole.Creator;
 
-          return (
-            <Box key={index} component="li" sx={{ display: 'flex', alignItems: 'end' }}>
-              <Typography>
-                {id ? (
-                  <Link
-                    component={RouterLink}
-                    to={getResearchProfilePath(id)}
-                    data-testid={dataTestId.registrationLandingPage.authorLink(id)}>
-                    {name}
-                  </Link>
-                ) : (
-                  name
-                )}
-                {showRole && ` (${t(`registration.contributors.types.${contributor.role.type}`)})`}
-                {affiliationIndexes && affiliationIndexes.length > 0 && (
-                  <sup>{affiliationIndexes && affiliationIndexes.length > 0 && affiliationIndexes.join(',')}</sup>
-                )}
-              </Typography>
-              <ContributorIndicators contributor={contributor} />
-              {index < contributors.length - 1 && <span>;</span>}
-            </Box>
-          );
-        })}
-        {hiddenCount && hiddenCount > 0 ? (
-          <Typography component="li">
-            {t('registration.public_page.other_contributors', { count: hiddenCount })}
-          </Typography>
-        ) : null}
-      </Box>
-    </div>
+        return (
+          <Box key={index} component="li" sx={{ display: 'flex', alignItems: 'end' }}>
+            <Typography>
+              {id ? (
+                <Link
+                  component={RouterLink}
+                  to={getResearchProfilePath(id)}
+                  data-testid={dataTestId.registrationLandingPage.authorLink(id)}>
+                  {name}
+                </Link>
+              ) : (
+                name
+              )}
+              {showRole && ` (${t(`registration.contributors.types.${contributor.role.type}`)})`}
+              {affiliationIndexes && affiliationIndexes.length > 0 && (
+                <sup>{affiliationIndexes && affiliationIndexes.length > 0 && affiliationIndexes.join(',')}</sup>
+              )}
+            </Typography>
+            <ContributorIndicators contributor={contributor} />
+            {index < contributors.length - 1 && <span>;</span>}
+          </Box>
+        );
+      })}
+      {hiddenCount && hiddenCount > 0 ? (
+        <Typography component="li">
+          {t('registration.public_page.other_contributors', { count: hiddenCount })}
+        </Typography>
+      ) : null}
+    </Box>
   );
 };

--- a/src/pages/public_registration/PublicRegistrationContributors.tsx
+++ b/src/pages/public_registration/PublicRegistrationContributors.tsx
@@ -6,15 +6,11 @@ import { useTranslation } from 'react-i18next';
 import { Link as RouterLink } from 'react-router-dom';
 import { ContributorIndicators } from '../../components/ContributorIndicators';
 import { AffiliationHierarchy } from '../../components/institution/AffiliationHierarchy';
-import { Contributor } from '../../types/contributor.types';
+import { Contributor, ContributorRole } from '../../types/contributor.types';
 import { PublicationInstanceType } from '../../types/registration.types';
 import { dataTestId } from '../../utils/dataTestIds';
 import { getDistinctContributorUnits } from '../../utils/institutions-helpers';
-import {
-  contributorConfig,
-  getContributorsWithPrimaryRole,
-  getContributorsWithSecondaryRole,
-} from '../../utils/registration-helpers';
+import { getContributorsWithPrimaryRole, getContributorsWithSecondaryRole } from '../../utils/registration-helpers';
 import { getResearchProfilePath } from '../../utils/urlPaths';
 
 interface PublicRegistrationContributorsProps {
@@ -34,7 +30,6 @@ export const PublicRegistrationContributors = ({
   const toggleShowAll = () => setShowAll(!showAll);
 
   const primaryContributorsToShow = showAll ? primaryContributors : primaryContributors.slice(0, 10);
-  const { primaryRoles, secondaryRoles } = contributorConfig[registrationType];
   const secondaryContributorsToShow = showAll ? secondaryContributors : [];
 
   const hiddenContributorsCount = useRef(
@@ -57,13 +52,11 @@ export const PublicRegistrationContributors = ({
             contributors={primaryContributorsToShow}
             distinctUnits={distinctUnits}
             hiddenCount={showAll ? undefined : hiddenContributorsCount.current}
-            showRole={primaryRoles.length > 1}
           />
           {showAll && secondaryContributorsToShow.length > 0 && (
             <ContributorsRow
               contributors={secondaryContributorsToShow}
               distinctUnits={distinctUnits}
-              showRole={secondaryRoles.length > 1}
               label={t('registration.heading.contributors')}
             />
           )}
@@ -94,17 +87,10 @@ interface ContributorsRowProps {
   contributors: Contributor[];
   distinctUnits: string[];
   label?: string;
-  showRole?: boolean;
   hiddenCount?: number;
 }
 
-const ContributorsRow = ({
-  contributors,
-  distinctUnits,
-  label,
-  showRole = false,
-  hiddenCount,
-}: ContributorsRowProps) => {
+const ContributorsRow = ({ contributors, distinctUnits, label, hiddenCount }: ContributorsRowProps) => {
   const { t } = useTranslation();
 
   return (
@@ -131,6 +117,8 @@ const ContributorsRow = ({
             ?.map((affiliation) => affiliation.type === 'Organization' && distinctUnits.indexOf(affiliation.id) + 1)
             .filter((affiliationIndex) => affiliationIndex)
             .sort();
+
+          const showRole = contributor.role.type !== ContributorRole.Creator;
 
           return (
             <Box key={index} component="li" sx={{ display: 'flex', alignItems: 'end' }}>


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47433

- Vis rollenavn for alle bidragsytere som er noe annet enn forfatter
- Fjern "Bidragsytere" heading fra visning over andre/secondary bidragsytere

Diffen får det til å virke som en større endring enn det i realiteten er, pg fjerning av unødvendig `<div>` som fjerner ett innrykk

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
