### PR TITLE
Implement new contributors design

### DIFF
--- a/src/components/ContributorSearchField.tsx
+++ b/src/components/ContributorSearchField.tsx
@@ -27,6 +27,7 @@ interface ContributorSearchFieldProps {
   setSelectedPerson: (val: CristinPerson | undefined) => void;
   searchTerm: string;
   setSearchTerm: (val: string) => void;
+  addProjectManager?: boolean;
 }
 
 export const ContributorSearchField = ({
@@ -34,6 +35,7 @@ export const ContributorSearchField = ({
   setSelectedPerson,
   searchTerm,
   setSearchTerm,
+  addProjectManager = false,
 }: ContributorSearchFieldProps) => {
   const { t } = useTranslation();
   const debouncedSearchTerm = useDebounce(searchTerm);
@@ -93,6 +95,7 @@ export const ContributorSearchField = ({
                     cristinPerson={cristinPerson}
                     setSelectedPerson={setSelectedPerson}
                     selectedPerson={selectedPerson}
+                    addProjectManager={addProjectManager}
                   />
                 ))}
               </TableBody>

--- a/src/pages/project/project_wizard/ProjectContributorsForm.tsx
+++ b/src/pages/project/project_wizard/ProjectContributorsForm.tsx
@@ -2,6 +2,8 @@ import { Box } from '@mui/material';
 import { ErrorBoundary } from '../../../components/ErrorBoundary';
 import { ProjectTabs } from '../../../types/project.types';
 import { ProjectContributors } from '../../projects/form/ProjectContributors';
+import { ProjectManager } from './ProjectManager';
+import { FormBox } from './styles';
 
 interface ProjectContributorsFormProps {
   suggestedProjectManager?: string;
@@ -12,10 +14,15 @@ export const ProjectContributorsForm = ({ suggestedProjectManager, maxVisitedTab
   return (
     <ErrorBoundary>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-        <ProjectContributors
-          suggestedProjectManager={suggestedProjectManager}
-          isVisited={maxVisitedTab > ProjectTabs.Contributors}
-        />
+        <FormBox>
+          <ProjectManager
+            suggestedProjectManager={suggestedProjectManager}
+            isVisited={maxVisitedTab >= ProjectTabs.Contributors}
+          />
+        </FormBox>
+        <FormBox>
+          <ProjectContributors />
+        </FormBox>
       </Box>
     </ErrorBoundary>
   );

--- a/src/pages/project/project_wizard/ProjectManager.tsx
+++ b/src/pages/project/project_wizard/ProjectManager.tsx
@@ -1,0 +1,117 @@
+import AddIcon from '@mui/icons-material/AddCircleOutlineSharp';
+import {
+  Button,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import { FieldArray, FieldArrayRenderProps, useFormikContext } from 'formik';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { alternatingTableRowColor } from '../../../themes/mainTheme';
+import { CristinProject, ProjectFieldName } from '../../../types/project.types';
+import { dataTestId } from '../../../utils/dataTestIds';
+import { AddProjectContributorModal } from '../../projects/AddProjectContributorModal';
+import { ContributorRow } from '../../projects/form/ContributorRow';
+
+interface ProjectContributorsProps {
+  suggestedProjectManager?: string;
+  isVisited: boolean;
+}
+
+export const ProjectManager = ({ suggestedProjectManager, isVisited }: ProjectContributorsProps) => {
+  const { t } = useTranslation();
+  const [addContributorViewIsOpen, setAddContributorViewIsOpen] = useState(false);
+  const { values, errors, setFieldValue } = useFormikContext<CristinProject>();
+  const { contributors } = values;
+  const projectManagerIndex = contributors.findIndex((c) => c.roles.some((r) => r.type === 'ProjectManager'));
+  const projectManager = contributors[projectManagerIndex];
+  const projectManagerRoleIndex = projectManager?.roles.findIndex((r) => r.type === 'ProjectManager');
+
+  const contributorError = errors?.contributors;
+
+  const removeProjectManager = (name: string, remove: (index: number) => any) => {
+    // Project manager has other roles on project: only delete the project manager-role
+    if (projectManager.roles.length > 1) {
+      const newContributors = [...contributors];
+      const newContributorObject = { ...contributors[projectManagerIndex] };
+      const newRoles = [...contributors[projectManagerIndex].roles];
+
+      newRoles.splice(projectManagerRoleIndex, 1);
+      newContributorObject.roles = newRoles;
+      newContributors[projectManagerIndex] = newContributorObject;
+      setFieldValue(name, newContributors);
+    } else {
+      // Project manager is only role: remove contributor
+      remove(projectManagerIndex);
+    }
+  };
+
+  const toggleAddContributorView = () => setAddContributorViewIsOpen(!addContributorViewIsOpen);
+
+  return (
+    <>
+      <Typography variant="h2">{t('project.project_manager')}</Typography>
+      {suggestedProjectManager && (
+        <Typography sx={{ marginBottom: '1rem' }}>
+          {t('project.project_manager_from_nfr', { name: suggestedProjectManager })}
+        </Typography>
+      )}
+      <FieldArray name={ProjectFieldName.Contributors}>
+        {({ name, remove }: FieldArrayRenderProps) => (
+          <>
+            <Button
+              sx={{ borderRadius: '1rem', width: '17rem' }}
+              onClick={toggleAddContributorView}
+              variant="contained"
+              startIcon={<AddIcon />}
+              disabled={projectManager !== undefined}
+              data-testid={dataTestId.projectForm.addProjectManagerButton}>
+              {t('project.add_project_manager')}
+            </Button>
+            {projectManager && (
+              <TableContainer sx={{ mb: '0.5rem' }} component={Paper}>
+                <Table size="small" sx={alternatingTableRowColor}>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>{t('common.role')}</TableCell>
+                      <TableCell>{t('common.name')}</TableCell>
+                      <TableCell>{t('common.affiliation')}</TableCell>
+                      <TableCell>{t('common.clear')}</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    <ContributorRow
+                      key={projectManager.identity.id}
+                      contributorIndex={projectManagerIndex}
+                      baseFieldName={`${name}[${projectManagerIndex}]`}
+                      contributor={projectManager}
+                      removeContributor={() => removeProjectManager(name, remove)}
+                      isProjectManager
+                    />
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            )}
+            {contributorError && typeof contributorError === 'string' && isVisited && (
+              <Typography
+                sx={{ color: 'error.main', marginTop: '0.25rem', letterSpacing: '0.03333em', marginBottom: '1rem' }}>
+                {contributorError}
+              </Typography>
+            )}
+          </>
+        )}
+      </FieldArray>
+      <AddProjectContributorModal
+        open={addContributorViewIsOpen}
+        toggleModal={toggleAddContributorView}
+        addProjectManager
+      />
+    </>
+  );
+};

--- a/src/pages/projects/AddProjectContributorForm.tsx
+++ b/src/pages/projects/AddProjectContributorForm.tsx
@@ -1,50 +1,26 @@
-import { Box, Button, MenuItem, TextField } from '@mui/material';
+import { Box, Button } from '@mui/material';
 import { useFormikContext } from 'formik';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDispatch } from 'react-redux';
 import { ContributorSearchField } from '../../components/ContributorSearchField';
 import { StyledRightAlignedFooter } from '../../components/styled/Wrappers';
-import { setNotification } from '../../redux/notificationSlice';
-import {
-  CristinProject,
-  ProjectContributor,
-  ProjectContributorType,
-  ProjectFieldName,
-} from '../../types/project.types';
+import { CristinProject, ProjectContributor, ProjectFieldName } from '../../types/project.types';
 import { CristinPerson } from '../../types/user.types';
 import { dataTestId } from '../../utils/dataTestIds';
 import { getValueByKey } from '../../utils/user-helpers';
 
-const roles: ProjectContributorType[] = ['ProjectManager', 'ProjectParticipant'];
-
 interface AddProjectContributorFormProps {
-  hasProjectManager: boolean;
   toggleModal: () => void;
 }
 
-export const AddProjectContributorForm = ({ hasProjectManager, toggleModal }: AddProjectContributorFormProps) => {
+export const AddProjectContributorForm = ({ toggleModal }: AddProjectContributorFormProps) => {
   const { t } = useTranslation();
-  const dispatch = useDispatch();
   const { values, setFieldValue } = useFormikContext<CristinProject>();
   const [searchTerm, setSearchTerm] = useState('');
-  const [selectedContributorRole, setSelectedContributorRole] = useState<ProjectContributorType>(
-    hasProjectManager ? 'ProjectParticipant' : 'ProjectManager'
-  );
   const [selectedPerson, setSelectedPerson] = useState<CristinPerson>();
 
   const addContributor = () => {
-    if (!selectedPerson || !selectedContributorRole) {
-      return;
-    }
-
-    if (selectedContributorRole === 'ProjectManager' && hasProjectManager) {
-      dispatch(
-        setNotification({
-          message: t('project.error.there_can_only_be_one_project_manager_choose_different_role'),
-          variant: 'error',
-        })
-      );
+    if (!selectedPerson) {
       return;
     }
 
@@ -55,9 +31,9 @@ export const AddProjectContributorForm = ({ hasProjectManager, toggleModal }: Ad
         firstName: getValueByKey('FirstName', selectedPerson.names),
         lastName: getValueByKey('LastName', selectedPerson.names),
       },
-      roles: selectedPerson.affiliations.map((affiliation, index) => {
+      roles: selectedPerson.affiliations.map((affiliation) => {
         return {
-          type: selectedContributorRole === 'ProjectManager' && index === 0 ? 'ProjectManager' : 'ProjectParticipant', // Backend only supports one ProjectManager role per project
+          type: 'ProjectParticipant',
           affiliation: { type: 'Organization', id: affiliation.organization, labels: {} },
         };
       }),
@@ -71,27 +47,6 @@ export const AddProjectContributorForm = ({ hasProjectManager, toggleModal }: Ad
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-      <TextField
-        data-testid={dataTestId.projectWizard.selectContributorType}
-        sx={{ maxWidth: '15rem' }}
-        value={selectedContributorRole}
-        onChange={(event) => {
-          const role = (event.target.value as ProjectContributorType) ?? '';
-          setSelectedContributorRole(role);
-        }}
-        fullWidth
-        select
-        label={t('project.form.select_project_role')}
-        variant="outlined">
-        {roles.map((role) => (
-          <MenuItem
-            key={role}
-            value={role}
-            disabled={hasProjectManager ? role === 'ProjectManager' : role === 'ProjectParticipant'}>
-            {t(`project.role_types.${role}`)}
-          </MenuItem>
-        ))}
-      </TextField>
       <ContributorSearchField
         selectedPerson={selectedPerson}
         setSelectedPerson={setSelectedPerson}

--- a/src/pages/projects/AddProjectContributorModal.tsx
+++ b/src/pages/projects/AddProjectContributorModal.tsx
@@ -1,29 +1,34 @@
 import { useTranslation } from 'react-i18next';
 import { Modal } from '../../components/Modal';
 import { AddProjectContributorForm } from './AddProjectContributorForm';
+import { AddProjectManagerForm } from './AddProjectManagerForm';
 
 interface AddProjectContributorModalProps {
   open: boolean;
-  hasProjectManager: boolean;
   toggleModal: () => void;
+  addProjectManager?: boolean;
 }
 
 export const AddProjectContributorModal = ({
   open,
-  hasProjectManager,
   toggleModal,
+  addProjectManager = false,
 }: AddProjectContributorModalProps) => {
   const { t } = useTranslation();
 
   return (
     <Modal
-      headingText={t('project.add_project_contributor')}
+      headingText={addProjectManager ? t('project.add_project_manager') : t('project.add_project_contributor')}
       open={open}
       onClose={toggleModal}
       fullWidth
       maxWidth="md"
       dataTestId="contributor-modal">
-      <AddProjectContributorForm hasProjectManager={hasProjectManager} toggleModal={toggleModal} />
+      {addProjectManager ? (
+        <AddProjectManagerForm toggleModal={toggleModal} />
+      ) : (
+        <AddProjectContributorForm toggleModal={toggleModal} />
+      )}
     </Modal>
   );
 };

--- a/src/pages/projects/AddProjectManagerForm.tsx
+++ b/src/pages/projects/AddProjectManagerForm.tsx
@@ -1,0 +1,113 @@
+import { Box, Button } from '@mui/material';
+import { useFormikContext } from 'formik';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
+import { ContributorSearchField } from '../../components/ContributorSearchField';
+import { StyledRightAlignedFooter } from '../../components/styled/Wrappers';
+import { setNotification } from '../../redux/notificationSlice';
+import {
+  CristinProject,
+  ProjectContributor,
+  ProjectContributorRole,
+  ProjectFieldName,
+} from '../../types/project.types';
+import { CristinPerson } from '../../types/user.types';
+import { dataTestId } from '../../utils/dataTestIds';
+import { getValueByKey } from '../../utils/user-helpers';
+
+interface AddProjectManagerFormProps {
+  toggleModal: () => void;
+}
+
+export const AddProjectManagerForm = ({ toggleModal }: AddProjectManagerFormProps) => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const { values, setFieldValue } = useFormikContext<CristinProject>();
+  const { contributors } = values;
+  const projectManagerIndex = contributors.findIndex((c) => c.roles.some((r) => r.type === 'ProjectManager'));
+  const projectManager = contributors[projectManagerIndex];
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedPerson, setSelectedPerson] = useState<CristinPerson>();
+
+  const addProjectManager = () => {
+    if (!selectedPerson) {
+      return;
+    }
+
+    if (projectManager) {
+      dispatch(
+        setNotification({
+          message: t('project.error.there_can_only_be_one_project_manager'),
+          variant: 'error',
+        })
+      );
+      return;
+    }
+
+    const existingContributorIndex = contributors.findIndex(
+      (contributor) => contributor.identity.id === selectedPerson.id
+    );
+
+    let newContributor: ProjectContributor;
+
+    if (existingContributorIndex > -1) {
+      newContributor = { ...contributors[existingContributorIndex] };
+    } else {
+      newContributor = {
+        identity: {
+          type: 'Person',
+          id: selectedPerson.id,
+          firstName: getValueByKey('FirstName', selectedPerson.names),
+          lastName: getValueByKey('LastName', selectedPerson.names),
+        },
+        roles: [],
+      };
+    }
+
+    newContributor.roles = [
+      ...newContributor.roles,
+      {
+        type: 'ProjectManager',
+        affiliation: {
+          type: 'Organization',
+          id: selectedPerson.affiliations[0].organization, // We can only choose one affiliation for projectManager
+        },
+      } as ProjectContributorRole,
+    ];
+
+    const newContributors = [...values.contributors];
+
+    if (existingContributorIndex > -1) {
+      newContributors[existingContributorIndex] = newContributor;
+    } else {
+      newContributors.push(newContributor);
+    }
+
+    setFieldValue(ProjectFieldName.Contributors, newContributors);
+    toggleModal();
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+      <ContributorSearchField
+        selectedPerson={selectedPerson}
+        setSelectedPerson={setSelectedPerson}
+        searchTerm={searchTerm}
+        setSearchTerm={setSearchTerm}
+        addProjectManager
+      />
+      <StyledRightAlignedFooter>
+        <Button
+          sx={{ mt: '1rem' }}
+          data-testid={dataTestId.projectForm.selectContributorButton}
+          disabled={!selectedPerson}
+          onClick={addProjectManager}
+          size="large"
+          variant="contained">
+          {t('project.add_project_manager')}
+        </Button>
+      </StyledRightAlignedFooter>
+    </Box>
+  );
+};

--- a/src/pages/projects/form/ProjectContributors.tsx
+++ b/src/pages/projects/form/ProjectContributors.tsx
@@ -21,44 +21,34 @@ import { dataTestId } from '../../../utils/dataTestIds';
 import { AddProjectContributorModal } from '../AddProjectContributorModal';
 import { ContributorRow } from './ContributorRow';
 
-interface ProjectContributorsProps {
-  suggestedProjectManager?: string;
-  isVisited: boolean;
-  showHeader?: boolean;
-}
-
-export const ProjectContributors = ({ suggestedProjectManager, isVisited, showHeader }: ProjectContributorsProps) => {
+export const ProjectContributors = () => {
   const { t } = useTranslation();
   const [rowsPerPage, setRowsPerPage] = useState(ROWS_PER_PAGE_OPTIONS[0]);
   const [currentPage, setCurrentPage] = useState(1);
   const [openAddContributorView, setOpenAddContributorView] = useState(false);
-  const { values, errors } = useFormikContext<CristinProject>();
+  const { values } = useFormikContext<CristinProject>();
   const { contributors } = values;
-  const contributorsToShow = contributors.slice(rowsPerPage * (currentPage - 1), rowsPerPage * currentPage);
-  const contributorError = errors?.contributors;
-  const hasProjectManager = values.contributors.some((contributor) =>
-    contributor.roles.some((role) => role.type === 'ProjectManager')
+  const contributorsWithNonProjectManagerRole = contributors.filter((contributor) =>
+    contributor.roles.some((role) => role.type !== 'ProjectManager')
   );
+  const paginatedContributors = contributorsWithNonProjectManagerRole.slice(
+    rowsPerPage * (currentPage - 1),
+    rowsPerPage * currentPage
+  );
+
   const toggleOpenAddContributorView = () => setOpenAddContributorView(!openAddContributorView);
   const hasUnidentifiedContributor = contributors.some((contributor) => !contributor.identity.id);
 
+  console.log('contributors', contributors);
+
   return (
     <>
-      {showHeader && (
-        <Typography variant="h3" gutterBottom sx={{ marginTop: '2rem', marginBottom: '1rem' }}>
-          {t('project.project_participants')}
-        </Typography>
-      )}
-      {suggestedProjectManager && (
-        <Typography sx={{ marginBottom: '1rem' }}>
-          {t('project.project_manager_from_nfr', { name: suggestedProjectManager })}
-        </Typography>
-      )}
+      <Typography variant="h2">{t('project.project_participants')}</Typography>
       <FieldArray name={ProjectFieldName.Contributors}>
         {({ name, remove }: FieldArrayRenderProps) => (
           <>
             <Button
-              sx={{ marginBottom: '1rem', borderRadius: '1rem', width: '17rem' }}
+              sx={{ borderRadius: '1rem', width: '17rem' }}
               onClick={toggleOpenAddContributorView}
               variant="contained"
               startIcon={<AddIcon />}
@@ -66,7 +56,7 @@ export const ProjectContributors = ({ suggestedProjectManager, isVisited, showHe
               data-testid={dataTestId.registrationWizard.description.projectForm.addParticipantButton}>
               {t('project.add_project_contributor')}
             </Button>
-            {contributors.length > 0 && (
+            {contributorsWithNonProjectManagerRole.length > 0 && (
               <ListPagination
                 count={contributors.length}
                 rowsPerPage={rowsPerPage}
@@ -88,7 +78,7 @@ export const ProjectContributors = ({ suggestedProjectManager, isVisited, showHe
                       </TableRow>
                     </TableHead>
                     <TableBody>
-                      {contributorsToShow.map((contributor) => {
+                      {paginatedContributors.map((contributor) => {
                         const contributorIndex = contributors.findIndex(
                           (c) => c.identity.id === contributor.identity.id
                         );
@@ -107,20 +97,10 @@ export const ProjectContributors = ({ suggestedProjectManager, isVisited, showHe
                 </TableContainer>
               </ListPagination>
             )}
-            {contributorError && typeof contributorError === 'string' && isVisited && (
-              <Typography
-                sx={{ color: 'error.main', marginTop: '0.25rem', letterSpacing: '0.03333em', marginBottom: '1rem' }}>
-                {contributorError}
-              </Typography>
-            )}
           </>
         )}
       </FieldArray>
-      <AddProjectContributorModal
-        open={openAddContributorView}
-        toggleModal={toggleOpenAddContributorView}
-        hasProjectManager={hasProjectManager}
-      />
+      <AddProjectContributorModal open={openAddContributorView} toggleModal={toggleOpenAddContributorView} />
     </>
   );
 };

--- a/src/pages/registration/contributors_tab/components/AddContributorTableRow.tsx
+++ b/src/pages/registration/contributors_tab/components/AddContributorTableRow.tsx
@@ -7,17 +7,21 @@ import { CristinPerson } from '../../../../types/user.types';
 import { dataTestId } from '../../../../utils/dataTestIds';
 import { filterActiveAffiliations, getFullCristinName } from '../../../../utils/user-helpers';
 import { LastRegistrationTableCellContent } from './LastRegistrationTableCellContent';
+import { SelectAffiliationCheckbox } from './SelectAffiliationCheckbox';
+import { SelectAffiliationRadioButton } from './SelectAffiliationRadioButton';
 
 interface CristinPersonTableRowProps {
   cristinPerson: CristinPerson;
   selectedPerson?: CristinPerson;
   setSelectedPerson: (selectedContributor: CristinPerson | undefined) => void;
+  addProjectManager?: boolean;
 }
 
 export const CristinPersonTableRow = ({
   cristinPerson,
   setSelectedPerson,
   selectedPerson,
+  addProjectManager = false,
 }: CristinPersonTableRowProps) => {
   const { t } = useTranslation();
   const activeAffiliations = filterActiveAffiliations(cristinPerson.affiliations);
@@ -37,7 +41,7 @@ export const CristinPersonTableRow = ({
               } else {
                 setSelectedPerson({
                   ...cristinPerson,
-                  affiliations: activeAffiliations,
+                  affiliations: addProjectManager ? [activeAffiliations[0]] : activeAffiliations,
                 });
               }
             }}
@@ -66,32 +70,23 @@ export const CristinPersonTableRow = ({
                     alignItems: 'center',
                     gap: '0.25rem',
                   }}>
-                  <IconButton
-                    data-testid={dataTestId.registrationWizard.contributors.selectAffiliationForContributor}
-                    onClick={() => {
-                      if (!selectedPerson) {
-                        return;
-                      }
-                      const newAffiliations = affiliationIsSelected
-                        ? selectedPerson.affiliations.filter((a) => a.organization !== affiliation.organization)
-                        : [...selectedPerson.affiliations, affiliation];
-
-                      const personWithAffiliation: CristinPerson = {
-                        ...selectedPerson,
-                        affiliations: newAffiliations,
-                      };
-                      setSelectedPerson(personWithAffiliation);
-                    }}
-                    color="primary"
-                    size="small"
-                    disabled={!personIsSelected}
-                    title={t('registration.contributors.select_affiliation')}>
-                    {affiliationIsSelected ? (
-                      <CheckCircle fontSize="small" color="info" />
-                    ) : (
-                      <CircleOutlined fontSize="small" />
-                    )}
-                  </IconButton>
+                  {addProjectManager ? (
+                    <SelectAffiliationRadioButton
+                      personIsSelected={personIsSelected}
+                      affiliation={affiliation}
+                      selectedPerson={selectedPerson}
+                      setSelectedPerson={setSelectedPerson}
+                      affiliationIsSelected={affiliationIsSelected}
+                    />
+                  ) : (
+                    <SelectAffiliationCheckbox
+                      personIsSelected={personIsSelected}
+                      affiliation={affiliation}
+                      selectedPerson={selectedPerson}
+                      setSelectedPerson={setSelectedPerson}
+                      affiliationIsSelected={affiliationIsSelected}
+                    />
+                  )}
                   <AffiliationHierarchy unitUri={affiliation.organization} commaSeparated />
                 </Box>
               );

--- a/src/translations/enTranslations.json
+++ b/src/translations/enTranslations.json
@@ -1131,7 +1131,7 @@
     "create_project": "New project",
     "edit_project": "Edit project",
     "error": {
-      "there_can_only_be_one_project_manager_choose_different_role": "A project can only have one project leader. Select another role."
+      "there_can_only_be_one_project_manager": "A project can only have one project leader."
     },
     "form": {
       "add_financing": "Add funding",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1121,13 +1121,15 @@
   "project": {
     "add_affiliation": "Legg til tilknytning",
     "add_project_contributor": "Legg til prosjektdeltaker",
+    "add_project_manager": "Legg til prosjektleder",
     "affiliation_modal": {
       "add_new_affiliation_helper_text": "<0>Bare institusjoner som prosjektet er gjennomført i samarbeid med, skal legges til som tilknytning til prosjektdeltaker.</0> <0>Legg til tilknytning til prosjektdeltaker ved å først søke opp institusjonen og eventuelt enhet.</0> <0>Tilhører prosjektdeltakeren flere forskjellige enheter under samme institusjon, må du legge til dette som ny tilknytning.</0>",
-      "cannot_delete_affiliation_for_project_manager": "Kan ikke fjerne tilknytning for prosjektleder",
+      "cannot_delete_affiliation_for_project_manager": "Prosjektleder må ha en tilknytning",
       "cannot_delete_only_affiliation": "Kan ikke fjerne eneste tilknytning",
       "delete_affiliation": "Fjern tilknytning",
       "edit_affiliation": "Endre tilknytning"
     },
+    "as_project_manager": "som prosjektleder",
     "close_view": "Lukk visning",
     "close_view_description": "Ulagret data du har skrevet inn vil gå tapt om du lukker denne visningen. Ønsker du likevel å lukke visningen?",
     "coordinating_institution": "Koordinerende institusjon",
@@ -1135,7 +1137,8 @@
     "create_project": "Nytt prosjekt",
     "edit_project": "Endre prosjekt",
     "error": {
-      "there_can_only_be_one_project_manager_choose_different_role": "Et prosjekt kan kun ha en prosjektleder. Velg en annen rolle."
+      "there_can_only_be_one_project_manager": "Et prosjekt kan kun ha en prosjektleder.",
+      "you_cannot_add_same_person_muliple_times": "Du kan ikke legge til samme person flere ganger"
     },
     "form": {
       "add_financing": "Legg til finansiering",
@@ -1148,8 +1151,9 @@
       "project_manager_cannot_be_removed": "Prosjektleder kan ikke fjernes",
       "related_projects": "Relaterte prosjekt",
       "related_projects_description": "Legg til andre prosjekter som er relatert til dette prosjektet",
+      "remove_project_manager": "Fjern prosjektleder",
       "remove_participant": "Fjern prosjektdeltaker",
-      "remove_participant_text": "Er du sikker på at du ønsker å fjerne {{name}}?",
+      "remove_participant_text": "Er du sikker på at du ønsker å fjerne {{name}}{{as}}?",
       "remove_project": "Fjern prosjekt",
       "select_project_role": "Velg rolle i prosjektet",
       "start_empty_project": "Start tomt prosjekt",
@@ -1167,6 +1171,7 @@
       "connections": "Koblinger",
       "description": "$t(common.description)",
       "details": "Detaljer",
+      "project_manager": "Prosjektleder",
       "project_participants": "Prosjektdeltakere"
     },
     "keywords": "Nøkkelord",
@@ -1189,6 +1194,7 @@
     "project_id": "Prosjekt-ID",
     "project_info": "Prosjektinfo",
     "project_manager": "Prosjektleder",
+    "project_contributor": "Prosjektdeltaker",
     "project_manager_from_nfr": "Prosjektleder fra NFR: {{name}}",
     "project_participant": "Prosjektdeltaker",
     "project_participants": "Prosjektdeltakere",

--- a/src/translations/nnTranslations.json
+++ b/src/translations/nnTranslations.json
@@ -1131,7 +1131,7 @@
     "create_project": "Nytt prosjekt",
     "edit_project": "Endre prosjekt",
     "error": {
-      "there_can_only_be_one_project_manager_choose_different_role": "Eit prosjekt kan kun ha ein prosjektleiar. Vel ei anna rolle."
+      "there_can_only_be_one_project_manager": "Eit prosjekt kan kun ha ein prosjektleiar."
     },
     "form": {
       "add_financing": "Legg til finansiering",

--- a/src/types/project.types.ts
+++ b/src/types/project.types.ts
@@ -39,7 +39,7 @@ export type ProjectOrganization = Omit<Organization, 'partOf' | 'hasPart' | 'acr
 
 export type ProjectStatus = 'ACTIVE' | 'CONCLUDED' | 'NOTSTARTED';
 
-interface ProjectContributorIdentity {
+export interface ProjectContributorIdentity {
   type: 'Person';
   id: string;
   firstName: string;
@@ -175,7 +175,9 @@ export enum ProjectFieldName {
   Keywords = 'keywords',
   RelatedProjects = 'relatedProjects',
   RoleType = 'roles[0].type',
+  Roles = 'roles',
   RoleAffiliation = 'roles[0].affiliation',
+  Type = 'type',
 }
 
 export enum ProjectContributorFieldName {

--- a/src/utils/dataTestIds.ts
+++ b/src/utils/dataTestIds.ts
@@ -226,6 +226,8 @@ export const dataTestId = {
     scientificSummaryNorwegianField: 'scientific-summary-norwegian-field',
     titleField: 'project-title-field',
     selectContributorButton: 'select-contributor-button',
+    addProjectManagerButton: 'add-project-manager-button',
+    addAffiliationButton: 'button-add-affiliation',
   },
   newProjectPage: {
     titleInput: 'project-title-input',
@@ -397,6 +399,7 @@ export const dataTestId = {
       nfrProjectLink: (id: string) => `nfr-project-link-${id}`,
       nfrProjectSearchField: 'nfr-project-search-field',
       projectForm: {
+        addProjectManagerButton: 'add-project-manager-button',
         addParticipantButton: 'add-participant-button',
         contributorAffiliationField: 'contributor-affiliation-field',
         contributorsSearchField: 'project-contributors-search-field',


### PR DESCRIPTION
# Description

Link to Jira issue: [https://sikt.atlassian.net/browse/NP-47318](https://sikt.atlassian.net/browse/NP-47318)

In this PR we are modifying the existing contributors view to separate the ProjectManager-role from the rest:

This requires some extra frontend logic, because the backend object collects all roles in the same object under the same identity.

**What should work when testing this PR:**
* There is a separate box for Project Manager
* It is possible to delte existing project Manager (this will display a form error that there must be one project manager)
* If there is not already a project manager chosen, it should be possible to search for and select a project manager
* When inside the select project manager-modal, after having searched for a user, it should only be possible to pre-select an affiliation to add with the user. It should only be possible to select one: the radio button selection will move if selecting another one. It should also be possible to select a user without selecting affiliation.
* The Project contributor view should look and work as earlier, except that it should no longer display the project manager.
* Since we are not out of beta yet, it should work in both the beta view and the old view

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._