### PR TITLE
Np 47652 show loading indicator when searching

### DIFF
--- a/src/pages/search/person_search/PersonSearch.tsx
+++ b/src/pages/search/person_search/PersonSearch.tsx
@@ -50,7 +50,7 @@ export const PersonSearch = ({ personQuery }: PersonSearchProps) => {
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-      {personQuery.isPending ? (
+      {personQuery.isFetching ? (
         <ListSkeleton arrayLength={3} minWidth={40} height={100} />
       ) : searchResults && searchResults.length > 0 ? (
         <div>

--- a/src/pages/search/project_search/ProjectSearch.tsx
+++ b/src/pages/search/project_search/ProjectSearch.tsx
@@ -27,7 +27,7 @@ export const ProjectSearch = ({ projectQuery }: ProjectSearchProps) => {
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-      {projectQuery.isPending ? (
+      {projectQuery.isFetching ? (
         <ListSkeleton arrayLength={3} minWidth={40} height={100} />
       ) : projectsSearchResults && projectsSearchResults.length > 0 ? (
         <div>

--- a/src/pages/search/registration_search/RegistrationSearch.tsx
+++ b/src/pages/search/registration_search/RegistrationSearch.tsx
@@ -31,19 +31,17 @@ export const RegistrationSearch = ({ registrationQuery }: Pick<SearchPageProps, 
       {registrationQuery.isFetching ? (
         <ListSkeleton arrayLength={3} minWidth={40} height={100} />
       ) : registrationQuery.data?.hits && registrationQuery.data.hits.length > 0 ? (
-        <>
-          <ListPagination
-            count={registrationQuery.data.totalHits}
-            page={page + 1}
-            onPageChange={(newPage) => updatePath(((newPage - 1) * rowsPerPage).toString(), rowsPerPage.toString())}
-            rowsPerPage={rowsPerPage}
-            onRowsPerPageChange={(newRowsPerPage) => updatePath('0', newRowsPerPage.toString())}
-            maxHits={10_000}
-            showPaginationTop
-            sortingComponent={<RegistrationSortSelector />}>
-            <RegistrationSearchResults searchResult={registrationQuery.data.hits} />
-          </ListPagination>
-        </>
+        <ListPagination
+          count={registrationQuery.data.totalHits}
+          page={page + 1}
+          onPageChange={(newPage) => updatePath(((newPage - 1) * rowsPerPage).toString(), rowsPerPage.toString())}
+          rowsPerPage={rowsPerPage}
+          onRowsPerPageChange={(newRowsPerPage) => updatePath('0', newRowsPerPage.toString())}
+          maxHits={10_000}
+          showPaginationTop
+          sortingComponent={<RegistrationSortSelector />}>
+          <RegistrationSearchResults searchResult={registrationQuery.data.hits} />
+        </ListPagination>
       ) : (
         <Typography sx={{ mx: { xs: '0.5rem', md: 0 } }}>{t('common.no_hits')}</Typography>
       )}

--- a/src/pages/search/registration_search/RegistrationSearch.tsx
+++ b/src/pages/search/registration_search/RegistrationSearch.tsx
@@ -28,7 +28,7 @@ export const RegistrationSearch = ({ registrationQuery }: Pick<SearchPageProps, 
 
   return (
     <section>
-      {registrationQuery.isPending ? (
+      {registrationQuery.isFetching ? (
         <ListSkeleton arrayLength={3} minWidth={40} height={100} />
       ) : registrationQuery.data?.hits && registrationQuery.data.hits.length > 0 ? (
         <>


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47652

Flere har rapportert/meldt om feil for de tror søket ikke virker pga manglende loading-indikator. Med dette legger jeg inn loading hver gang søket endres,så bruker får tydelig beskjed om at "noe skjer". Fasetter vil fortsatt vises som før, for å unngå at innholdet hopper rundt på skjermen.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
