### PR TITLE
NP-47323 Add correction list for antology with NVI applicable chapter

### DIFF
--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -331,6 +331,7 @@ export enum ResultParam {
   FundingIdentifier = 'fundingIdentifier',
   FundingSource = 'fundingSource',
   Handle = 'handle',
+  HasChildren = 'hasChildren',
   HasNoChildren = 'hasNoChildren',
   Identifier = 'id',
   IdentifierNot = 'idNot',
@@ -385,6 +386,7 @@ export interface FetchResultsParams {
   [ResultParam.FundingIdentifier]?: string | null;
   [ResultParam.FundingSource]?: string | null;
   [ResultParam.Handle]?: string | null;
+  [ResultParam.HasChildren]?: boolean | null;
   [ResultParam.HasNoChildren]?: boolean | null;
   [ResultParam.Identifier]?: string | null;
   [ResultParam.IdentifierNot]?: string | null;
@@ -465,6 +467,9 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
   }
   if (params.handle) {
     searchParams.set(ResultParam.Handle, params.handle);
+  }
+  if (params.hasChildren === true || params.hasChildren === false) {
+    searchParams.set(ResultParam.HasChildren, params.hasChildren.toString());
   }
   if (params.hasNoChildren === true || params.hasNoChildren === false) {
     searchParams.set(ResultParam.HasNoChildren, params.hasNoChildren.toString());

--- a/src/pages/messages/components/NviCorrectionList.tsx
+++ b/src/pages/messages/components/NviCorrectionList.tsx
@@ -20,6 +20,7 @@ export type CorrectionListId =
   | 'ApplicableCategoriesWithNonApplicableChannel'
   | 'NonApplicableCategoriesWithApplicableChannel'
   | 'AntologyWithoutChapter'
+  | 'AntologyWithApplicableChapter'
   | 'BooksWithLessThan50Pages';
 
 type CorrectionListSearchConfig = {
@@ -60,6 +61,15 @@ export const correctionListConfig: CorrectionListSearchConfig = {
     queryParams: {
       categoryShould: Object.values(BookType),
       publicationPages: '0,50',
+    },
+    disabledFilters: [],
+  },
+  AntologyWithApplicableChapter: {
+    i18nKey: 'tasks.nvi.correction_list_type.antology_with_applicable_chapter',
+    queryParams: {
+      categoryShould: [BookType.Anthology],
+      hasChildren: true,
+      scientificValue: [ScientificValueLevels.LevelOne, ScientificValueLevels.LevelTwo].join(','),
     },
     disabledFilters: [],
   },

--- a/src/pages/messages/components/NviCorrectionListNavigationAccordion.tsx
+++ b/src/pages/messages/components/NviCorrectionListNavigationAccordion.tsx
@@ -64,6 +64,12 @@ export const NviCorrectionListNavigationAccordion = () => {
           {t('tasks.nvi.correction_list_type.antology_without_chapter')}
         </SelectableButton>
         <SelectableButton
+          data-testid={dataTestId.tasksPage.correctionList.antologyWithApplicableChapterButton}
+          isSelected={selectedNviList === 'AntologyWithApplicableChapter'}
+          onClick={() => openNewCorrectionList('AntologyWithApplicableChapter')}>
+          {t('tasks.nvi.correction_list_type.antology_with_applicable_chapter')}
+        </SelectableButton>
+        <SelectableButton
           data-testid={dataTestId.tasksPage.correctionList.booksWithLessThan50PagesButton}
           isSelected={selectedNviList === 'BooksWithLessThan50Pages'}
           onClick={() => openNewCorrectionList('BooksWithLessThan50Pages')}>

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1999,6 +1999,7 @@
         "applicable_category_in_non_applicable_channel": "Tellende kategorier i ikke-tellende kanaler",
         "book_with_less_than_50_pages": "Bøker med færre enn 50 sider",
         "correction_list_duct": "Retteliste (DUCT)",
+        "antology_with_applicable_chapter": "Antologier med tellende kapittel",
         "non_applicable_category_in_applicable_channel": "Ikke-tellende kategorier i tellende kanaler"
       },
       "delete_note": "Slett melding",

--- a/src/utils/dataTestIds.ts
+++ b/src/utils/dataTestIds.ts
@@ -672,6 +672,7 @@ export const dataTestId = {
   tasksPage: {
     areaOfResponsibilitySelector: 'area-of-responsibility-selector',
     correctionList: {
+      antologyWithApplicableChapterButton: 'antology-with-applicable-chapter-button',
       antologyWithoutChapterButton: 'antology-without-chapter-button',
       booksWithLessThan50PagesButton: 'books-with-less-than-50-pages-button',
       applicableCategoriesWithNonApplicableChannelButton: 'applicable-categories-with-non-applicable-channel-button',


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47323

TODO før dette ev. kan merges:
- Avklar med backend om søket faktisk sjekker at kapitlene kvalifiserer til NVI, for på query params ser det ut som det bare sjekkes at selve antologien er på en kanal med nivå som kvaligfiserer til NVI: https://api.dev.nva.aws.unit.no/search/resources?categoryShould=BookAnthology&hasChildren=true&scientificValue=Unassigned,LevelZero
- Bare returner faktiske verdier fra `useRegistrationSearchParams`, for å unngå at `null` overskriver en faktisk verdi. Feks noe sånt:
```
export const getObjectEntriesWithValue = (object: Record<string, any>) =>
  Object.fromEntries(Object.entries(object).filter(([, value]) => value !== null && value !== undefined));
```

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [ ] The changes are working as expected
- [ ] The changes are tested OK for different screen sizes
- [ ] The changes are tested OK for a11y
- [ ] Interactive elements have data-testids
- [ ] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
