### PR TITLE
Np 47555 move new status filter

### DIFF
--- a/src/components/DialoguesWithoutCuratorButton.tsx
+++ b/src/components/DialoguesWithoutCuratorButton.tsx
@@ -1,4 +1,5 @@
-import ChatBubbleIcon from '@mui/icons-material/ChatBubble';
+import CheckBoxIcon from '@mui/icons-material/CheckBox';
+import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import { Badge, Box, Button } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
@@ -17,9 +18,8 @@ export const DialoguesWithoutCuratorButton = () => {
   const user = useSelector((store: RootState) => store.user);
   const history = useHistory();
   const searchParams = new URLSearchParams(history.location.search);
-
-  const dialoguesWithoutCuratorSelected =
-    searchParams.get(TicketSearchParam.Status) === statusNew && !searchParams.get(TicketSearchParam.Assignee);
+  const currentStatusFilter = (searchParams.get(TicketSearchParam.Status)?.split(',') ?? []) as TicketStatus[];
+  const newStatusIsSelected = currentStatusFilter.includes(statusNew);
 
   const notificationsQuery = useQuery({
     enabled: user?.isDoiCurator || user?.isSupportCurator || user?.isPublishingCurator,
@@ -33,11 +33,15 @@ export const DialoguesWithoutCuratorButton = () => {
   )?.count;
 
   const toggleDialoguesWithoutCurators = () => {
-    if (dialoguesWithoutCuratorSelected) {
-      searchParams.delete(TicketSearchParam.Status);
+    if (newStatusIsSelected) {
+      const newValues = currentStatusFilter.filter((status) => status !== statusNew);
+      if (newValues.length > 0) {
+        searchParams.set(TicketSearchParam.Status, newValues.join(','));
+      } else {
+        searchParams.delete(TicketSearchParam.Status);
+      }
     } else {
-      searchParams.set(TicketSearchParam.Status, statusNew);
-      searchParams.delete(TicketSearchParam.Assignee);
+      searchParams.set(TicketSearchParam.Status, [...currentStatusFilter, statusNew].join(','));
     }
     history.push({ search: searchParams.toString() });
   };
@@ -46,16 +50,16 @@ export const DialoguesWithoutCuratorButton = () => {
     <Button
       fullWidth
       size="medium"
-      variant={dialoguesWithoutCuratorSelected ? 'contained' : 'outlined'}
+      variant="outlined"
       color="primary"
       sx={{ textTransform: 'none' }}
-      startIcon={<ChatBubbleIcon />}
+      startIcon={newStatusIsSelected ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
       endIcon={<Badge badgeContent={unassignedNotificationsCount} sx={{ ml: '1rem' }} />}
       onClick={toggleDialoguesWithoutCurators}
-      title={t('tasks.dialogues_without_curator')}
+      title={t('tasks.include_tasks_without_curator')}
       data-testid={dataTestId.tasksPage.dialoguesWithoutCuratorButton}>
       <Box component="span" sx={{ whiteSpace: 'nowrap' }}>
-        {t('tasks.dialogues_without_curator')}
+        {t('tasks.include_tasks_without_curator')}
       </Box>
     </Button>
   );

--- a/src/components/DialoguesWithoutCuratorButton.tsx
+++ b/src/components/DialoguesWithoutCuratorButton.tsx
@@ -1,6 +1,6 @@
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
-import { Badge, Box, Button } from '@mui/material';
+import { Badge, Button } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -58,9 +58,7 @@ export const DialoguesWithoutCuratorButton = () => {
       onClick={toggleDialoguesWithoutCurators}
       title={t('tasks.include_tasks_without_curator')}
       data-testid={dataTestId.tasksPage.dialoguesWithoutCuratorButton}>
-      <Box component="span" sx={{ whiteSpace: 'nowrap' }}>
-        {t('tasks.include_tasks_without_curator')}
-      </Box>
+      {t('tasks.include_tasks_without_curator')}
     </Button>
   );
 };

--- a/src/components/TicketStatusFilter.tsx
+++ b/src/components/TicketStatusFilter.tsx
@@ -2,26 +2,32 @@ import { Checkbox, FormControl, InputLabel, MenuItem, Select, SelectChangeEvent,
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { TicketSearchParam } from '../api/searchApi';
-import { TicketStatus, ticketStatusValues } from '../types/publication_types/ticket.types';
+import { TicketStatus } from '../types/publication_types/ticket.types';
 import { dataTestId } from '../utils/dataTestIds';
 
 const labelId = 'status-filter-select';
 
-export const TicketStatusFilter = () => {
+interface TicketStatusFilterProps {
+  options: TicketStatus[];
+}
+
+export const TicketStatusFilter = ({ options }: TicketStatusFilterProps) => {
   const { t } = useTranslation();
   const history = useHistory();
   const searchParams = new URLSearchParams(history.location.search);
-  const selectedStatuses = (searchParams.get(TicketSearchParam.Status)?.split(',') ?? []) as TicketStatus[];
+  const currentStatusFilter = (searchParams.get(TicketSearchParam.Status)?.split(',') ?? []) as TicketStatus[];
+  const selectedOptions = currentStatusFilter.filter((status) => options.includes(status));
+  const otherSelectedStatuses = currentStatusFilter.filter((status) => !options.includes(status));
 
-  const handleChange = (event: SelectChangeEvent<string[]>) => {
-    const newSelectedStatuses = event.target.value as TicketStatus[];
+  const handleChange = (event: SelectChangeEvent<TicketStatus[]>) => {
+    const newSelectedOptions = event.target.value as TicketStatus[];
+    const newSelectedStatuses = [...otherSelectedStatuses, ...newSelectedOptions];
 
     if (newSelectedStatuses.length > 0) {
       searchParams.set(TicketSearchParam.Status, newSelectedStatuses.join(','));
     } else {
       searchParams.delete(TicketSearchParam.Status);
     }
-
     history.push({ search: searchParams.toString() });
   };
 
@@ -33,18 +39,18 @@ export const TicketStatusFilter = () => {
         label={t('tasks.status')}
         data-testid={dataTestId.myPage.myMessages.ticketStatusField}
         multiple
-        value={selectedStatuses}
+        value={selectedOptions}
         onChange={handleChange}
-        renderValue={(selected: TicketStatus[]) => {
-          if (selected.length === ticketStatusValues.length) {
+        renderValue={(selected) => {
+          if (selected.length === options.length) {
             return t('my_page.messages.all_ticket_types');
           } else {
             return selected.map((value) => t(`my_page.messages.ticket_types.${value}`)).join(', ');
           }
         }}>
-        {ticketStatusValues.map((status) => (
+        {options.map((status) => (
           <MenuItem sx={{ height: '2.5rem' }} key={status} value={status}>
-            <Checkbox checked={selectedStatuses.includes(status)} />
+            <Checkbox checked={selectedOptions.includes(status)} />
             <Typography>{t(`my_page.messages.ticket_types.${status}`)}</Typography>
           </MenuItem>
         ))}

--- a/src/pages/messages/components/TicketList.tsx
+++ b/src/pages/messages/components/TicketList.tsx
@@ -15,7 +15,7 @@ import { ListSkeleton } from '../../../components/ListSkeleton';
 import { SearchForm } from '../../../components/SearchForm';
 import { SortSelector } from '../../../components/SortSelector';
 import { TicketStatusFilter } from '../../../components/TicketStatusFilter';
-import { CustomerTicketSearchResponse } from '../../../types/publication_types/ticket.types';
+import { CustomerTicketSearchResponse, ticketStatusValues } from '../../../types/publication_types/ticket.types';
 import { RoleName } from '../../../types/user.types';
 import { stringIncludesMathJax, typesetMathJax } from '../../../utils/mathJaxHelpers';
 import { UrlPathTemplate } from '../../../utils/urlPaths';
@@ -35,6 +35,10 @@ export const TicketList = ({ ticketsQuery, setRowsPerPage, rowsPerPage, setPage,
   const { t } = useTranslation();
   const history = useHistory();
   const isOnTasksPage = history.location.pathname === UrlPathTemplate.TasksDialogue;
+
+  const ticketStatusOptions = isOnTasksPage
+    ? ticketStatusValues.filter((status) => status !== 'New')
+    : ticketStatusValues;
 
   const tickets = useMemo(() => ticketsQuery.data?.hits ?? [], [ticketsQuery.data?.hits]);
 
@@ -69,7 +73,7 @@ export const TicketList = ({ ticketsQuery, setRowsPerPage, rowsPerPage, setPage,
 
       <Grid container columns={16} spacing={2} sx={{ px: { xs: '0.5rem', md: 0 }, mb: '1rem' }}>
         <Grid item xs={16} md={5} lg={4}>
-          <TicketStatusFilter />
+          <TicketStatusFilter options={ticketStatusOptions} />
         </Grid>
         <Grid item xs={16} md={isOnTasksPage ? 6 : 11} lg={isOnTasksPage ? 8 : 12}>
           <SearchForm placeholder={t('tasks.search_placeholder')} />

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1981,7 +1981,6 @@
   },
   "tasks": {
     "correction_list": "Retteliste",
-    "dialogues_without_curator": "Dialoger uten kurator",
     "nvi": {
       "approval_status_count": "Kontrollert ({{checked}} av {{total}})",
       "approve_nvi_candidate": "Godkjenn resultat",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1981,6 +1981,7 @@
   },
   "tasks": {
     "correction_list": "Retteliste",
+    "include_tasks_without_curator": "Inkluder oppgaver uten kurator",
     "nvi": {
       "approval_status_count": "Kontrollert ({{checked}} av {{total}})",
       "approve_nvi_candidate": "Godkjenn resultat",
@@ -2024,8 +2025,7 @@
     "select_other_unit_filter": "Velg andre",
     "status": "Status",
     "unread": "Uleste",
-    "user_dialog": "Brukerdialog",
-    "include_tasks_without_curator": "Inkluder oppgaver uten kurator"
+    "user_dialog": "Brukerdialog"
   },
   "unpublish_actions": {
     "duplicate": "Duplikat",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -307,10 +307,6 @@
     "yes": "Ja"
   },
   "disciplines": {
-    "0001": "Humaniora",
-    "0002": "Samfunnsvitenskap",
-    "0003": "Medisin og helsefag",
-    "0004": "Realfag og teknologi",
     "1003": "Arkeologi og konservering",
     "1005": "Asiatiske og afrikanske studier",
     "1007": "Engelsk",
@@ -382,7 +378,11 @@
     "1162": "Konstruksjonsfag",
     "1166": "Filosofi",
     "1168": "Historie og idéhistorie",
-    "1170": "Kunst, design og arkitektur"
+    "1170": "Kunst, design og arkitektur",
+    "0001": "Humaniora",
+    "0002": "Samfunnsvitenskap",
+    "0003": "Medisin og helsefag",
+    "0004": "Realfag og teknologi"
   },
   "editor": {
     "categories_with_files": "Kategorier med filopplasting",
@@ -2025,7 +2025,8 @@
     "select_other_unit_filter": "Velg andre",
     "status": "Status",
     "unread": "Uleste",
-    "user_dialog": "Brukerdialog"
+    "user_dialog": "Brukerdialog",
+    "include_tasks_without_curator": "Inkluder oppgaver uten kurator"
   },
   "unpublish_actions": {
     "duplicate": "Duplikat",


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47555

Ta vekk "Innmeldt" som status fra Oppgaver-visning til kurator, og legg til egen knapp som styrer bare om nye oppgaver uten kurator også skal inkluderes i søket. Den skal være enabled by default. Det er ønske om litt justering på plasseringen til disse søkefeltene også, men ser det vil bli en del knoting med mange `<Grid>` items og sånt styr for både Oppgaver og Min Side, så lar det ligge inntil videre. Ser for meg det kan være fornuftig å ta etter at vi har flyttet "Ulest"-knappen også, da det også vil påvirke visningen her

Før:
![bilde](https://github.com/user-attachments/assets/b8cfff3b-611b-4a2e-86c2-6ee2b757e110)

Etter:
![bilde](https://github.com/user-attachments/assets/773ab7a6-e21b-4f6a-ab7a-55a7ad506f58)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
