### PR TITLE
Fixed bug when we added contributor without adding affiliation

### DIFF
--- a/src/pages/projects/AddProjectContributorForm.tsx
+++ b/src/pages/projects/AddProjectContributorForm.tsx
@@ -43,7 +43,7 @@ export const AddProjectContributorForm = ({ hasProjectManager, toggleModal }: Ad
     if (selectedContributorRole === 'ProjectManager' && hasProjectManager) {
       dispatch(
         setNotification({
-          message: t('project.error.there_can_only_be_one_project_manager_choose_different_role'),
+          message: t('project.error.there_can_only_be_one_project_manager'),
           variant: 'error',
         })
       );

--- a/src/pages/projects/ProjectAddAffiliationModal.tsx
+++ b/src/pages/projects/ProjectAddAffiliationModal.tsx
@@ -33,8 +33,6 @@ export const ProjectAddAffiliationModal = ({
       return;
     }
 
-    console.log('addAffiliation--------------------');
-
     // Avoid adding same unit twice
     if (
       contributorRoles.some(
@@ -48,8 +46,6 @@ export const ProjectAddAffiliationModal = ({
     const emptyRoleIndex = contributorRoles.findIndex(
       (role) => !role.affiliation || (role.affiliation?.type === 'Organization' && role.affiliation?.id === '')
     );
-
-    console.log('emptyRoleIndex', emptyRoleIndex);
 
     const newAffiliation: ProjectOrganization = {
       type: 'Organization',

--- a/src/pages/projects/ProjectAddAffiliationModal.tsx
+++ b/src/pages/projects/ProjectAddAffiliationModal.tsx
@@ -33,10 +33,12 @@ export const ProjectAddAffiliationModal = ({
       return;
     }
 
+    console.log('addAffiliation--------------------');
+
     // Avoid adding same unit twice
     if (
       contributorRoles.some(
-        (role) => role.affiliation.type === 'Organization' && role.affiliation.id === newAffiliationId
+        (role) => role.affiliation?.type === 'Organization' && role.affiliation?.id === newAffiliationId
       )
     ) {
       dispatch(setNotification({ message: t('common.contributors.add_duplicate_affiliation'), variant: 'info' }));
@@ -44,8 +46,10 @@ export const ProjectAddAffiliationModal = ({
     }
 
     const emptyRoleIndex = contributorRoles.findIndex(
-      (role) => role.affiliation.type === 'Organization' && role.affiliation.id === ''
+      (role) => !role.affiliation || (role.affiliation?.type === 'Organization' && role.affiliation?.id === '')
     );
+
+    console.log('emptyRoleIndex', emptyRoleIndex);
 
     const newAffiliation: ProjectOrganization = {
       type: 'Organization',

--- a/src/pages/projects/ProjectContributors.tsx
+++ b/src/pages/projects/ProjectContributors.tsx
@@ -73,11 +73,11 @@ const ContributorList = ({ contributors, projectRole }: ContributorListProps) =>
         </Typography>
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
           {contributor.roles.map((contributorRole) => {
-            if (contributorRole.type === projectRole) {
+            if (contributorRole.type === projectRole && contributorRole.affiliation) {
               return (
                 <AffiliationHierarchy
-                  key={contributorRole.affiliation.id}
-                  unitUri={contributorRole.affiliation.id}
+                  key={contributorRole.affiliation!.id}
+                  unitUri={contributorRole.affiliation!.id}
                   condensed
                 />
               );

--- a/src/pages/projects/ProjectEditAffiliationModal.tsx
+++ b/src/pages/projects/ProjectEditAffiliationModal.tsx
@@ -41,7 +41,7 @@ export const ProjectEditAffiliationModal = ({
       return;
     }
     const roleToChangeIndex = contributorRoles.findIndex(
-      (role) => role.affiliation.type === 'Organization' && role.affiliation.id === preselectedOrganization.id
+      (role) => role.affiliation?.type === 'Organization' && role.affiliation?.id === preselectedOrganization.id
     );
 
     if (roleToChangeIndex < 0) {
@@ -51,7 +51,7 @@ export const ProjectEditAffiliationModal = ({
     // If user tries to change affiliation to an already existing affiliation
     if (
       contributorRoles.some(
-        (role) => role.affiliation.type === 'Organization' && role.affiliation.id === newAffiliationId
+        (role) => role.affiliation?.type === 'Organization' && role.affiliation?.id === newAffiliationId
       )
     ) {
       dispatch(setNotification({ message: t('common.contributors.add_duplicate_affiliation'), variant: 'info' }));

--- a/src/pages/projects/form/ContributorRow.tsx
+++ b/src/pages/projects/form/ContributorRow.tsx
@@ -37,14 +37,16 @@ export const ContributorRow = ({
   const [showConfirmRemoveContributor, setShowConfirmRemoveContributor] = useState(false);
 
   const contributorErrors = errors?.contributors?.[contributorIndex] as ProjectContributor;
-  const affiliationError = contributorErrors?.roles?.[0]?.affiliation.id;
+  const affiliationError = contributorErrors?.roles?.[0]?.affiliation?.id;
   const affiliationFieldTouched = touched?.contributors?.[contributorIndex]?.roles;
   const baseFieldRoles = `${baseFieldName}.${ProjectContributorFieldName.Roles}`;
+
+  console.log('contributor***', contributor);
 
   const toggleAffiliationModal = () => setOpenAffiliationModal(!openAffiliationModal);
 
   const removeAffiliation = (affiliationId: string) => {
-    const roleToRemoveIndex = contributor.roles.findIndex((role) => role.affiliation.id === affiliationId);
+    const roleToRemoveIndex = contributor.roles.findIndex((role) => role.affiliation?.id === affiliationId);
     if (contributor.roles.length === 1 || contributor.roles[roleToRemoveIndex].type === 'ProjectManager') {
       return;
     }
@@ -83,18 +85,18 @@ export const ContributorRow = ({
         <ContributorName
           id={contributor.identity.id}
           name={getFullName(contributor.identity.firstName, contributor.identity.lastName)}
-          hasVerifiedAffiliation={contributor.roles?.some((role) => role.affiliation.type === 'Organization')}
+          hasVerifiedAffiliation={contributor.roles?.some((role) => role.affiliation?.type === 'Organization')}
           sx={{ width: '15rem', marginTop: '0.5rem' }}
         />
       </TableCell>
       <TableCell>
         <>
           {contributor.roles
-            .filter((r) => r.affiliation.id)
+            .filter((role) => role.affiliation?.id)
             .map((role) => (
               <ProjectOrganizationBox
-                key={role.affiliation.id}
-                unitUri={role.affiliation.id}
+                key={role.affiliation!.id}
+                unitUri={role.affiliation!.id}
                 authorName={getFullName(contributor.identity.firstName, contributor.identity.lastName)}
                 contributorRoles={contributor.roles}
                 baseFieldName={baseFieldRoles}
@@ -102,7 +104,7 @@ export const ContributorRow = ({
                 removeAffiliation={
                   contributor.roles.length === 1 || role.type === 'ProjectManager'
                     ? undefined
-                    : () => removeAffiliation(role.affiliation.id)
+                    : () => removeAffiliation(role.affiliation!.id)
                 }
                 disabledTooltip={
                   role.type === 'ProjectManager'

--- a/src/pages/projects/form/ContributorRow.tsx
+++ b/src/pages/projects/form/ContributorRow.tsx
@@ -41,8 +41,6 @@ export const ContributorRow = ({
   const affiliationFieldTouched = touched?.contributors?.[contributorIndex]?.roles;
   const baseFieldRoles = `${baseFieldName}.${ProjectContributorFieldName.Roles}`;
 
-  console.log('contributor***', contributor);
-
   const toggleAffiliationModal = () => setOpenAffiliationModal(!openAffiliationModal);
 
   const removeAffiliation = (affiliationId: string) => {

--- a/src/pages/projects/form/ProjectFormDialog.tsx
+++ b/src/pages/projects/form/ProjectFormDialog.tsx
@@ -130,13 +130,8 @@ export const ProjectFormDialog = ({
                 coordinatingInstitution: {
                   id: true,
                 },
-                contributors: values.contributors.map((contributor) => ({
+                contributors: values.contributors.map(() => ({
                   identity: { id: true },
-                  roles: contributor.roles.map(() => ({
-                    affiliation: {
-                      id: true,
-                    },
-                  })),
                 })),
                 funding: values.funding.map(() => ({
                   source: true,

--- a/src/pages/projects/form/ProjectFormPanel1.tsx
+++ b/src/pages/projects/form/ProjectFormPanel1.tsx
@@ -23,6 +23,8 @@ export const ProjectFormPanel1 = ({ currentProject, suggestedProjectManager }: P
   const { t } = useTranslation();
   const { values, setFieldValue, setFieldTouched, touched, errors } = useFormikContext<SaveCristinProject>();
 
+  console.log('values.contributors', values.contributors);
+
   const thisIsRekProject = isRekProject(currentProject);
 
   return (

--- a/src/pages/projects/form/ProjectFormPanel1.tsx
+++ b/src/pages/projects/form/ProjectFormPanel1.tsx
@@ -23,8 +23,6 @@ export const ProjectFormPanel1 = ({ currentProject, suggestedProjectManager }: P
   const { t } = useTranslation();
   const { values, setFieldValue, setFieldTouched, touched, errors } = useFormikContext<SaveCristinProject>();
 
-  console.log('values.contributors', values.contributors);
-
   const thisIsRekProject = isRekProject(currentProject);
 
   return (

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1135,7 +1135,8 @@
     "create_project": "Nytt prosjekt",
     "edit_project": "Endre prosjekt",
     "error": {
-      "there_can_only_be_one_project_manager_choose_different_role": "Et prosjekt kan kun ha en prosjektleder. Velg en annen rolle."
+      "there_can_only_be_one_project_manager_choose_different_role": "Et prosjekt kan kun ha en prosjektleder. Velg en annen rolle.",
+      "contributor_already_added_with_same_role_and_affiliation": "Prosjektdeltaker er allerede lagt til med samme rolle og tilknytning"
     },
     "form": {
       "add_financing": "Legg til finansiering",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1135,8 +1135,8 @@
     "create_project": "Nytt prosjekt",
     "edit_project": "Endre prosjekt",
     "error": {
-      "there_can_only_be_one_project_manager_choose_different_role": "Et prosjekt kan kun ha en prosjektleder. Velg en annen rolle.",
-      "contributor_already_added_with_same_role_and_affiliation": "Prosjektdeltaker er allerede lagt til med samme rolle og tilknytning"
+      "there_can_only_be_one_project_manager": "Et prosjekt kan kun ha en prosjektleder.",
+      "contributor_already_added_with_same_role_and_affiliation": "Prosjektdeltaker er allerede lagt til med samme rolle og tilknytning."
     },
     "form": {
       "add_financing": "Legg til finansiering",

--- a/src/types/project.types.ts
+++ b/src/types/project.types.ts
@@ -39,7 +39,7 @@ export type ProjectOrganization = Omit<Organization, 'partOf' | 'hasPart' | 'acr
 
 export type ProjectStatus = 'ACTIVE' | 'CONCLUDED' | 'NOTSTARTED';
 
-interface ProjectContributorIdentity {
+export interface ProjectContributorIdentity {
   type: 'Person';
   id: string;
   firstName: string;
@@ -50,7 +50,7 @@ export type ProjectContributorType = 'ProjectManager' | 'ProjectParticipant';
 
 export interface ProjectContributorRole {
   type: ProjectContributorType;
-  affiliation: ProjectOrganization;
+  affiliation: ProjectOrganization | undefined;
 }
 
 export interface ProjectContributor {
@@ -175,7 +175,7 @@ export enum ProjectFieldName {
   Keywords = 'keywords',
   RelatedProjects = 'relatedProjects',
   RoleType = 'roles[0].type',
-  RoleAffiliation = 'roles[0].affiliation',
+  Type = 'type',
 }
 
 export enum ProjectContributorFieldName {


### PR DESCRIPTION
# Description

Link to Jira issue: [https://sikt.atlassian.net/browse/NP-47475](https://sikt.atlassian.net/browse/NP-47475)

When we added a new contributor without selecting affiliation, the view would be buggy, because it couldn't handle not having affiliations:

![image](https://github.com/user-attachments/assets/06598e55-8441-4572-8b90-4f03da677854)

Now I changed the type definition so that affiliations can be empty. I also fixed some smaller bugs to handle edge cases.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
