### PR TITLE
Np 47571 add filters to nvi correction list

### DIFF
--- a/src/components/CategorySearchFilter.tsx
+++ b/src/components/CategorySearchFilter.tsx
@@ -10,9 +10,10 @@ import { CategoryChip } from './CategorySelector';
 
 interface CategorySearchFilterProps {
   searchParam: ResultParam.CategoryShould | TicketSearchParam.PublicationType;
+  disabled?: boolean;
 }
 
-export const CategorySearchFilter = ({ searchParam }: CategorySearchFilterProps) => {
+export const CategorySearchFilter = ({ searchParam, disabled }: CategorySearchFilterProps) => {
   const { t } = useTranslation();
   const history = useHistory();
   const params = new URLSearchParams(history.location.search);
@@ -45,6 +46,7 @@ export const CategorySearchFilter = ({ searchParam }: CategorySearchFilterProps)
           />
         ) : (
           <Chip
+            disabled={disabled}
             label={t('registration.resource_type.select_resource_type')}
             color="primary"
             onClick={toggleCategoryFilter}

--- a/src/components/CategorySearchFilter.tsx
+++ b/src/components/CategorySearchFilter.tsx
@@ -6,6 +6,7 @@ import { ResultParam, TicketSearchParam } from '../api/searchApi';
 import { StyledTypography } from '../pages/search/advanced_search/AdvancedSearchPage';
 import { CategoryFilterDialog } from '../pages/search/advanced_search/CategoryFilterDialog';
 import { PublicationInstanceType } from '../types/registration.types';
+import { dataTestId } from '../utils/dataTestIds';
 import { CategoryChip } from './CategorySelector';
 
 interface CategorySearchFilterProps {
@@ -46,6 +47,7 @@ export const CategorySearchFilter = ({ searchParam, disabled }: CategorySearchFi
           />
         ) : (
           <Chip
+            data-testid={dataTestId.startPage.advancedSearch.selectCategoryChip}
             disabled={disabled}
             label={t('registration.resource_type.select_resource_type')}
             color="primary"

--- a/src/components/CategorySearchFilter.tsx
+++ b/src/components/CategorySearchFilter.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { ResultParam, TicketSearchParam } from '../api/searchApi';
+import { StyledTypography } from '../pages/search/advanced_search/AdvancedSearchPage';
 import { CategoryFilterDialog } from '../pages/search/advanced_search/CategoryFilterDialog';
 import { PublicationInstanceType } from '../types/registration.types';
 import { CategoryChip } from './CategorySelector';
@@ -22,6 +23,7 @@ export const CategorySearchFilter = ({ searchParam }: CategorySearchFilterProps)
 
   return (
     <section>
+      <StyledTypography>{t('common.category')}</StyledTypography>
       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem' }}>
         {selectedCategories.slice(0, 3).map((category) => (
           <CategoryChip

--- a/src/components/CategorySearchFilter.tsx
+++ b/src/components/CategorySearchFilter.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { ResultParam, TicketSearchParam } from '../api/searchApi';
-import { StyledTypography } from '../pages/search/advanced_search/AdvancedSearchPage';
+import { StyledFilterTitle } from '../pages/search/advanced_search/AdvancedSearchPage';
 import { CategoryFilterDialog } from '../pages/search/advanced_search/CategoryFilterDialog';
 import { PublicationInstanceType } from '../types/registration.types';
 import { dataTestId } from '../utils/dataTestIds';
@@ -25,7 +25,7 @@ export const CategorySearchFilter = ({ searchParam, disabled }: CategorySearchFi
 
   return (
     <section>
-      <StyledTypography>{t('common.category')}</StyledTypography>
+      <StyledFilterTitle>{t('common.category')}</StyledFilterTitle>
       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem' }}>
         {selectedCategories.slice(0, 3).map((category) => (
           <CategoryChip

--- a/src/pages/messages/components/NviCorrectionList.tsx
+++ b/src/pages/messages/components/NviCorrectionList.tsx
@@ -24,6 +24,7 @@ type CorrectionListSearchConfig = {
   [key in CorrectionListId]: {
     i18nKey: ParseKeys;
     queryParams: FetchResultsParams;
+    disabledFilters: ResultParam[];
   };
 };
 
@@ -34,6 +35,7 @@ const correctionListConfig: CorrectionListSearchConfig = {
       categoryShould: nviApplicableTypes,
       scientificValue: ScientificValueLevels.LevelZero,
     },
+    disabledFilters: [ResultParam.CategoryShould],
   },
   NonApplicableCategoriesWithApplicableChannel: {
     i18nKey: 'tasks.nvi.correction_list_type.non_applicable_category_in_applicable_channel',
@@ -41,6 +43,7 @@ const correctionListConfig: CorrectionListSearchConfig = {
       categoryNot: nviApplicableTypes,
       scientificValue: [ScientificValueLevels.LevelOne, ScientificValueLevels.LevelTwo].join(','),
     },
+    disabledFilters: [],
   },
 };
 
@@ -90,14 +93,21 @@ export const NviCorrectionList = () => {
         <>
           <Box
             sx={{ px: { xs: '0.5rem', md: 0 }, display: 'flex', flexDirection: 'column', gap: '0.5rem', mb: '1rem' }}>
-            <OrganizationFilters topLevelOrganizationId={topLevelOrganizationId} unitId={unitId} />
+            <OrganizationFilters
+              topLevelOrganizationId={topLevelOrganizationId}
+              unitId={unitId}
+              disabled={listConfig.disabledFilters.includes(ResultParam.Unit)}
+            />
 
             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
               <PublisherFilter />
               <JournalFilter />
               <SeriesFilter />
               <Divider flexItem orientation="vertical" sx={{ bgcolor: 'primary.main' }} />
-              <CategorySearchFilter searchParam={ResultParam.CategoryShould} />
+              <CategorySearchFilter
+                searchParam={ResultParam.CategoryShould}
+                disabled={listConfig.disabledFilters.includes(ResultParam.CategoryShould)}
+              />
             </Box>
           </Box>
 

--- a/src/pages/messages/components/NviCorrectionList.tsx
+++ b/src/pages/messages/components/NviCorrectionList.tsx
@@ -9,6 +9,7 @@ import { CategorySearchFilter } from '../../../components/CategorySearchFilter';
 import { PublicationInstanceType } from '../../../types/registration.types';
 import { ROWS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 import { nviApplicableTypes } from '../../../utils/registration-helpers';
+import { OrganizationFilters } from '../../search/advanced_search/OrganizationFilters';
 import { ScientificValueLevels } from '../../search/advanced_search/ScientificValueFilter';
 import { RegistrationSearch } from '../../search/registration_search/RegistrationSearch';
 
@@ -49,15 +50,22 @@ export const NviCorrectionList = () => {
   const listId = searchParams.get(nviCorrectionListQueryKey) as CorrectionListId | null;
   const listConfig = listId && correctionListConfig[listId];
 
+  const categoryShould =
+    (searchParams.get(ResultParam.CategoryShould)?.split(',') as PublicationInstanceType[] | null) ?? [];
+  const topLevelOrganizationId = searchParams.get(ResultParam.TopLevelOrganization);
+  const unitId = searchParams.get(ResultParam.Unit);
+  const excludeSubunits = searchParams.get(ResultParam.ExcludeSubunits) === 'true';
+
   const fetchParams: FetchResultsParams = {
     ...listConfig?.queryParams,
-    categoryShould:
-      (searchParams.get(ResultParam.CategoryShould)?.split(',') as PublicationInstanceType[] | null) ?? [],
+    categoryShould,
+    unit: unitId ?? topLevelOrganizationId,
     from: Number(searchParams.get(ResultParam.From) ?? 0),
     results: Number(searchParams.get(ResultParam.Results) ?? ROWS_PER_PAGE_OPTIONS[0]),
     publicationYearSince: (new Date().getFullYear() - 1).toString(),
     order: searchParams.get(ResultParam.Order) as ResultSearchOrder | null,
     sort: searchParams.get(ResultParam.Sort) as SortOrder | null,
+    excludeSubunits,
   };
 
   const registrationQuery = useRegistrationSearch({ enabled: !!listConfig, params: fetchParams });
@@ -75,6 +83,7 @@ export const NviCorrectionList = () => {
       {listConfig ? (
         <>
           <CategorySearchFilter searchParam={ResultParam.CategoryShould} />
+          <OrganizationFilters topLevelOrganizationId={topLevelOrganizationId} unitId={unitId} />
           <RegistrationSearch registrationQuery={registrationQuery} />
         </>
       ) : (

--- a/src/pages/messages/components/NviCorrectionList.tsx
+++ b/src/pages/messages/components/NviCorrectionList.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { ParseKeys } from 'i18next';
 import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
@@ -9,8 +9,11 @@ import { CategorySearchFilter } from '../../../components/CategorySearchFilter';
 import { PublicationInstanceType } from '../../../types/registration.types';
 import { ROWS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 import { nviApplicableTypes } from '../../../utils/registration-helpers';
+import { JournalFilter } from '../../search/advanced_search/JournalFilter';
 import { OrganizationFilters } from '../../search/advanced_search/OrganizationFilters';
+import { PublisherFilter } from '../../search/advanced_search/PublisherFilter';
 import { ScientificValueLevels } from '../../search/advanced_search/ScientificValueFilter';
+import { SeriesFilter } from '../../search/advanced_search/SeriesFilter';
 import { RegistrationSearch } from '../../search/registration_search/RegistrationSearch';
 
 export type CorrectionListId =
@@ -59,13 +62,16 @@ export const NviCorrectionList = () => {
   const fetchParams: FetchResultsParams = {
     ...listConfig?.queryParams,
     categoryShould,
-    unit: unitId ?? topLevelOrganizationId,
+    excludeSubunits,
     from: Number(searchParams.get(ResultParam.From) ?? 0),
+    journal: searchParams.get(ResultParam.Journal),
     results: Number(searchParams.get(ResultParam.Results) ?? ROWS_PER_PAGE_OPTIONS[0]),
     publicationYearSince: (new Date().getFullYear() - 1).toString(),
+    publisher: searchParams.get(ResultParam.Publisher),
     order: searchParams.get(ResultParam.Order) as ResultSearchOrder | null,
+    series: searchParams.get(ResultParam.Series),
     sort: searchParams.get(ResultParam.Sort) as SortOrder | null,
-    excludeSubunits,
+    unit: unitId ?? topLevelOrganizationId,
   };
 
   const registrationQuery = useRegistrationSearch({ enabled: !!listConfig, params: fetchParams });
@@ -84,6 +90,13 @@ export const NviCorrectionList = () => {
         <>
           <CategorySearchFilter searchParam={ResultParam.CategoryShould} />
           <OrganizationFilters topLevelOrganizationId={topLevelOrganizationId} unitId={unitId} />
+
+          <Box sx={{ display: 'flex', gap: '1rem' }}>
+            <PublisherFilter />
+            <JournalFilter />
+            <SeriesFilter />
+          </Box>
+
           <RegistrationSearch registrationQuery={registrationQuery} />
         </>
       ) : (

--- a/src/pages/messages/components/NviCorrectionList.tsx
+++ b/src/pages/messages/components/NviCorrectionList.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { useRegistrationSearch } from '../../../api/hooks/useRegistrationSearch';
 import { FetchResultsParams, ResultParam, ResultSearchOrder, SortOrder } from '../../../api/searchApi';
+import { CategorySearchFilter } from '../../../components/CategorySearchFilter';
+import { PublicationInstanceType } from '../../../types/registration.types';
 import { ROWS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 import { nviApplicableTypes } from '../../../utils/registration-helpers';
 import { ScientificValueLevels } from '../../search/advanced_search/ScientificValueFilter';
@@ -49,6 +51,8 @@ export const NviCorrectionList = () => {
 
   const fetchParams: FetchResultsParams = {
     ...listConfig?.queryParams,
+    categoryShould:
+      (searchParams.get(ResultParam.CategoryShould)?.split(',') as PublicationInstanceType[] | null) ?? [],
     from: Number(searchParams.get(ResultParam.From) ?? 0),
     results: Number(searchParams.get(ResultParam.Results) ?? ROWS_PER_PAGE_OPTIONS[0]),
     publicationYearSince: (new Date().getFullYear() - 1).toString(),
@@ -69,7 +73,10 @@ export const NviCorrectionList = () => {
       </Typography>
 
       {listConfig ? (
-        <RegistrationSearch registrationQuery={registrationQuery} />
+        <>
+          <CategorySearchFilter searchParam={ResultParam.CategoryShould} />
+          <RegistrationSearch registrationQuery={registrationQuery} />
+        </>
       ) : (
         <iframe
           style={{ border: 'none', height: '80vh' }}

--- a/src/pages/messages/components/NviCorrectionList.tsx
+++ b/src/pages/messages/components/NviCorrectionList.tsx
@@ -63,7 +63,6 @@ export const NviCorrectionList = () => {
   const excludeSubunits = searchParams.get(ResultParam.ExcludeSubunits) === 'true';
 
   const fetchParams: FetchResultsParams = {
-    ...listConfig?.queryParams,
     categoryShould,
     excludeSubunits,
     from: Number(searchParams.get(ResultParam.From) ?? 0),
@@ -75,6 +74,7 @@ export const NviCorrectionList = () => {
     series: searchParams.get(ResultParam.Series),
     sort: searchParams.get(ResultParam.Sort) as SortOrder | null,
     unit: unitId ?? topLevelOrganizationId,
+    ...listConfig?.queryParams,
   };
 
   const registrationQuery = useRegistrationSearch({ enabled: !!listConfig, params: fetchParams });

--- a/src/pages/messages/components/NviCorrectionList.tsx
+++ b/src/pages/messages/components/NviCorrectionList.tsx
@@ -43,7 +43,7 @@ const correctionListConfig: CorrectionListSearchConfig = {
       categoryNot: nviApplicableTypes,
       scientificValue: [ScientificValueLevels.LevelOne, ScientificValueLevels.LevelTwo].join(','),
     },
-    disabledFilters: [],
+    disabledFilters: [ResultParam.CategoryShould],
   },
 };
 
@@ -93,21 +93,19 @@ export const NviCorrectionList = () => {
         <>
           <Box
             sx={{ px: { xs: '0.5rem', md: 0 }, display: 'flex', flexDirection: 'column', gap: '0.5rem', mb: '1rem' }}>
-            <OrganizationFilters
-              topLevelOrganizationId={topLevelOrganizationId}
-              unitId={unitId}
-              disabled={listConfig.disabledFilters.includes(ResultParam.Unit)}
-            />
-
             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
-              <PublisherFilter />
-              <JournalFilter />
-              <SeriesFilter />
+              <OrganizationFilters topLevelOrganizationId={topLevelOrganizationId} unitId={unitId} />
               <Divider flexItem orientation="vertical" sx={{ bgcolor: 'primary.main' }} />
               <CategorySearchFilter
                 searchParam={ResultParam.CategoryShould}
                 disabled={listConfig.disabledFilters.includes(ResultParam.CategoryShould)}
               />
+            </Box>
+
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem 1rem' }}>
+              <PublisherFilter />
+              <JournalFilter />
+              <SeriesFilter />
             </Box>
           </Box>
 

--- a/src/pages/messages/components/NviCorrectionList.tsx
+++ b/src/pages/messages/components/NviCorrectionList.tsx
@@ -87,19 +87,22 @@ export const NviCorrectionList = () => {
       </Typography>
 
       {listConfig ? (
-        <Box sx={{ px: { xs: '0.5rem', md: 0 }, display: 'flex', flexDirection: 'column', gap: '0.5rem', mb: '1rem' }}>
-          <OrganizationFilters topLevelOrganizationId={topLevelOrganizationId} unitId={unitId} />
+        <>
+          <Box
+            sx={{ px: { xs: '0.5rem', md: 0 }, display: 'flex', flexDirection: 'column', gap: '0.5rem', mb: '1rem' }}>
+            <OrganizationFilters topLevelOrganizationId={topLevelOrganizationId} unitId={unitId} />
 
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
-            <PublisherFilter />
-            <JournalFilter />
-            <SeriesFilter />
-            <Divider flexItem orientation="vertical" sx={{ bgcolor: 'primary.main' }} />
-            <CategorySearchFilter searchParam={ResultParam.CategoryShould} />
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
+              <PublisherFilter />
+              <JournalFilter />
+              <SeriesFilter />
+              <Divider flexItem orientation="vertical" sx={{ bgcolor: 'primary.main' }} />
+              <CategorySearchFilter searchParam={ResultParam.CategoryShould} />
+            </Box>
           </Box>
 
           <RegistrationSearch registrationQuery={registrationQuery} />
-        </Box>
+        </>
       ) : (
         <iframe
           style={{ border: 'none', height: '80vh' }}

--- a/src/pages/messages/components/NviCorrectionList.tsx
+++ b/src/pages/messages/components/NviCorrectionList.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography } from '@mui/material';
+import { Box, Divider, Typography } from '@mui/material';
 import { ParseKeys } from 'i18next';
 import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
@@ -87,18 +87,19 @@ export const NviCorrectionList = () => {
       </Typography>
 
       {listConfig ? (
-        <>
-          <CategorySearchFilter searchParam={ResultParam.CategoryShould} />
+        <Box sx={{ px: { xs: '0.5rem', md: 0 }, display: 'flex', flexDirection: 'column', gap: '0.5rem', mb: '1rem' }}>
           <OrganizationFilters topLevelOrganizationId={topLevelOrganizationId} unitId={unitId} />
 
-          <Box sx={{ display: 'flex', gap: '1rem' }}>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
             <PublisherFilter />
             <JournalFilter />
             <SeriesFilter />
+            <Divider flexItem orientation="vertical" sx={{ bgcolor: 'primary.main' }} />
+            <CategorySearchFilter searchParam={ResultParam.CategoryShould} />
           </Box>
 
           <RegistrationSearch registrationQuery={registrationQuery} />
-        </>
+        </Box>
       ) : (
         <iframe
           style={{ border: 'none', height: '80vh' }}

--- a/src/pages/messages/components/NviCorrectionListNavigationAccordion.tsx
+++ b/src/pages/messages/components/NviCorrectionListNavigationAccordion.tsx
@@ -16,6 +16,18 @@ export const NviCorrectionListNavigationAccordion = () => {
 
   const selectedNviList = searchParams.get(nviCorrectionListQueryKey);
 
+  const goToNewCorrectionList = (correctionListId: CorrectionListId) => {
+    if (selectedNviList !== correctionListId) {
+      const newSearchParams = new URLSearchParams();
+      const currentSearchSize = searchParams.get(ResultParam.Results);
+      if (currentSearchSize) {
+        newSearchParams.set(ResultParam.Results, currentSearchSize);
+      }
+      newSearchParams.set(nviCorrectionListQueryKey, correctionListId);
+      history.push({ search: newSearchParams.toString() });
+    }
+  };
+
   return (
     <NavigationListAccordion
       title={t('tasks.correction_list')}
@@ -33,31 +45,13 @@ export const NviCorrectionListNavigationAccordion = () => {
         <SelectableButton
           data-testid={dataTestId.tasksPage.correctionList.applicableCategoriesWithNonApplicableChannelButton}
           isSelected={selectedNviList === 'ApplicableCategoriesWithNonApplicableChannel'}
-          onClick={() => {
-            if (selectedNviList !== 'ApplicableCategoriesWithNonApplicableChannel') {
-              searchParams.set(
-                nviCorrectionListQueryKey,
-                'ApplicableCategoriesWithNonApplicableChannel' satisfies CorrectionListId
-              );
-              searchParams.delete(ResultParam.From);
-              history.push({ search: searchParams.toString() });
-            }
-          }}>
+          onClick={() => goToNewCorrectionList('ApplicableCategoriesWithNonApplicableChannel')}>
           {t('tasks.nvi.correction_list_type.applicable_category_in_non_applicable_channel')}
         </SelectableButton>
         <SelectableButton
           data-testid={dataTestId.tasksPage.correctionList.nonApplicableCategoriesWithApplicableChannelButton}
           isSelected={selectedNviList === 'NonApplicableCategoriesWithApplicableChannel'}
-          onClick={() => {
-            if (selectedNviList !== 'NonApplicableCategoriesWithApplicableChannel') {
-              searchParams.set(
-                nviCorrectionListQueryKey,
-                'NonApplicableCategoriesWithApplicableChannel' satisfies CorrectionListId
-              );
-              searchParams.delete(ResultParam.From);
-              history.push({ search: searchParams.toString() });
-            }
-          }}>
+          onClick={() => goToNewCorrectionList('NonApplicableCategoriesWithApplicableChannel')}>
           {t('tasks.nvi.correction_list_type.non_applicable_category_in_applicable_channel')}
         </SelectableButton>
       </NavigationList>

--- a/src/pages/messages/components/NviCorrectionListNavigationAccordion.tsx
+++ b/src/pages/messages/components/NviCorrectionListNavigationAccordion.tsx
@@ -13,17 +13,16 @@ export const NviCorrectionListNavigationAccordion = () => {
   const { t } = useTranslation();
   const history = useHistory();
   const searchParams = new URLSearchParams(history.location.search);
-
   const selectedNviList = searchParams.get(nviCorrectionListQueryKey);
 
-  const goToNewCorrectionList = (correctionListId: CorrectionListId) => {
-    if (selectedNviList !== correctionListId) {
+  const openNewCorrectionList = (newCorrectionListId: CorrectionListId) => {
+    if (selectedNviList !== newCorrectionListId) {
       const newSearchParams = new URLSearchParams();
       const currentSearchSize = searchParams.get(ResultParam.Results);
       if (currentSearchSize) {
         newSearchParams.set(ResultParam.Results, currentSearchSize);
       }
-      newSearchParams.set(nviCorrectionListQueryKey, correctionListId);
+      newSearchParams.set(nviCorrectionListQueryKey, newCorrectionListId);
       history.push({ search: newSearchParams.toString() });
     }
   };
@@ -45,13 +44,13 @@ export const NviCorrectionListNavigationAccordion = () => {
         <SelectableButton
           data-testid={dataTestId.tasksPage.correctionList.applicableCategoriesWithNonApplicableChannelButton}
           isSelected={selectedNviList === 'ApplicableCategoriesWithNonApplicableChannel'}
-          onClick={() => goToNewCorrectionList('ApplicableCategoriesWithNonApplicableChannel')}>
+          onClick={() => openNewCorrectionList('ApplicableCategoriesWithNonApplicableChannel')}>
           {t('tasks.nvi.correction_list_type.applicable_category_in_non_applicable_channel')}
         </SelectableButton>
         <SelectableButton
           data-testid={dataTestId.tasksPage.correctionList.nonApplicableCategoriesWithApplicableChannelButton}
           isSelected={selectedNviList === 'NonApplicableCategoriesWithApplicableChannel'}
-          onClick={() => goToNewCorrectionList('NonApplicableCategoriesWithApplicableChannel')}>
+          onClick={() => openNewCorrectionList('NonApplicableCategoriesWithApplicableChannel')}>
           {t('tasks.nvi.correction_list_type.non_applicable_category_in_applicable_channel')}
         </SelectableButton>
       </NavigationList>

--- a/src/pages/search/advanced_search/AdvancedSearchPage.tsx
+++ b/src/pages/search/advanced_search/AdvancedSearchPage.tsx
@@ -37,8 +37,8 @@ const StyledDivider = styled(Divider)(({ theme }) => ({
   backgroundColor: theme.palette.primary.main,
 }));
 
-const StyledTypography = styled(Typography)({
-  marginBottom: '0.25rem',
+export const StyledTypography = styled(Typography)({
+  marginBottom: '0.2rem',
   fontWeight: 'bold',
 });
 
@@ -128,7 +128,6 @@ export const AdvancedSearchPage = () => {
           {isLargeScreen && <StyledDivider orientation="vertical" flexItem />}
 
           <Grid item>
-            <StyledTypography>{t('common.category')}</StyledTypography>
             <CategorySearchFilter searchParam={ResultParam.CategoryShould} />
           </Grid>
 
@@ -173,7 +172,6 @@ export const AdvancedSearchPage = () => {
           {isLargeScreen && <StyledDivider orientation="vertical" flexItem />}
 
           <Grid item>
-            <StyledTypography>{t('common.institution')}</StyledTypography>
             <OrganizationFilters topLevelOrganizationId={topLevelOrganizationId} unitId={unitId} />
           </Grid>
         </Grid>
@@ -183,17 +181,14 @@ export const AdvancedSearchPage = () => {
         <Grid container item direction={isLargeScreen ? 'row' : 'column'} xs={12} gap={2}>
           <Grid container item direction={isLargeScreen ? 'row' : 'column'} gap={2}>
             <Grid item>
-              <StyledTypography>{t('common.publisher')}</StyledTypography>
               <PublisherFilter />
             </Grid>
 
             <Grid item>
-              <StyledTypography>{t('registration.resource_type.journal')}</StyledTypography>
               <JournalFilter />
             </Grid>
 
             <Grid item>
-              <StyledTypography>{t('registration.resource_type.series')}</StyledTypography>
               <SeriesFilter />
             </Grid>
           </Grid>

--- a/src/pages/search/advanced_search/AdvancedSearchPage.tsx
+++ b/src/pages/search/advanced_search/AdvancedSearchPage.tsx
@@ -37,7 +37,7 @@ const StyledDivider = styled(Divider)(({ theme }) => ({
   backgroundColor: theme.palette.primary.main,
 }));
 
-export const StyledTypography = styled(Typography)({
+export const StyledFilterTitle = styled(Typography)({
   marginBottom: '0.2rem',
   fontWeight: 'bold',
 });
@@ -107,7 +107,7 @@ export const AdvancedSearchPage = () => {
       <Grid container rowGap={2} sx={{ px: { xs: '0.5rem', md: 0 } }}>
         <Typography variant="h2">{t('search.advanced_search.advanced_search')}</Typography>
         <Grid item xs={12}>
-          <StyledTypography>{t('search.advanced_search.title_search')}</StyledTypography>
+          <StyledFilterTitle>{t('search.advanced_search.title_search')}</StyledFilterTitle>
           <Box sx={{ display: 'flex', gap: '0.5rem' }}>
             <SearchForm
               sx={{ flex: '1 0 15rem' }}
@@ -121,7 +121,7 @@ export const AdvancedSearchPage = () => {
 
         <Grid item container direction={isLargeScreen ? 'row' : 'column'} xs={12} gap={2}>
           <Grid item sx={{ width: 'fit-content' }}>
-            <StyledTypography>{t('search.advanced_search.publishing_period')}</StyledTypography>
+            <StyledFilterTitle>{t('search.advanced_search.publishing_period')}</StyledFilterTitle>
             <PublicationYearIntervalFilter />
           </Grid>
 
@@ -134,14 +134,14 @@ export const AdvancedSearchPage = () => {
           {isLargeScreen && <StyledDivider orientation="vertical" flexItem />}
 
           <Grid item>
-            <StyledTypography id="language-select-label">{t('common.language')}</StyledTypography>
+            <StyledFilterTitle id="language-select-label">{t('common.language')}</StyledFilterTitle>
             <LanguageFilter />
           </Grid>
 
           {isLargeScreen && <StyledDivider orientation="vertical" flexItem />}
 
           <Grid item>
-            <StyledTypography>{t('common.nvi')}</StyledTypography>
+            <StyledFilterTitle>{t('common.nvi')}</StyledFilterTitle>
             <FormControlLabel
               data-testid={dataTestId.startPage.advancedSearch.scientificIndexStatusCheckbox}
               control={<Checkbox name="scientificIndexStatus" />}
@@ -154,9 +154,9 @@ export const AdvancedSearchPage = () => {
           {isLargeScreen && <StyledDivider orientation="vertical" flexItem />}
 
           <Grid item>
-            <StyledTypography id="file-status-select-label">
+            <StyledFilterTitle id="file-status-select-label">
               {t('registration.files_and_license.files')}
-            </StyledTypography>
+            </StyledFilterTitle>
             <FileStatusSelect />
           </Grid>
         </Grid>
@@ -165,7 +165,7 @@ export const AdvancedSearchPage = () => {
 
         <Grid container item direction={isLargeScreen ? 'row' : 'column'} xs={12} gap={2}>
           <Grid item>
-            <StyledTypography>{t('registration.contributors.contributor')}</StyledTypography>
+            <StyledFilterTitle>{t('registration.contributors.contributor')}</StyledFilterTitle>
             <SearchForm paramName={ResultParam.ContributorName} placeholder={t('search.search_for_contributor')} />
           </Grid>
 
@@ -202,12 +202,12 @@ export const AdvancedSearchPage = () => {
 
         <Grid container item direction={isLargeScreen ? 'row' : 'column'} xs={12} gap={2}>
           <Grid item>
-            <StyledTypography>{t('common.financier')}</StyledTypography>
+            <StyledFilterTitle>{t('common.financier')}</StyledFilterTitle>
             <FundingSourceFilter />
           </Grid>
 
           <Grid item>
-            <StyledTypography>{t('project.grant_id')}</StyledTypography>
+            <StyledFilterTitle>{t('project.grant_id')}</StyledFilterTitle>
             <SearchForm
               paramName={ResultParam.FundingIdentifier}
               placeholder={t('search.search_for_funding_identifier')}
@@ -217,7 +217,7 @@ export const AdvancedSearchPage = () => {
           {isLargeScreen && <StyledDivider orientation="vertical" flexItem />}
 
           <Grid item>
-            <StyledTypography>{t('registration.resource_type.course_code')}</StyledTypography>
+            <StyledFilterTitle>{t('registration.resource_type.course_code')}</StyledFilterTitle>
             <SearchForm
               dataTestId={dataTestId.startPage.advancedSearch.courseField}
               paramName={ResultParam.Course}
@@ -228,7 +228,7 @@ export const AdvancedSearchPage = () => {
           {isLargeScreen && <StyledDivider orientation="vertical" flexItem />}
 
           <Grid item>
-            <StyledTypography>{t('editor.vocabulary')}</StyledTypography>
+            <StyledFilterTitle>{t('editor.vocabulary')}</StyledFilterTitle>
             <VocabularSearchField />
           </Grid>
         </Grid>

--- a/src/pages/search/advanced_search/JournalFilter.tsx
+++ b/src/pages/search/advanced_search/JournalFilter.tsx
@@ -15,6 +15,7 @@ import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
 import { keepSimilarPreviousData } from '../../../utils/searchHelpers';
 import { PublicationChannelOption } from '../../registration/resource_type_tab/components/PublicationChannelOption';
+import { StyledTypography } from './AdvancedSearchPage';
 
 export const JournalFilter = () => {
   const { t } = useTranslation();
@@ -59,48 +60,51 @@ export const JournalFilter = () => {
   const isFetching = journalParam ? selectedJournalQuery.isPending : journalOptionsQuery.isFetching;
 
   return (
-    <Autocomplete
-      size="small"
-      sx={{ minWidth: '15rem' }}
-      value={journalParam && selectedJournalQuery.data ? selectedJournalQuery.data : null}
-      isOptionEqualToValue={(option, value) => option.id === value.id}
-      options={options}
-      filterOptions={(options) => options}
-      inputValue={journalQuery}
-      onInputChange={(_, newInputValue) => setJournalQuery(newInputValue)}
-      onChange={(_, newValue) => handleChange(newValue)}
-      blurOnSelect
-      disableClearable={!journalQuery}
-      loading={isFetching}
-      getOptionLabel={(option) => option.name}
-      renderOption={({ key, ...props }, option, state) => (
-        <PublicationChannelOption
-          key={option.identifier}
-          props={props}
-          option={option}
-          state={state}
-          hideScientificLevel
-        />
-      )}
-      ListboxComponent={AutocompleteListboxWithExpansion}
-      ListboxProps={
-        {
-          hasMoreHits: !!journalOptionsQuery.data?.totalHits && journalOptionsQuery.data.totalHits > searchSize,
-          onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
-          isLoadingMoreHits: journalOptionsQuery.isFetching && searchSize > options.length,
-        } satisfies AutocompleteListboxWithExpansionProps as any
-      }
-      data-testid={dataTestId.startPage.advancedSearch.journalField}
-      renderInput={(params) => (
-        <AutocompleteTextField
-          {...params}
-          variant="outlined"
-          isLoading={isFetching}
-          placeholder={t('registration.resource_type.search_for_title_or_issn')}
-          showSearchIcon={!journalParam}
-          multiline
-        />
-      )}
-    />
+    <section>
+      <StyledTypography>{t('registration.resource_type.journal')}</StyledTypography>
+      <Autocomplete
+        size="small"
+        sx={{ minWidth: '15rem' }}
+        value={journalParam && selectedJournalQuery.data ? selectedJournalQuery.data : null}
+        isOptionEqualToValue={(option, value) => option.id === value.id}
+        options={options}
+        filterOptions={(options) => options}
+        inputValue={journalQuery}
+        onInputChange={(_, newInputValue) => setJournalQuery(newInputValue)}
+        onChange={(_, newValue) => handleChange(newValue)}
+        blurOnSelect
+        disableClearable={!journalQuery}
+        loading={isFetching}
+        getOptionLabel={(option) => option.name}
+        renderOption={({ key, ...props }, option, state) => (
+          <PublicationChannelOption
+            key={option.identifier}
+            props={props}
+            option={option}
+            state={state}
+            hideScientificLevel
+          />
+        )}
+        ListboxComponent={AutocompleteListboxWithExpansion}
+        ListboxProps={
+          {
+            hasMoreHits: !!journalOptionsQuery.data?.totalHits && journalOptionsQuery.data.totalHits > searchSize,
+            onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
+            isLoadingMoreHits: journalOptionsQuery.isFetching && searchSize > options.length,
+          } satisfies AutocompleteListboxWithExpansionProps as any
+        }
+        data-testid={dataTestId.startPage.advancedSearch.journalField}
+        renderInput={(params) => (
+          <AutocompleteTextField
+            {...params}
+            variant="outlined"
+            isLoading={isFetching}
+            placeholder={t('registration.resource_type.search_for_title_or_issn')}
+            showSearchIcon={!journalParam}
+            multiline
+          />
+        )}
+      />
+    </section>
   );
 };

--- a/src/pages/search/advanced_search/JournalFilter.tsx
+++ b/src/pages/search/advanced_search/JournalFilter.tsx
@@ -15,7 +15,7 @@ import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
 import { keepSimilarPreviousData } from '../../../utils/searchHelpers';
 import { PublicationChannelOption } from '../../registration/resource_type_tab/components/PublicationChannelOption';
-import { StyledTypography } from './AdvancedSearchPage';
+import { StyledFilterTitle } from './AdvancedSearchPage';
 
 export const JournalFilter = () => {
   const { t } = useTranslation();
@@ -61,7 +61,7 @@ export const JournalFilter = () => {
 
   return (
     <section>
-      <StyledTypography>{t('registration.resource_type.journal')}</StyledTypography>
+      <StyledFilterTitle>{t('registration.resource_type.journal')}</StyledFilterTitle>
       <Autocomplete
         size="small"
         sx={{ minWidth: '15rem' }}

--- a/src/pages/search/advanced_search/OrganizationFilters.tsx
+++ b/src/pages/search/advanced_search/OrganizationFilters.tsx
@@ -18,6 +18,7 @@ import { RootState } from '../../../redux/store';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
 import { getLanguageString } from '../../../utils/translation-helpers';
+import { StyledTypography } from './AdvancedSearchPage';
 import { OrganizationHierarchyFilter } from './OrganizationHierarchyFilter';
 
 interface OrganizationFiltersProps {
@@ -79,119 +80,122 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
   };
 
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        gap: '0.5rem 1rem',
-        flexDirection: { xs: 'column', lg: 'row' },
-        alignItems: { xs: 'start', lg: 'center' },
-      }}>
-      <Autocomplete
-        fullWidth
-        size="small"
-        options={options}
-        inputMode="search"
-        sx={{ minWidth: '15rem' }}
-        getOptionLabel={(option) => getLanguageString(option.labels)}
-        getOptionKey={(option) => option.id}
-        filterOptions={(options) => options}
-        onInputChange={(_, value, reason) => {
-          if (reason !== 'reset') {
-            setSearchTerm(value);
-          }
-        }}
-        onChange={(_, selectedInstitution) => {
-          if (selectedInstitution !== topLevelOrganizationId) {
-            const params = new URLSearchParams(history.location.search);
-            if (selectedInstitution) {
-              params.set(ResultParam.TopLevelOrganization, selectedInstitution.id);
-            } else {
-              params.delete(ResultParam.TopLevelOrganization);
-              params.delete(ResultParam.ExcludeSubunits);
+    <section>
+      <StyledTypography>{t('common.institution')}</StyledTypography>
+      <Box
+        sx={{
+          display: 'flex',
+          gap: '0.5rem 1rem',
+          flexDirection: { xs: 'column', lg: 'row' },
+          alignItems: { xs: 'start', lg: 'center' },
+        }}>
+        <Autocomplete
+          fullWidth
+          size="small"
+          options={options}
+          inputMode="search"
+          sx={{ minWidth: '15rem' }}
+          getOptionLabel={(option) => getLanguageString(option.labels)}
+          getOptionKey={(option) => option.id}
+          filterOptions={(options) => options}
+          onInputChange={(_, value, reason) => {
+            if (reason !== 'reset') {
+              setSearchTerm(value);
             }
-            params.set(ResultParam.From, '0');
-            params.delete(ResultParam.Unit);
-            history.push({ search: params.toString() });
-            setSearchTerm('');
-          }
-        }}
-        isOptionEqualToValue={(option, value) => option.id === value.id}
-        disabled={topLevelOrganizationQuery.isFetching}
-        value={topLevelOrganizationQuery.data ?? null}
-        loading={isLoading}
-        renderOption={({ key, ...props }, option) => (
-          <OrganizationRenderOption key={option.id} props={props} option={option} />
-        )}
-        ListboxComponent={AutocompleteListboxWithExpansion}
-        ListboxProps={
-          {
-            hasMoreHits: !!organizationSearchQuery.data?.size && organizationSearchQuery.data.size > searchSize,
-            onShowMoreHits: () => setSearchSize(searchSize + defaultOrganizationSearchSize),
-            isLoadingMoreHits: organizationSearchQuery.isFetching && searchSize > options.length,
-          } satisfies AutocompleteListboxWithExpansionProps as any
-        }
-        renderInput={(params) => (
-          <AutocompleteTextField
-            {...params}
-            variant="outlined"
-            multiline
-            isLoading={isLoading}
-            data-testid={dataTestId.organization.searchField}
-            placeholder={t('project.search_for_institution')}
-            showSearchIcon
-          />
-        )}
-      />
-
-      <Chip
-        data-testid={dataTestId.organization.subSearchField}
-        color="primary"
-        onClick={toggleShowUnitSelection}
-        label={
-          unitId ? (
-            subUnitQuery.isPending ? (
-              <Skeleton sx={{ minWidth: '10rem' }} />
-            ) : (
-              getLanguageString(subUnitQuery.data?.labels)
-            )
-          ) : (
-            <Box component="span" sx={{ textWrap: 'nowrap' }}>
-              {t('common.select_unit')}
-            </Box>
-          )
-        }
-        onDelete={
-          unitId
-            ? () => {
-                params.delete(ResultParam.From);
-                params.delete(ResultParam.Unit);
-                history.push({ search: params.toString() });
+          }}
+          onChange={(_, selectedInstitution) => {
+            if (selectedInstitution !== topLevelOrganizationId) {
+              const params = new URLSearchParams(history.location.search);
+              if (selectedInstitution) {
+                params.set(ResultParam.TopLevelOrganization, selectedInstitution.id);
+              } else {
+                params.delete(ResultParam.TopLevelOrganization);
+                params.delete(ResultParam.ExcludeSubunits);
               }
-            : undefined
-        }
-        sx={{ minWidth: unitId ? '15rem' : undefined }}
-        disabled={!topLevelOrganizationQuery.data?.hasPart || topLevelOrganizationQuery.data?.hasPart?.length === 0}
-      />
-
-      {topLevelOrganizationQuery.data && (
-        <OrganizationHierarchyFilter
-          organization={topLevelOrganizationQuery.data}
-          open={showUnitSelection}
-          onClose={toggleShowUnitSelection}
+              params.set(ResultParam.From, '0');
+              params.delete(ResultParam.Unit);
+              history.push({ search: params.toString() });
+              setSearchTerm('');
+            }
+          }}
+          isOptionEqualToValue={(option, value) => option.id === value.id}
+          disabled={topLevelOrganizationQuery.isFetching}
+          value={topLevelOrganizationQuery.data ?? null}
+          loading={isLoading}
+          renderOption={({ key, ...props }, option) => (
+            <OrganizationRenderOption key={option.id} props={props} option={option} />
+          )}
+          ListboxComponent={AutocompleteListboxWithExpansion}
+          ListboxProps={
+            {
+              hasMoreHits: !!organizationSearchQuery.data?.size && organizationSearchQuery.data.size > searchSize,
+              onShowMoreHits: () => setSearchSize(searchSize + defaultOrganizationSearchSize),
+              isLoadingMoreHits: organizationSearchQuery.isFetching && searchSize > options.length,
+            } satisfies AutocompleteListboxWithExpansionProps as any
+          }
+          renderInput={(params) => (
+            <AutocompleteTextField
+              {...params}
+              variant="outlined"
+              multiline
+              isLoading={isLoading}
+              data-testid={dataTestId.organization.searchField}
+              placeholder={t('project.search_for_institution')}
+              showSearchIcon
+            />
+          )}
         />
-      )}
 
-      <FormControlLabel
-        sx={{ whiteSpace: 'nowrap' }}
-        control={
-          <Checkbox
-            disabled={!topLevelOrganizationId}
-            onChange={handleCheckedExcludeSubunits}
-            checked={!!topLevelOrganizationId && excludeSubunits}
+        <Chip
+          data-testid={dataTestId.organization.subSearchField}
+          color="primary"
+          onClick={toggleShowUnitSelection}
+          label={
+            unitId ? (
+              subUnitQuery.isPending ? (
+                <Skeleton sx={{ minWidth: '10rem' }} />
+              ) : (
+                getLanguageString(subUnitQuery.data?.labels)
+              )
+            ) : (
+              <Box component="span" sx={{ textWrap: 'nowrap' }}>
+                {t('common.select_unit')}
+              </Box>
+            )
+          }
+          onDelete={
+            unitId
+              ? () => {
+                  params.delete(ResultParam.From);
+                  params.delete(ResultParam.Unit);
+                  history.push({ search: params.toString() });
+                }
+              : undefined
+          }
+          sx={{ minWidth: unitId ? '15rem' : undefined }}
+          disabled={!topLevelOrganizationQuery.data?.hasPart || topLevelOrganizationQuery.data?.hasPart?.length === 0}
+        />
+
+        {topLevelOrganizationQuery.data && (
+          <OrganizationHierarchyFilter
+            organization={topLevelOrganizationQuery.data}
+            open={showUnitSelection}
+            onClose={toggleShowUnitSelection}
           />
-        }
-        label={t('tasks.nvi.exclude_subunits')}
-      />
-    </Box>
+        )}
+
+        <FormControlLabel
+          sx={{ whiteSpace: 'nowrap' }}
+          control={
+            <Checkbox
+              disabled={!topLevelOrganizationId}
+              onChange={handleCheckedExcludeSubunits}
+              checked={!!topLevelOrganizationId && excludeSubunits}
+            />
+          }
+          label={t('tasks.nvi.exclude_subunits')}
+        />
+      </Box>
+    </section>
   );
 };

--- a/src/pages/search/advanced_search/OrganizationFilters.tsx
+++ b/src/pages/search/advanced_search/OrganizationFilters.tsx
@@ -24,9 +24,10 @@ import { OrganizationHierarchyFilter } from './OrganizationHierarchyFilter';
 interface OrganizationFiltersProps {
   topLevelOrganizationId: string | null;
   unitId: string | null;
+  disabled?: boolean;
 }
 
-export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: OrganizationFiltersProps) => {
+export const OrganizationFilters = ({ topLevelOrganizationId, unitId, disabled }: OrganizationFiltersProps) => {
   const { t } = useTranslation();
   const history = useHistory();
   const [searchTerm, setSearchTerm] = useState('');
@@ -119,7 +120,7 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
             }
           }}
           isOptionEqualToValue={(option, value) => option.id === value.id}
-          disabled={topLevelOrganizationQuery.isFetching}
+          disabled={disabled || topLevelOrganizationQuery.isFetching}
           value={topLevelOrganizationQuery.data ?? null}
           loading={isLoading}
           renderOption={({ key, ...props }, option) => (

--- a/src/pages/search/advanced_search/OrganizationFilters.tsx
+++ b/src/pages/search/advanced_search/OrganizationFilters.tsx
@@ -24,10 +24,9 @@ import { OrganizationHierarchyFilter } from './OrganizationHierarchyFilter';
 interface OrganizationFiltersProps {
   topLevelOrganizationId: string | null;
   unitId: string | null;
-  disabled?: boolean;
 }
 
-export const OrganizationFilters = ({ topLevelOrganizationId, unitId, disabled }: OrganizationFiltersProps) => {
+export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: OrganizationFiltersProps) => {
   const { t } = useTranslation();
   const history = useHistory();
   const [searchTerm, setSearchTerm] = useState('');
@@ -120,7 +119,7 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId, disabled }
             }
           }}
           isOptionEqualToValue={(option, value) => option.id === value.id}
-          disabled={disabled || topLevelOrganizationQuery.isFetching}
+          disabled={topLevelOrganizationQuery.isFetching}
           value={topLevelOrganizationQuery.data ?? null}
           loading={isLoading}
           renderOption={({ key, ...props }, option) => (

--- a/src/pages/search/advanced_search/OrganizationFilters.tsx
+++ b/src/pages/search/advanced_search/OrganizationFilters.tsx
@@ -18,7 +18,7 @@ import { RootState } from '../../../redux/store';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
 import { getLanguageString } from '../../../utils/translation-helpers';
-import { StyledTypography } from './AdvancedSearchPage';
+import { StyledFilterTitle } from './AdvancedSearchPage';
 import { OrganizationHierarchyFilter } from './OrganizationHierarchyFilter';
 
 interface OrganizationFiltersProps {
@@ -81,7 +81,7 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
 
   return (
     <section>
-      <StyledTypography>{t('common.institution')}</StyledTypography>
+      <StyledFilterTitle>{t('common.institution')}</StyledFilterTitle>
       <Box
         sx={{
           display: 'flex',

--- a/src/pages/search/advanced_search/PublisherFilter.tsx
+++ b/src/pages/search/advanced_search/PublisherFilter.tsx
@@ -15,6 +15,7 @@ import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
 import { keepSimilarPreviousData } from '../../../utils/searchHelpers';
 import { PublicationChannelOption } from '../../registration/resource_type_tab/components/PublicationChannelOption';
+import { StyledTypography } from './AdvancedSearchPage';
 
 export const PublisherFilter = () => {
   const { t } = useTranslation();
@@ -59,48 +60,51 @@ export const PublisherFilter = () => {
   const isFetching = publisherParam ? selectedPublisherQuery.isPending : publisherOptionsQuery.isFetching;
 
   return (
-    <Autocomplete
-      size="small"
-      sx={{ minWidth: '15rem' }}
-      value={publisherParam && selectedPublisherQuery.data ? selectedPublisherQuery.data : null}
-      isOptionEqualToValue={(option, value) => option.id === value.id}
-      options={options}
-      filterOptions={(options) => options}
-      inputValue={publisherQuery}
-      onInputChange={(_, newInputValue) => setPublisherQuery(newInputValue)}
-      onChange={(_, newValue) => handleChange(newValue)}
-      blurOnSelect
-      disableClearable={!publisherQuery}
-      loading={isFetching}
-      getOptionLabel={(option) => option.name}
-      renderOption={({ key, ...props }, option, state) => (
-        <PublicationChannelOption
-          key={option.identifier}
-          props={props}
-          option={option}
-          state={state}
-          hideScientificLevel
-        />
-      )}
-      ListboxComponent={AutocompleteListboxWithExpansion}
-      ListboxProps={
-        {
-          hasMoreHits: !!publisherOptionsQuery.data?.totalHits && publisherOptionsQuery.data.totalHits > searchSize,
-          onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
-          isLoadingMoreHits: publisherOptionsQuery.isFetching && searchSize > options.length,
-        } satisfies AutocompleteListboxWithExpansionProps as any
-      }
-      data-testid={dataTestId.startPage.advancedSearch.publisherField}
-      renderInput={(params) => (
-        <AutocompleteTextField
-          {...params}
-          variant="outlined"
-          isLoading={isFetching}
-          placeholder={t('registration.resource_type.search_for_publisher_placeholder')}
-          showSearchIcon={!publisherParam}
-          multiline
-        />
-      )}
-    />
+    <section>
+      <StyledTypography>{t('common.publisher')}</StyledTypography>
+      <Autocomplete
+        size="small"
+        sx={{ minWidth: '15rem' }}
+        value={publisherParam && selectedPublisherQuery.data ? selectedPublisherQuery.data : null}
+        isOptionEqualToValue={(option, value) => option.id === value.id}
+        options={options}
+        filterOptions={(options) => options}
+        inputValue={publisherQuery}
+        onInputChange={(_, newInputValue) => setPublisherQuery(newInputValue)}
+        onChange={(_, newValue) => handleChange(newValue)}
+        blurOnSelect
+        disableClearable={!publisherQuery}
+        loading={isFetching}
+        getOptionLabel={(option) => option.name}
+        renderOption={({ key, ...props }, option, state) => (
+          <PublicationChannelOption
+            key={option.identifier}
+            props={props}
+            option={option}
+            state={state}
+            hideScientificLevel
+          />
+        )}
+        ListboxComponent={AutocompleteListboxWithExpansion}
+        ListboxProps={
+          {
+            hasMoreHits: !!publisherOptionsQuery.data?.totalHits && publisherOptionsQuery.data.totalHits > searchSize,
+            onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
+            isLoadingMoreHits: publisherOptionsQuery.isFetching && searchSize > options.length,
+          } satisfies AutocompleteListboxWithExpansionProps as any
+        }
+        data-testid={dataTestId.startPage.advancedSearch.publisherField}
+        renderInput={(params) => (
+          <AutocompleteTextField
+            {...params}
+            variant="outlined"
+            isLoading={isFetching}
+            placeholder={t('registration.resource_type.search_for_publisher_placeholder')}
+            showSearchIcon={!publisherParam}
+            multiline
+          />
+        )}
+      />
+    </section>
   );
 };

--- a/src/pages/search/advanced_search/PublisherFilter.tsx
+++ b/src/pages/search/advanced_search/PublisherFilter.tsx
@@ -15,7 +15,7 @@ import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
 import { keepSimilarPreviousData } from '../../../utils/searchHelpers';
 import { PublicationChannelOption } from '../../registration/resource_type_tab/components/PublicationChannelOption';
-import { StyledTypography } from './AdvancedSearchPage';
+import { StyledFilterTitle } from './AdvancedSearchPage';
 
 export const PublisherFilter = () => {
   const { t } = useTranslation();
@@ -61,7 +61,7 @@ export const PublisherFilter = () => {
 
   return (
     <section>
-      <StyledTypography>{t('common.publisher')}</StyledTypography>
+      <StyledFilterTitle>{t('common.publisher')}</StyledFilterTitle>
       <Autocomplete
         size="small"
         sx={{ minWidth: '15rem' }}

--- a/src/pages/search/advanced_search/SeriesFilter.tsx
+++ b/src/pages/search/advanced_search/SeriesFilter.tsx
@@ -15,7 +15,7 @@ import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
 import { keepSimilarPreviousData } from '../../../utils/searchHelpers';
 import { PublicationChannelOption } from '../../registration/resource_type_tab/components/PublicationChannelOption';
-import { StyledTypography } from './AdvancedSearchPage';
+import { StyledFilterTitle } from './AdvancedSearchPage';
 
 export const SeriesFilter = () => {
   const { t } = useTranslation();
@@ -61,7 +61,7 @@ export const SeriesFilter = () => {
 
   return (
     <section>
-      <StyledTypography>{t('registration.resource_type.series')}</StyledTypography>
+      <StyledFilterTitle>{t('registration.resource_type.series')}</StyledFilterTitle>
       <Autocomplete
         size="small"
         sx={{ minWidth: '15rem' }}

--- a/src/pages/search/advanced_search/SeriesFilter.tsx
+++ b/src/pages/search/advanced_search/SeriesFilter.tsx
@@ -15,6 +15,7 @@ import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
 import { keepSimilarPreviousData } from '../../../utils/searchHelpers';
 import { PublicationChannelOption } from '../../registration/resource_type_tab/components/PublicationChannelOption';
+import { StyledTypography } from './AdvancedSearchPage';
 
 export const SeriesFilter = () => {
   const { t } = useTranslation();
@@ -59,48 +60,51 @@ export const SeriesFilter = () => {
   const isFetching = seriesParam ? selectedSeriesQuery.isPending : seriesOptionsQuery.isFetching;
 
   return (
-    <Autocomplete
-      size="small"
-      sx={{ minWidth: '15rem' }}
-      value={seriesParam && selectedSeriesQuery.data ? selectedSeriesQuery.data : null}
-      isOptionEqualToValue={(option, value) => option.id === value.id}
-      options={options}
-      filterOptions={(options) => options}
-      inputValue={seriesQuery}
-      onInputChange={(_, newInputValue) => setSeriesQuery(newInputValue)}
-      onChange={(_, newValue) => handleChange(newValue)}
-      blurOnSelect
-      disableClearable={!seriesQuery}
-      loading={isFetching}
-      getOptionLabel={(option) => option.name}
-      renderOption={({ key, ...props }, option, state) => (
-        <PublicationChannelOption
-          key={option.identifier}
-          props={props}
-          option={option}
-          state={state}
-          hideScientificLevel
-        />
-      )}
-      ListboxComponent={AutocompleteListboxWithExpansion}
-      ListboxProps={
-        {
-          hasMoreHits: !!seriesOptionsQuery.data?.totalHits && seriesOptionsQuery.data.totalHits > searchSize,
-          onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
-          isLoadingMoreHits: seriesOptionsQuery.isFetching && searchSize > options.length,
-        } satisfies AutocompleteListboxWithExpansionProps as any
-      }
-      data-testid={dataTestId.startPage.advancedSearch.seriesField}
-      renderInput={(params) => (
-        <AutocompleteTextField
-          {...params}
-          variant="outlined"
-          isLoading={isFetching}
-          placeholder={t('registration.resource_type.search_for_title_or_issn')}
-          showSearchIcon={!seriesParam}
-          multiline
-        />
-      )}
-    />
+    <section>
+      <StyledTypography>{t('registration.resource_type.series')}</StyledTypography>
+      <Autocomplete
+        size="small"
+        sx={{ minWidth: '15rem' }}
+        value={seriesParam && selectedSeriesQuery.data ? selectedSeriesQuery.data : null}
+        isOptionEqualToValue={(option, value) => option.id === value.id}
+        options={options}
+        filterOptions={(options) => options}
+        inputValue={seriesQuery}
+        onInputChange={(_, newInputValue) => setSeriesQuery(newInputValue)}
+        onChange={(_, newValue) => handleChange(newValue)}
+        blurOnSelect
+        disableClearable={!seriesQuery}
+        loading={isFetching}
+        getOptionLabel={(option) => option.name}
+        renderOption={({ key, ...props }, option, state) => (
+          <PublicationChannelOption
+            key={option.identifier}
+            props={props}
+            option={option}
+            state={state}
+            hideScientificLevel
+          />
+        )}
+        ListboxComponent={AutocompleteListboxWithExpansion}
+        ListboxProps={
+          {
+            hasMoreHits: !!seriesOptionsQuery.data?.totalHits && seriesOptionsQuery.data.totalHits > searchSize,
+            onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
+            isLoadingMoreHits: seriesOptionsQuery.isFetching && searchSize > options.length,
+          } satisfies AutocompleteListboxWithExpansionProps as any
+        }
+        data-testid={dataTestId.startPage.advancedSearch.seriesField}
+        renderInput={(params) => (
+          <AutocompleteTextField
+            {...params}
+            variant="outlined"
+            isLoading={isFetching}
+            placeholder={t('registration.resource_type.search_for_title_or_issn')}
+            showSearchIcon={!seriesParam}
+            multiline
+          />
+        )}
+      />
+    </section>
   );
 };

--- a/src/utils/dataTestIds.ts
+++ b/src/utils/dataTestIds.ts
@@ -196,6 +196,7 @@ export const dataTestId = {
         levelZeroCheckbox: 'level-zero-checkbox',
       },
       searchButton: 'search-button',
+      selectCategoryChip: 'select-category-chip',
       seriesField: 'series-field',
       vocabularyField: 'vocabulary-field',
     },


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47571

Vis andre filter man kan bruke i tillegg til satte filter for NVI-kooreksjonsliste. Har også flyttet tittel til feltene inn til samme komponent som feltet, for å unngå å måtte oppgi det på nytt hver gang.

Lagt til følgende filter:
- Institusjon og enhet
- Kategori
- Kanal (tidsskrift, utgiver og serie)

Har i tillegg lagt til støtte for å disable søkefelter som kan/vil være i konflikt med bestemte rettelister.

![bilde](https://github.com/user-attachments/assets/481235f0-e358-43db-a096-e828b07639ef)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [ ] The changes are tested OK for different screen sizes
   > Sleit med å få til en god løsning for mobilløsning av dette, så endte opp med noe litt hallveis der. Sleit med at det ser ut som feltene er knyttet til Griden som brukes i avansert søk, så fant ikke noen god løsning som ikke krever en rewrite av det også, så da lar jeg det ligge. Se gjerne om dere ser noen enkle løsninger.
- [ ] The changes are tested OK for a11y
  > Har noen minor issues pga aria role som jeg ikke har funnet en god løsning på. Dette gjelder også på avansert søk fra før.
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
