### PR TITLE
NP-47600 Show assign doi popup for rejected DOI request on result without file

### DIFF
--- a/src/pages/public_registration/action_accordions/DoiRequestAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/DoiRequestAccordion.tsx
@@ -346,6 +346,22 @@ export const DoiRequestAccordion = ({
           </DialogActions>
         </Modal>
 
+        <ConfirmDialog
+          open={showConfirmDialogAssignDoi}
+          title={t('registration.public_page.tasks_panel.no_published_files_on_registration')}
+          onAccept={async () => {
+            await approveTicketMutation.mutateAsync();
+            toggleConfirmDialogAssignDoi();
+          }}
+          isLoading={isLoadingData || approveTicketMutation.isPending}
+          onCancel={toggleConfirmDialogAssignDoi}>
+          <Trans
+            t={t}
+            i18nKey="registration.public_page.tasks_panel.no_published_files_on_registration_description"
+            components={[<Typography paragraph key="1" />]}
+          />
+        </ConfirmDialog>
+
         {userIsCurator && isPublishedRegistration && isPendingDoiRequest && (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', mt: '1rem' }}>
             <Typography>{t('registration.public_page.tasks_panel.assign_doi_about')}</Typography>
@@ -361,22 +377,6 @@ export const DoiRequestAccordion = ({
               disabled={isLoadingData || approveTicketMutation.isPending}>
               {t('common.reject_doi')}
             </Button>
-
-            <ConfirmDialog
-              open={showConfirmDialogAssignDoi}
-              title={t('registration.public_page.tasks_panel.no_published_files_on_registration')}
-              onAccept={async () => {
-                await approveTicketMutation.mutateAsync();
-                toggleConfirmDialogAssignDoi();
-              }}
-              isLoading={isLoadingData || approveTicketMutation.isPending}
-              onCancel={toggleConfirmDialogAssignDoi}>
-              <Trans
-                t={t}
-                i18nKey="registration.public_page.tasks_panel.no_published_files_on_registration_description"
-                components={[<Typography paragraph key="1" />]}
-              />
-            </ConfirmDialog>
 
             <ConfirmMessageDialog
               open={openRejectDoiDialog}


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47600

Sørg for at man kan vise bekreftelsesdialog også for resultat uten filer.
Dette er en glipp fra https://github.com/BIBSYSDEV/NVA-Frontend/pull/6162.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
