### PR TITLE
NP-47395 Give publishing curators access to bypass file restrictions of other users

### DIFF
--- a/src/pages/registration/FilesAndLicensePanel.tsx
+++ b/src/pages/registration/FilesAndLicensePanel.tsx
@@ -14,6 +14,7 @@ import {
   associatedArtifactIsLink,
   associatedArtifactIsNullArtifact,
   getAssociatedFiles,
+  isDegree,
   userCanEditRegistration,
   userIsValidImporter,
 } from '../../utils/registration-helpers';
@@ -88,6 +89,12 @@ export const FilesAndLicensePanel = ({ uppy }: FilesAndLicensePanelProps) => {
 
   const canEditFiles = userCanEditRegistration(values) || userIsValidImporter(user, values);
 
+  const categorySupportsFiles =
+    !!customer && !!publicationInstanceType && customer.allowFileUploadForTypes.includes(publicationInstanceType);
+
+  const canUploadFiles =
+    categorySupportsFiles || (isDegree(publicationInstanceType) ? user?.isThesisCurator : user?.isPublishingCurator);
+
   return (
     <Paper elevation={0} component={BackgroundDiv} sx={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
       <Typography component="h2" variant="h3">
@@ -124,9 +131,7 @@ export const FilesAndLicensePanel = ({ uppy }: FilesAndLicensePanelProps) => {
           <>
             {!isNullAssociatedArtifact && (
               <>
-                {customer &&
-                publicationInstanceType &&
-                !customer.allowFileUploadForTypes.includes(publicationInstanceType) ? (
+                {!canUploadFiles ? (
                   <Typography>{t('registration.resource_type.protected_file_type')}</Typography>
                 ) : (
                   <FileUploader

--- a/src/utils/registration-helpers.ts
+++ b/src/utils/registration-helpers.ts
@@ -756,6 +756,11 @@ export const getDisabledCategories = (
     });
   }
 
+  if (user?.isPublishingCurator) {
+    // Publishing curator should be allowed to add files to categories where the customer has disallowed files
+    return disabledCategories;
+  }
+
   const hasFiles = getAssociatedFiles(registration.associatedArtifacts).length > 0;
 
   if (hasFiles && customer && customer.allowFileUploadForTypes.length !== allPublicationInstanceTypes.length) {


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47395

Tidligere ble alle brukere nektet å legge til fil for kategorier som kunden har definert at ikke skal ha filer [her](https://dev.nva.sikt.no/institution/overview/categories). Etter akseptansetest viser det seg at publiseringskurator har ekstra privilegier og fortsatt skal kunne legge til filer. Samme gjelder for studentoppgave-kurator.

Syns løsningen for dette er litt rotete, da det blir egen logikk både for disabling av kategorier og for å skjule filopplaster. Føles som dette burde hengt sammen på en måte, men ser ikke noen naturlig måte å gjøre det på... Så nå må vi egentlig bare passe på at reglene stemmer begge plasser da :/ 

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
