### PR TITLE
Notification when project already exists

### DIFF
--- a/src/api/hooks/useDuplicateProjectSearch.ts
+++ b/src/api/hooks/useDuplicateProjectSearch.ts
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { ProjectsSearchParams, searchForProjects } from '../cristinApi';
+
+export const useDuplicateProjectSearch = (title: string | undefined) => {
+  const { t } = useTranslation();
+
+  const projectQueryParams: ProjectsSearchParams = {
+    query: title,
+  };
+
+  const enabled = !!title;
+
+  const projectQuery = useQuery({
+    enabled: enabled,
+    queryKey: ['projects', projectQueryParams],
+    queryFn: () => searchForProjects(10, 1, projectQueryParams),
+    meta: { errorMessage: t('feedback.error.project_search') },
+  });
+
+  const projectsWithSimilarName = projectQuery.data?.hits ?? [];
+
+  const duplicateProject = projectsWithSimilarName.find((project) => {
+    if (!title) {
+      return false;
+    }
+
+    return project.title?.toLowerCase() === title.toLowerCase();
+  });
+
+  return {
+    isPending: enabled && projectQuery.isPending,
+    duplicateProject: duplicateProject,
+  };
+};

--- a/src/pages/project/project_wizard/EmptyProjectForm.tsx
+++ b/src/pages/project/project_wizard/EmptyProjectForm.tsx
@@ -1,10 +1,15 @@
 import EastOutlinedIcon from '@mui/icons-material/EastOutlined';
+import ErrorIcon from '@mui/icons-material/Error';
 import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutlined';
-import { Box, Button, TextField } from '@mui/material';
+import { Box, Button, CircularProgress, TextField } from '@mui/material';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDuplicateProjectSearch } from '../../../api/hooks/useDuplicateProjectSearch';
+import { StyledInfoBanner } from '../../../components/styled/Wrappers';
 import { SaveCristinProject } from '../../../types/project.types';
 import { dataTestId } from '../../../utils/dataTestIds';
+import { useDebounce } from '../../../utils/hooks/useDebounce';
+import { ProjectListItem } from '../../search/project_search/ProjectListItem';
 import { CreateProjectAccordion } from './CreateProjectAccordion';
 
 interface EmptyProjectFormProps {
@@ -16,6 +21,8 @@ interface EmptyProjectFormProps {
 export const EmptyProjectForm = ({ newProject, setNewProject, setShowProjectForm }: EmptyProjectFormProps) => {
   const { t } = useTranslation();
   const [title, setTitle] = useState('');
+  const debouncedTitle = useDebounce(title);
+  const titleSearch = useDuplicateProjectSearch(debouncedTitle);
   const disabled = !title;
 
   const createProject = () => {
@@ -35,10 +42,23 @@ export const EmptyProjectForm = ({ newProject, setNewProject, setShowProjectForm
           data-testid={dataTestId.newProjectPage.titleInput}
           variant="filled"
           onChange={(event) => setTitle(event.target.value)}
+          InputProps={{
+            endAdornment: titleSearch.isPending ? (
+              <CircularProgress size={20} />
+            ) : titleSearch.duplicateProject ? (
+              <ErrorIcon color="warning" />
+            ) : undefined,
+          }}
           fullWidth
           placeholder={t('project.form.write_project_title')}
           label={t('common.title')}
         />
+        {titleSearch.duplicateProject && (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+            <StyledInfoBanner>{t('project.duplicate_project_warning')}</StyledInfoBanner>
+            <ProjectListItem project={titleSearch.duplicateProject} />
+          </Box>
+        )}
         <Button
           variant="contained"
           sx={{ width: 'fit-content', alignSelf: 'end' }}

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1138,6 +1138,7 @@
     "coordinating_institution": "Koordinerende institusjon",
     "create_new_project": "Opprett nytt prosjekt",
     "create_project": "Nytt prosjekt",
+    "duplicate_project_warning": "Det finnes et prosjekt  NVA med samme tittel. Vennligst ikke registrer prosjektet dersom det er samme prosjekt, slik at du ikke oppretter duplikater.",
     "edit_project": "Endre prosjekt",
     "error": {
       "contributor_already_added_with_same_role_and_affiliation": "Prosjektdeltaker er allerede lagt til med samme rolle og tilknytning."


### PR DESCRIPTION
# Description

Link to Jira issue: [https://sikt.atlassian.net/browse/NP-47430](https://sikt.atlassian.net/browse/NP-47430)

Added a notification for when somebody tries to create a project with a title that already exists:

![image](https://github.com/user-attachments/assets/f267cad6-03b7-4364-82a6-406762ff7d0a)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [ ] The changes are working as expected
- [ ] The changes are tested OK for different screen sizes
- [ ] The changes are tested OK for a11y
- [ ] Interactive elements have data-testids
- [ ] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
