### PR TITLE
Show suggested project manager when NFR-project

### DIFF
--- a/src/pages/project/project_wizard/CreateNfrProject.tsx
+++ b/src/pages/project/project_wizard/CreateNfrProject.tsx
@@ -13,6 +13,7 @@ interface NFRProjectProps {
   newProject: SaveCristinProject;
   setNewProject: (val: SaveCristinProject) => void;
   setShowProjectForm: (val: boolean) => void;
+  setSuggestedProjectManager: (val: string) => void;
   coordinatingInstitution: ProjectOrganization;
 }
 
@@ -20,6 +21,7 @@ export const CreateNfrProject = ({
   newProject,
   setNewProject,
   setShowProjectForm,
+  setSuggestedProjectManager,
   coordinatingInstitution,
 }: NFRProjectProps) => {
   const { t } = useTranslation();
@@ -29,6 +31,8 @@ export const CreateNfrProject = ({
     if (!selectedProject) {
       return;
     }
+
+    setSuggestedProjectManager(selectedProject.lead);
 
     setNewProject({
       ...newProject,

--- a/src/pages/project/project_wizard/CreateProject.tsx
+++ b/src/pages/project/project_wizard/CreateProject.tsx
@@ -17,11 +17,12 @@ const CreateProject = () => {
   const currentInstitutionQuery = useFetchOrganization(topOrgCristinId);
   const [newProject, setNewProject] = useState(emptyProject);
   const [showProjectForm, setShowProjectForm] = useState(false);
+  const [suggestedProjectManager, setSuggestedProjectManager] = useState('');
 
   return (
     <StyledPageContent>
       {showProjectForm ? (
-        <ProjectForm project={newProject} />
+        <ProjectForm project={newProject} suggestedProjectManager={suggestedProjectManager} />
       ) : (
         <>
           <PageHeader>{t('project.create_project')}</PageHeader>
@@ -30,6 +31,7 @@ const CreateProject = () => {
               newProject={newProject}
               setNewProject={setNewProject}
               setShowProjectForm={setShowProjectForm}
+              setSuggestedProjectManager={setSuggestedProjectManager}
               coordinatingInstitution={currentInstitutionQuery.data ?? emptyProject.coordinatingInstitution}
             />
             <EmptyProjectForm

--- a/src/pages/project/project_wizard/ProjectForm.tsx
+++ b/src/pages/project/project_wizard/ProjectForm.tsx
@@ -26,9 +26,10 @@ import { ProjectFormStepper } from './ProjectFormStepper';
 
 interface ProjectFormProps {
   project: SaveCristinProject | CristinProject;
+  suggestedProjectManager?: string;
 }
 
-export const ProjectForm = ({ project }: ProjectFormProps) => {
+export const ProjectForm = ({ project, suggestedProjectManager }: ProjectFormProps) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const history = useHistory();
@@ -101,7 +102,12 @@ export const ProjectForm = ({ project }: ProjectFormProps) => {
             <Box id="form" sx={{ bgcolor: 'secondary.main', mb: '0.5rem', padding: '1.5rem 1.25rem' }}>
               {tabNumber === ProjectTabs.Description && <ProjectDescriptionForm thisIsRekProject={thisIsRekProject} />}
               {tabNumber === ProjectTabs.Details && <ProjectDetailsForm thisIsRekProject={thisIsRekProject} />}
-              {tabNumber === ProjectTabs.Contributors && <ProjectContributorsForm maxVisitedTab={maxVisitedTab} />}
+              {tabNumber === ProjectTabs.Contributors && (
+                <ProjectContributorsForm
+                  maxVisitedTab={maxVisitedTab}
+                  suggestedProjectManager={suggestedProjectManager}
+                />
+              )}
               {tabNumber === ProjectTabs.Connections && <ProjectConnectionsForm />}
             </Box>
             <ProjectFormActions tabNumber={tabNumber} setTabNumber={setTabNumber} onCancel={onCancel} />

--- a/src/pages/project/project_wizard/ProjectManager.tsx
+++ b/src/pages/project/project_wizard/ProjectManager.tsx
@@ -42,11 +42,6 @@ export const ProjectManager = ({ suggestedProjectManager, isVisited = false }: P
   return (
     <>
       <Typography variant="h2">{t('project.project_manager')}</Typography>
-      {suggestedProjectManager && (
-        <Typography sx={{ marginBottom: '1rem' }}>
-          {t('project.project_manager_from_nfr', { name: suggestedProjectManager })}
-        </Typography>
-      )}
       <FieldArray name={ProjectFieldName.Contributors}>
         {({ name, remove }: FieldArrayRenderProps) => (
           <>
@@ -83,6 +78,7 @@ export const ProjectManager = ({ suggestedProjectManager, isVisited = false }: P
       <AddProjectContributorModal
         open={addProjectManagerViewIsOpen}
         toggleModal={toggleAddProjectManagerView}
+        suggestedProjectManager={suggestedProjectManager}
         addProjectManager
       />
     </>

--- a/src/pages/projects/AddProjectContributorModal.tsx
+++ b/src/pages/projects/AddProjectContributorModal.tsx
@@ -12,11 +12,13 @@ interface AddProjectContributorModalProps {
   open: boolean;
   toggleModal: () => void;
   addProjectManager?: boolean;
+  suggestedProjectManager?: string;
 }
 
 export const AddProjectContributorModal = ({
   open,
   toggleModal,
+  suggestedProjectManager,
   addProjectManager = false,
 }: AddProjectContributorModalProps) => {
   const { t } = useTranslation();
@@ -110,7 +112,11 @@ export const AddProjectContributorModal = ({
       maxWidth="md"
       dataTestId="contributor-modal">
       {addProjectManager ? (
-        <AddProjectManagerForm toggleModal={toggleModal} addContributor={addContributor} />
+        <AddProjectManagerForm
+          toggleModal={toggleModal}
+          addContributor={addContributor}
+          suggestedProjectManager={suggestedProjectManager}
+        />
       ) : (
         <AddProjectContributorForm toggleModal={toggleModal} addContributor={addContributor} />
       )}

--- a/src/pages/projects/AddProjectManagerForm.tsx
+++ b/src/pages/projects/AddProjectManagerForm.tsx
@@ -1,4 +1,4 @@
-import { Box, Button } from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
 import { useFormikContext } from 'formik';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -20,9 +20,14 @@ interface AddProjectManagerFormProps {
     contributors: ProjectContributor[],
     roleToAddTo: ProjectContributorType
   ) => ProjectContributor[] | undefined;
+  suggestedProjectManager?: string;
 }
 
-export const AddProjectManagerForm = ({ toggleModal, addContributor }: AddProjectManagerFormProps) => {
+export const AddProjectManagerForm = ({
+  toggleModal,
+  addContributor,
+  suggestedProjectManager,
+}: AddProjectManagerFormProps) => {
   const { t } = useTranslation();
   const { values, setFieldValue } = useFormikContext<CristinProject>();
   const { contributors } = values;
@@ -40,6 +45,11 @@ export const AddProjectManagerForm = ({ toggleModal, addContributor }: AddProjec
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+      {suggestedProjectManager && (
+        <Typography sx={{ marginBottom: '1rem' }}>
+          {t('project.project_manager_from_nfr', { name: suggestedProjectManager })}
+        </Typography>
+      )}
       <ContributorSearchField
         selectedPerson={selectedPerson}
         setSelectedPerson={setSelectedPerson}


### PR DESCRIPTION
# Description

Link to Jira issue: [https://sikt.atlassian.net/browse/NP-47448](https://sikt.atlassian.net/browse/NP-47448)

This is just reinstating functionality from the old project-form: When a new project is created from NFR-project a lot of  fields will come pre-filled in the form. One of these should be project manager, but since that it difficult to add when many people can have the same name, will will just display the name in the select-box:

![image](https://github.com/user-attachments/assets/033cf6aa-71df-42bb-9d50-a5e486b8e4a3)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
