### PR TITLE
Revert "NP-47395 Give publishing curators access to bypass file restrictions of other users"

### DIFF
--- a/src/pages/registration/FilesAndLicensePanel.tsx
+++ b/src/pages/registration/FilesAndLicensePanel.tsx
@@ -14,7 +14,6 @@ import {
   associatedArtifactIsLink,
   associatedArtifactIsNullArtifact,
   getAssociatedFiles,
-  isDegree,
   userCanEditRegistration,
   userIsValidImporter,
 } from '../../utils/registration-helpers';
@@ -89,12 +88,6 @@ export const FilesAndLicensePanel = ({ uppy }: FilesAndLicensePanelProps) => {
 
   const canEditFiles = userCanEditRegistration(values) || userIsValidImporter(user, values);
 
-  const categorySupportsFiles =
-    !!customer && !!publicationInstanceType && customer.allowFileUploadForTypes.includes(publicationInstanceType);
-
-  const canUploadFiles =
-    categorySupportsFiles || (isDegree(publicationInstanceType) ? user?.isThesisCurator : user?.isPublishingCurator);
-
   return (
     <Paper elevation={0} component={BackgroundDiv} sx={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
       <Typography component="h2" variant="h3">
@@ -131,7 +124,9 @@ export const FilesAndLicensePanel = ({ uppy }: FilesAndLicensePanelProps) => {
           <>
             {!isNullAssociatedArtifact && (
               <>
-                {!canUploadFiles ? (
+                {customer &&
+                publicationInstanceType &&
+                !customer.allowFileUploadForTypes.includes(publicationInstanceType) ? (
                   <Typography>{t('registration.resource_type.protected_file_type')}</Typography>
                 ) : (
                   <FileUploader

--- a/src/utils/registration-helpers.ts
+++ b/src/utils/registration-helpers.ts
@@ -756,11 +756,6 @@ export const getDisabledCategories = (
     });
   }
 
-  if (user?.isPublishingCurator) {
-    // Publishing curator should be allowed to add files to categories where the customer has disallowed files
-    return disabledCategories;
-  }
-
   const hasFiles = getAssociatedFiles(registration.associatedArtifacts).length > 0;
 
   if (hasFiles && customer && customer.allowFileUploadForTypes.length !== allPublicationInstanceTypes.length) {


### PR DESCRIPTION
Reverts BIBSYSDEV/NVA-Frontend#6154

Denne "fiksen" viste seg å være en feil, som ble oppdaget når den skulle retestes. Derfor tar vi den bort igjen, som egentlig bare er bra for kodens del også, for syns som nevnt i den PRen at dette var litt rotete