### PR TITLE
Added warning on cancel-button i new project view

### DIFF
--- a/src/pages/project/project_wizard/ProjectFormActions.tsx
+++ b/src/pages/project/project_wizard/ProjectFormActions.tsx
@@ -1,11 +1,13 @@
 import { LoadingButton } from '@mui/lab';
 import { Box } from '@mui/material';
 import { useFormikContext } from 'formik';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CancelButton } from '../../../components/buttons/CancelButton';
 import { DoubleNextButton } from '../../../components/buttons/DoubleNextButton';
 import { NextButton } from '../../../components/buttons/NextButton';
 import { PreviousButton } from '../../../components/buttons/PreviousButton';
+import { ConfirmDialog } from '../../../components/ConfirmDialog';
 import { StyledFormFooter } from '../../../components/styled/Wrappers';
 import { ProjectTabs, SaveCristinProject } from '../../../types/project.types';
 import { dataTestId } from '../../../utils/dataTestIds';
@@ -20,6 +22,7 @@ interface ProjectFormActionsProps {
 export const ProjectFormActions = ({ tabNumber, setTabNumber, onCancel }: ProjectFormActionsProps) => {
   const { t } = useTranslation();
   const { isSubmitting, errors, touched } = useFormikContext<SaveCristinProject>();
+  const [openCancelConfirmView, setOpenCancelConfirmView] = useState(false);
   const isFirstTab = tabNumber === ProjectTabs.Description;
   const isLastTab = tabNumber === ProjectTabs.Connections;
   const disable = hasErrors(errors, touched);
@@ -35,7 +38,7 @@ export const ProjectFormActions = ({ tabNumber, setTabNumber, onCancel }: Projec
         <CancelButton
           sx={{ mr: '1rem' }}
           testId={dataTestId.projectWizard.formActions.cancelEditProjectButton}
-          onClick={onCancel}
+          onClick={() => setOpenCancelConfirmView(true)}
         />
         {isLastTab && (
           <LoadingButton
@@ -55,6 +58,16 @@ export const ProjectFormActions = ({ tabNumber, setTabNumber, onCancel }: Projec
           </>
         )}
       </Box>
+      <ConfirmDialog
+        open={openCancelConfirmView}
+        title={t('project.close_view')}
+        onAccept={() => {
+          setOpenCancelConfirmView(false);
+          onCancel();
+        }}
+        onCancel={() => setOpenCancelConfirmView(false)}>
+        {t('project.close_view_description')}
+      </ConfirmDialog>
     </StyledFormFooter>
   );
 };

--- a/src/pages/project/project_wizard/ProjectFormActions.tsx
+++ b/src/pages/project/project_wizard/ProjectFormActions.tsx
@@ -31,8 +31,6 @@ export const ProjectFormActions = ({ tabNumber, setTabNumber, onCancel }: Projec
   const goToPreviousTab = () => setTabNumber(tabNumber - 1);
   const goToLastTab = () => setTabNumber(ProjectTabs.Connections);
 
-  console.log('test');
-
   return (
     <StyledFormFooter>
       <Box sx={{ display: 'flex', flexGrow: '1' }}>{!isFirstTab && <PreviousButton onClick={goToPreviousTab} />}</Box>

--- a/src/pages/project/project_wizard/ProjectFormActions.tsx
+++ b/src/pages/project/project_wizard/ProjectFormActions.tsx
@@ -31,6 +31,8 @@ export const ProjectFormActions = ({ tabNumber, setTabNumber, onCancel }: Projec
   const goToPreviousTab = () => setTabNumber(tabNumber - 1);
   const goToLastTab = () => setTabNumber(ProjectTabs.Connections);
 
+  console.log('test');
+
   return (
     <StyledFormFooter>
       <Box sx={{ display: 'flex', flexGrow: '1' }}>{!isFirstTab && <PreviousButton onClick={goToPreviousTab} />}</Box>


### PR DESCRIPTION
# Description

Link to Jira issue: [https://sikt.atlassian.net/browse/NP-47421](https://sikt.atlassian.net/browse/NP-47421)

Now, when clicking cancel in new project view, you get a confirm-dialog to ensure you know you will lose your unsaved data:

![image](https://github.com/user-attachments/assets/404903c6-2de2-4286-b1f9-55b1b15ac570)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
