### PR TITLE
Np 47593 handle fetching unpublished results

### DIFF
--- a/src/api/hooks/useFetchRegistration.ts
+++ b/src/api/hooks/useFetchRegistration.ts
@@ -29,6 +29,8 @@ export const useFetchRegistration = (
         query: Query<Registration, AxiosError<DeletedRegistrationProblem>>
       ) => {
         if (error.response?.status === 410) {
+          // Fetching an unpublished results will return a 410 Gone (client error) response.
+          // The frontend should then use the supplied 'resource' property instead, and treat it as an successful GET.
           const errorRegistration = query.state.error?.response?.data?.resource;
           if (errorRegistration) {
             query.setData(errorRegistration);

--- a/src/api/hooks/useFetchRegistration.ts
+++ b/src/api/hooks/useFetchRegistration.ts
@@ -7,7 +7,7 @@ import { DeletedRegistrationProblem } from '../../types/error_responses';
 import { Registration } from '../../types/registration.types';
 import { fetchRegistration } from '../registrationApi';
 
-export const useFetchRegistration = (identifier: string, shouldNotRedirect?: boolean) => {
+export const useFetchRegistration = (identifier = '', shouldNotRedirect?: boolean) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
 

--- a/src/api/hooks/useFetchRegistration.ts
+++ b/src/api/hooks/useFetchRegistration.ts
@@ -1,0 +1,39 @@
+import { Query, useQuery } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
+import { setNotification } from '../../redux/notificationSlice';
+import { DeletedRegistrationProblem } from '../../types/error_responses';
+import { Registration } from '../../types/registration.types';
+import { fetchRegistration } from '../registrationApi';
+
+export const useFetchRegistration = (identifier: string, shouldNotRedirect?: boolean) => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+
+  return useQuery({
+    queryKey: ['registration', identifier, shouldNotRedirect],
+    enabled: !!identifier,
+    queryFn: () => fetchRegistration(identifier, shouldNotRedirect),
+    meta: {
+      handleError: (
+        error: AxiosError<DeletedRegistrationProblem>,
+        query: Query<Registration, AxiosError<DeletedRegistrationProblem>>
+      ) => {
+        if (error.response?.status === 410) {
+          const errorRegistration = query.state.error?.response?.data?.resource;
+          if (errorRegistration) {
+            query.setData(errorRegistration);
+          }
+        } else {
+          dispatch(
+            setNotification({
+              message: t('feedback.error.get_registration'),
+              variant: 'error',
+            })
+          );
+        }
+      },
+    },
+  });
+};

--- a/src/api/hooks/useFetchRegistration.ts
+++ b/src/api/hooks/useFetchRegistration.ts
@@ -7,13 +7,21 @@ import { DeletedRegistrationProblem } from '../../types/error_responses';
 import { Registration } from '../../types/registration.types';
 import { fetchRegistration } from '../registrationApi';
 
-export const useFetchRegistration = (identifier = '', shouldNotRedirect?: boolean) => {
+interface FetchRegistrationConfig {
+  enabled?: boolean;
+  shouldNotRedirect?: boolean;
+}
+
+export const useFetchRegistration = (
+  identifier = '',
+  { enabled = true, shouldNotRedirect = false }: FetchRegistrationConfig = {}
+) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
 
   return useQuery({
     queryKey: ['registration', identifier, shouldNotRedirect],
-    enabled: !!identifier,
+    enabled: enabled && !!identifier,
     queryFn: () => fetchRegistration(identifier, shouldNotRedirect),
     meta: {
       handleError: (

--- a/src/pages/basic_data/app_admin/central_import/CentralImportCandidateMerge.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportCandidateMerge.tsx
@@ -6,12 +6,8 @@ import { getLanguageByUri } from 'nva-language';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { Redirect, useHistory, useParams } from 'react-router-dom';
-import {
-  fetchImportCandidate,
-  fetchRegistration,
-  updateImportCandidateStatus,
-  updateRegistration,
-} from '../../../../api/registrationApi';
+import { useFetchRegistration } from '../../../../api/hooks/useFetchRegistration';
+import { fetchImportCandidate, updateImportCandidateStatus, updateRegistration } from '../../../../api/registrationApi';
 import { PageSpinner } from '../../../../components/PageSpinner';
 import { setNotification } from '../../../../redux/notificationSlice';
 import { AssociatedLink } from '../../../../types/associatedArtifact.types';
@@ -42,11 +38,7 @@ export const CentralImportCandidateMerge = () => {
   const history = useHistory<BasicDataLocationState>();
   const { candidateIdentifier, registrationIdentifier } = useParams<MergeImportCandidateParams>();
 
-  const registrationQuery = useQuery({
-    queryKey: ['registration', registrationIdentifier],
-    queryFn: () => fetchRegistration(registrationIdentifier),
-    meta: { errorMessage: t('feedback.error.get_registration') },
-  });
+  const registrationQuery = useFetchRegistration(registrationIdentifier);
 
   const importCandidateQuery = useQuery({
     queryKey: ['importCandidate', candidateIdentifier],

--- a/src/pages/basic_data/app_admin/central_import/CentralImportDuplicationCheckPage.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportDuplicationCheckPage.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { Link, useLocation, useParams } from 'react-router-dom';
-import { fetchImportCandidate, fetchRegistration, updateImportCandidateStatus } from '../../../../api/registrationApi';
+import { useFetchRegistration } from '../../../../api/hooks/useFetchRegistration';
+import { fetchImportCandidate, updateImportCandidateStatus } from '../../../../api/registrationApi';
 import { FetchImportCandidatesParams, fetchImportCandidates } from '../../../../api/searchApi';
 import { ConfirmMessageDialog } from '../../../../components/ConfirmMessageDialog';
 import { PageSpinner } from '../../../../components/PageSpinner';
@@ -70,12 +71,9 @@ export const CentralImportDuplicationCheckPage = () => {
       ),
   });
 
-  const importedRegistrationId = importCandidate?.importStatus.nvaPublicationId ?? '';
-  const importedRegistrationQuery = useQuery({
-    queryKey: ['registration', importedRegistrationId],
-    enabled: importCandidate?.importStatus.candidateStatus === 'IMPORTED' && !!importedRegistrationId,
-    queryFn: () => fetchRegistration(getIdentifierFromId(importedRegistrationId)),
-    meta: { errorMessage: t('feedback.error.get_registration') },
+  const importedRegistrationIdentifier = getIdentifierFromId(importCandidate?.importStatus.nvaPublicationId ?? '');
+  const importedRegistrationQuery = useFetchRegistration(importedRegistrationIdentifier, {
+    enabled: importCandidate?.importStatus.candidateStatus === 'IMPORTED',
   });
 
   useEffect(() => {

--- a/src/pages/messages/components/NviCandidatePage.tsx
+++ b/src/pages/messages/components/NviCandidatePage.tsx
@@ -4,7 +4,7 @@ import { AxiosError } from 'axios';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useParams } from 'react-router-dom';
 import { useFetchNviCandidates } from '../../../api/hooks/useFetchNviCandidates';
-import { fetchRegistration } from '../../../api/registrationApi';
+import { useFetchRegistration } from '../../../api/hooks/useFetchRegistration';
 import { fetchNviCandidate } from '../../../api/searchApi';
 import { ErrorBoundary } from '../../../components/ErrorBoundary';
 import { PageSpinner } from '../../../components/PageSpinner';
@@ -44,12 +44,7 @@ export const NviCandidatePage = () => {
   const periodStatus = nviCandidate?.period.status;
   const registrationIdentifier = getIdentifierFromId(nviCandidate?.publicationId ?? '');
 
-  const registrationQuery = useQuery({
-    enabled: !!registrationIdentifier,
-    queryKey: ['registration', registrationIdentifier],
-    queryFn: () => fetchRegistration(registrationIdentifier),
-    meta: { errorMessage: t('feedback.error.get_registration') },
-  });
+  const registrationQuery = useFetchRegistration(registrationIdentifier);
 
   const nviQueryParams = location.state?.candidateOffsetState?.nviQueryParams;
   const thisCandidateOffset = location.state?.candidateOffsetState?.currentOffset;

--- a/src/pages/public_registration/ChapterPublisherInfo.tsx
+++ b/src/pages/public_registration/ChapterPublisherInfo.tsx
@@ -1,7 +1,6 @@
 import { Box, Typography } from '@mui/material';
-import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { fetchRegistration } from '../../api/registrationApi';
+import { useFetchRegistration } from '../../api/hooks/useFetchRegistration';
 import { BookPublicationContext } from '../../types/publication_types/bookRegistration.types';
 import { ChapterPublicationContext } from '../../types/publication_types/chapterRegistration.types';
 import { ReportPublicationContext } from '../../types/publication_types/reportRegistration.types';
@@ -16,13 +15,7 @@ export const ChapterPublisherInfo = ({ publicationContext }: ChapterPublisherInf
   const { t } = useTranslation();
 
   const identifier = publicationContext.id ? getIdentifierFromId(publicationContext.id) : '';
-
-  const publisherQuery = useQuery({
-    enabled: !!identifier,
-    queryKey: ['registration', identifier],
-    queryFn: () => fetchRegistration(identifier),
-    meta: { errorMessage: t('feedback.error.search') },
-  });
+  const publisherQuery = useFetchRegistration(identifier);
 
   const publisherPublicationContext = publisherQuery.data?.entityDescription?.reference?.publicationContext as
     | BookPublicationContext

--- a/src/pages/public_registration/DeletedPublicationInformation.tsx
+++ b/src/pages/public_registration/DeletedPublicationInformation.tsx
@@ -1,7 +1,6 @@
 import { Box, Link, Typography } from '@mui/material';
-import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { fetchRegistration } from '../../api/registrationApi';
+import { useFetchRegistration } from '../../api/hooks/useFetchRegistration';
 import { PageSpinner } from '../../components/PageSpinner';
 import { Registration, RegistrationStatus } from '../../types/registration.types';
 import { getIdentifierFromId } from '../../utils/general-helpers';
@@ -16,11 +15,7 @@ export const DeletedPublicationInformation = ({ registration }: DeletePublicatio
 
   const originalIdentifier = registration.duplicateOf ? getIdentifierFromId(registration.duplicateOf) : '';
 
-  const originalRegistrationQuery = useQuery({
-    queryKey: ['registration', originalIdentifier],
-    queryFn: () => fetchRegistration(originalIdentifier ?? ''),
-    enabled: !!originalIdentifier,
-  });
+  const originalRegistrationQuery = useFetchRegistration(originalIdentifier);
   const originalRegistration = originalRegistrationQuery.data;
 
   const originalRegistrationMainTitle = getTitleString(originalRegistration?.entityDescription?.mainTitle);

--- a/src/pages/public_registration/PublicPublicationContext.tsx
+++ b/src/pages/public_registration/PublicPublicationContext.tsx
@@ -24,7 +24,7 @@ import { hyphenate } from 'isbn3';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { fetchResource } from '../../api/commonApi';
-import { fetchRegistration } from '../../api/registrationApi';
+import { useFetchRegistration } from '../../api/hooks/useFetchRegistration';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
 import { ListSkeleton } from '../../components/ListSkeleton';
 import { NpiLevelTypography } from '../../components/NpiLevelTypography';
@@ -314,12 +314,7 @@ const PublicOutputRow = ({ output, showType }: PublicOutputRowProps) => {
   const exhibitionCatalogIdentifier =
     output.type === 'ExhibitionCatalog' && output.id ? getIdentifierFromId(output.id) : '';
 
-  const exhibitionCatalogQuery = useQuery({
-    enabled: !!exhibitionCatalogIdentifier,
-    queryKey: ['registration', exhibitionCatalogIdentifier],
-    queryFn: () => fetchRegistration(exhibitionCatalogIdentifier),
-    meta: { errorMessage: t('feedback.error.get_registration') },
-  });
+  const exhibitionCatalogQuery = useFetchRegistration(exhibitionCatalogIdentifier);
 
   const nameString = exhibitionCatalogIdentifier
     ? exhibitionCatalogQuery.data?.entityDescription?.mainTitle

--- a/src/pages/public_registration/RegistrationLandingPage.tsx
+++ b/src/pages/public_registration/RegistrationLandingPage.tsx
@@ -1,15 +1,12 @@
 import { Box } from '@mui/material';
-import { Query, useQuery } from '@tanstack/react-query';
-import { AxiosError } from 'axios';
+import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { useDispatch } from 'react-redux';
 import { useHistory, useParams } from 'react-router-dom';
-import { fetchRegistration, fetchRegistrationTickets } from '../../api/registrationApi';
+import { useFetchRegistration } from '../../api/hooks/useFetchRegistration';
+import { fetchRegistrationTickets } from '../../api/registrationApi';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
 import { PageSpinner } from '../../components/PageSpinner';
-import { setNotification } from '../../redux/notificationSlice';
-import { DeletedRegistrationProblem } from '../../types/error_responses';
-import { Registration, RegistrationStatus } from '../../types/registration.types';
+import { RegistrationStatus } from '../../types/registration.types';
 import { userCanEditRegistration } from '../../utils/registration-helpers';
 import { IdentifierParams } from '../../utils/urlPaths';
 import NotFound from '../errorpages/NotFound';
@@ -20,34 +17,9 @@ import { PublicRegistrationContent } from './PublicRegistrationContent';
 export const RegistrationLandingPage = () => {
   const history = useHistory();
   const { t } = useTranslation();
-  const dispatch = useDispatch();
   const { identifier } = useParams<IdentifierParams>();
   const shouldNotRedirect = new URLSearchParams(history.location.search).has('shouldNotRedirect');
-
-  const registrationQuery = useQuery({
-    queryKey: ['registration', identifier, shouldNotRedirect],
-    queryFn: () => fetchRegistration(identifier, shouldNotRedirect),
-    meta: {
-      handleError: (
-        error: AxiosError<DeletedRegistrationProblem>,
-        query: Query<Registration, AxiosError<DeletedRegistrationProblem>>
-      ) => {
-        if (error.response?.status === 410) {
-          const errorRegistration = query.state.error?.response?.data?.resource;
-          if (errorRegistration) {
-            query.setData(errorRegistration);
-          }
-        } else {
-          dispatch(
-            setNotification({
-              message: t('feedback.error.get_registration'),
-              variant: 'error',
-            })
-          );
-        }
-      },
-    },
-  });
+  const registrationQuery = useFetchRegistration(identifier, shouldNotRedirect);
 
   const registration = registrationQuery.data;
   const registrationId = registration?.id;

--- a/src/pages/public_registration/RegistrationLandingPage.tsx
+++ b/src/pages/public_registration/RegistrationLandingPage.tsx
@@ -19,7 +19,7 @@ export const RegistrationLandingPage = () => {
   const { t } = useTranslation();
   const { identifier } = useParams<IdentifierParams>();
   const shouldNotRedirect = new URLSearchParams(history.location.search).has('shouldNotRedirect');
-  const registrationQuery = useFetchRegistration(identifier, shouldNotRedirect);
+  const registrationQuery = useFetchRegistration(identifier, { shouldNotRedirect });
 
   const registration = registrationQuery.data;
   const registrationId = registration?.id;

--- a/src/pages/public_registration/RegistrationSummary.tsx
+++ b/src/pages/public_registration/RegistrationSummary.tsx
@@ -1,8 +1,6 @@
 import { Link, Skeleton } from '@mui/material';
-import { useQuery } from '@tanstack/react-query';
-import { useTranslation } from 'react-i18next';
 import { Link as RouterLink } from 'react-router-dom';
-import { fetchRegistration } from '../../api/registrationApi';
+import { useFetchRegistration } from '../../api/hooks/useFetchRegistration';
 import { getIdentifierFromId } from '../../utils/general-helpers';
 import { getTitleString } from '../../utils/registration-helpers';
 import { getRegistrationLandingPagePath } from '../../utils/urlPaths';
@@ -12,15 +10,8 @@ interface RegistrationSummaryProps {
 }
 
 export const RegistrationSummary = ({ id }: RegistrationSummaryProps) => {
-  const { t } = useTranslation();
-
   const identifier = getIdentifierFromId(id);
-
-  const containerQuery = useQuery({
-    queryKey: ['registration', identifier],
-    queryFn: () => fetchRegistration(identifier),
-    meta: { errorMessage: t('feedback.error.search') },
-  });
+  const containerQuery = useFetchRegistration(identifier);
 
   const container = containerQuery.data;
 

--- a/src/pages/public_registration/action_accordions/DeletedRegistrationInformation.tsx
+++ b/src/pages/public_registration/action_accordions/DeletedRegistrationInformation.tsx
@@ -1,8 +1,7 @@
 import { Box, Link, Skeleton, Typography } from '@mui/material';
-import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
+import { useFetchRegistration } from '../../../api/hooks/useFetchRegistration';
 import { useFetchUserQuery } from '../../../api/hooks/useFetchUserQuery';
-import { fetchRegistration } from '../../../api/registrationApi';
 import { ProfilePicture } from '../../../components/ProfilePicture';
 import { PublicationNote, Registration } from '../../../types/registration.types';
 import { toDateString } from '../../../utils/date-helpers';
@@ -22,13 +21,7 @@ export const DeletedRegistrationInformation = ({
   const { t } = useTranslation();
 
   const duplicateRegistrationIdentifier = getIdentifierFromId(registration.duplicateOf ?? '');
-
-  const duplicateRegistrationQuery = useQuery({
-    enabled: !!duplicateRegistrationIdentifier,
-    queryKey: ['registration', duplicateRegistrationIdentifier],
-    queryFn: () => fetchRegistration(duplicateRegistrationIdentifier),
-    meta: { errorMessage: t('feedback.error.get_registration') },
-  });
+  const duplicateRegistrationQuery = useFetchRegistration(duplicateRegistrationIdentifier);
 
   const senderQuery = useFetchUserQuery(unpublishingNote.createdBy ?? '');
 

--- a/src/pages/registration/RegistrationForm.tsx
+++ b/src/pages/registration/RegistrationForm.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
-import { fetchRegistration } from '../../api/registrationApi';
+import { useFetchRegistration } from '../../api/hooks/useFetchRegistration';
 import { fetchNviCandidateForRegistration } from '../../api/scientificIndexApi';
 import { ConfirmDialog } from '../../components/ConfirmDialog';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
@@ -47,12 +47,7 @@ export const RegistrationForm = ({ identifier }: RegistrationFormProps) => {
   const highestValidatedTab =
     useLocation<RegistrationFormLocationState>().state?.highestValidatedTab ?? RegistrationTab.FilesAndLicenses;
 
-  const registrationQuery = useQuery({
-    enabled: !!identifier,
-    queryKey: ['registration', identifier],
-    queryFn: () => fetchRegistration(identifier),
-    meta: { errorMessage: t('feedback.error.get_registration') },
-  });
+  const registrationQuery = useFetchRegistration(identifier);
   const registration = registrationQuery.data;
   const registrationId = registrationQuery.data?.id ?? '';
   const canHaveNviCandidate =

--- a/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/OutputRow.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/OutputRow.tsx
@@ -3,10 +3,9 @@ import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import CancelIcon from '@mui/icons-material/Cancel';
 import EditIcon from '@mui/icons-material/Edit';
 import { Box, Button, Skeleton, TableCell, TableRow, Tooltip, Typography } from '@mui/material';
-import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { fetchRegistration } from '../../../../../api/registrationApi';
+import { useFetchRegistration } from '../../../../../api/hooks/useFetchRegistration';
 import { ConfirmDialog } from '../../../../../components/ConfirmDialog';
 import {
   ArtisticOutputItem,
@@ -85,12 +84,7 @@ export const OutputRow = ({
   const shouldFetchItem = item.type === 'ExhibitionCatalog';
   const exhibitionCatalogIdentifier = shouldFetchItem && item.id ? getIdentifierFromId(item.id) : '';
 
-  const exhibitionCatalogQuery = useQuery({
-    enabled: !!exhibitionCatalogIdentifier,
-    queryKey: ['registration', exhibitionCatalogIdentifier],
-    queryFn: () => fetchRegistration(exhibitionCatalogIdentifier),
-    meta: { errorMessage: t('feedback.error.get_registration') },
-  });
+  const exhibitionCatalogQuery = useFetchRegistration(exhibitionCatalogIdentifier);
 
   const title = shouldFetchItem ? exhibitionCatalogQuery.data?.entityDescription?.mainTitle : getOutputName(item);
 


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47593

Håndter henting av resultat som har blitt avpublisert, da vi i de tilfellene vil vise ene propertyen i responsen som data, og ignorere at det gir en `410 Gone` klient error.
Eksempel: https://dev.nva.sikt.no/registration/0191ea9a2606-aaa0bc79-e5a1-49e1-8f8d-a9036838c789/edit

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
