### PR TITLE
Now showing institution for contributors

### DIFF
--- a/src/components/institution/AffiliationHierarchy.tsx
+++ b/src/components/institution/AffiliationHierarchy.tsx
@@ -1,7 +1,6 @@
 import { Typography } from '@mui/material';
-import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { fetchOrganization } from '../../api/cristinApi';
+import { useFetchOrganization } from '../../api/hooks/useFetchOrganization';
 import { getOrganizationHierarchy } from '../../utils/institutions-helpers';
 import { getLanguageString } from '../../utils/translation-helpers';
 import { AffiliationSkeleton } from './AffiliationSkeleton';
@@ -9,22 +8,19 @@ import { AffiliationSkeleton } from './AffiliationSkeleton';
 interface AffiliationHierarchyProps {
   unitUri: string;
   commaSeparated?: boolean; // Comma separated or line breaks
-  boldTopLevel?: boolean; // Only relevant if commaSeparated=false
+  condensed?: boolean; // Display only top and bottom level
+  boldTopLevel?: boolean; // Only relevant if commaSeparated=false and condensed=false
 }
 
-export const AffiliationHierarchy = ({ unitUri, commaSeparated, boldTopLevel = true }: AffiliationHierarchyProps) => {
+export const AffiliationHierarchy = ({
+  unitUri,
+  commaSeparated,
+  condensed,
+  boldTopLevel = true,
+}: AffiliationHierarchyProps) => {
   const { t } = useTranslation();
-
-  const organizationQuery = useQuery({
-    enabled: !!unitUri,
-    queryKey: ['organization', unitUri],
-    queryFn: () => fetchOrganization(unitUri),
-    meta: { errorMessage: t('feedback.error.get_institution') },
-    staleTime: Infinity,
-    gcTime: 1_800_000, // 30 minutes
-  });
+  const organizationQuery = useFetchOrganization(unitUri);
   const organization = organizationQuery.data;
-
   const unitNames = getOrganizationHierarchy(organizationQuery.data).map((unit) => getLanguageString(unit.labels));
 
   return organizationQuery.isPending ? (
@@ -34,6 +30,8 @@ export const AffiliationHierarchy = ({ unitUri, commaSeparated, boldTopLevel = t
       <i>
         <Typography>{unitNames.join(', ')}</Typography>
       </i>
+    ) : condensed ? (
+      <Typography>{`${unitNames[unitNames.length - 1]} ${unitNames.length > 1 ? `${t('common.at').toLowerCase()} ${unitNames[0]}` : ''}`}</Typography>
     ) : (
       <div>
         {unitNames.map((unitName, index) =>

--- a/src/pages/projects/ProjectContributors.tsx
+++ b/src/pages/projects/ProjectContributors.tsx
@@ -1,8 +1,8 @@
 import { Box, Link as MuiLink, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { AffiliationHierarchy } from '../../components/institution/AffiliationHierarchy';
 import { ProjectContributor, ProjectContributorType } from '../../types/project.types';
-import { getLanguageString } from '../../utils/translation-helpers';
 import { getResearchProfilePath } from '../../utils/urlPaths';
 import {
   getProjectManagers,
@@ -72,12 +72,14 @@ const ContributorList = ({ contributors, projectRole }: ContributorListProps) =>
           </MuiLink>
         </Typography>
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-          {contributor.roles.map((contributorRole, j) => {
+          {contributor.roles.map((contributorRole) => {
             if (contributorRole.type === projectRole) {
               return (
-                <Typography variant="body2" key={j}>
-                  {getLanguageString(contributorRole.affiliation.labels)}
-                </Typography>
+                <AffiliationHierarchy
+                  key={contributorRole.affiliation.id}
+                  unitUri={contributorRole.affiliation.id}
+                  condensed
+                />
               );
             }
             return null;

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -289,6 +289,7 @@
     "update": "Oppdater",
     "url": "URL",
     "use": "Bruk",
+    "at": "ved",
     "version": "Versjon",
     "will_be_available": "Blir tilgjengelig",
     "x_days_one": "{{count}} dag",


### PR DESCRIPTION
# Description

Link to Jira issue: [https://sikt.atlassian.net/browse/NP-47077](https://sikt.atlassian.net/browse/NP-47077)

In Project view, if the contributor belongs to a sub-institution below an organization, we are currently only showing the sub-institution in the Project Landing page. In Cristin, they are also stating where the sub-institution belongs. So in this PR I added that. No change where the affiliation is the top level:

![image](https://github.com/user-attachments/assets/7de474c7-c178-464b-af26-dd6f8a602b23)

Also, this solves a potential other problem that could arise, where the roles-object on a ProjectContributor could have no labels. No we fetch the organization text from the organization object.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
