### PR TITLE
NP-47382 Remove old correction lists from DUCT

### DIFF
--- a/src/pages/messages/components/NviCorrectionList.tsx
+++ b/src/pages/messages/components/NviCorrectionList.tsx
@@ -92,12 +92,12 @@ export const NviCorrectionList = () => {
         <title>{t('tasks.correction_list')}</title>
       </Helmet>
 
-      <Typography variant="h1" gutterBottom sx={{ mx: { xs: '0.25rem', md: 0 } }}>
-        {listConfig ? t(listConfig.i18nKey) : t('tasks.nvi.correction_list_type.correction_list_duct')}
-      </Typography>
-
-      {listConfig ? (
+      {listConfig && (
         <>
+          <Typography variant="h1" gutterBottom sx={{ mx: { xs: '0.25rem', md: 0 } }}>
+            {t(listConfig.i18nKey)}
+          </Typography>
+
           <Box
             sx={{ px: { xs: '0.5rem', md: 0 }, display: 'flex', flexDirection: 'column', gap: '0.5rem', mb: '1rem' }}>
             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
@@ -121,13 +121,6 @@ export const NviCorrectionList = () => {
 
           <RegistrationSearch registrationQuery={registrationQuery} />
         </>
-      ) : (
-        <iframe
-          style={{ border: 'none', height: '80vh' }}
-          title={t('tasks.nvi.correction_list_type.correction_list_duct')}
-          width="100%"
-          src="https://rapport-dv.uhad.no/t/DUCT/views/Ryddelister_2023/Rettelister2023?%3Aembed=y"
-        />
       )}
     </section>
   );

--- a/src/pages/messages/components/NviCorrectionListNavigationAccordion.tsx
+++ b/src/pages/messages/components/NviCorrectionListNavigationAccordion.tsx
@@ -36,15 +36,11 @@ export const NviCorrectionListNavigationAccordion = () => {
       title={t('tasks.correction_list')}
       startIcon={<RuleIcon sx={{ bgcolor: 'white' }} />}
       accordionPath={UrlPathTemplate.TasksNviCorrectionList}
+      defaultPath={`${UrlPathTemplate.TasksNviCorrectionList}?${nviCorrectionListQueryKey}=${
+        'ApplicableCategoriesWithNonApplicableChannel' satisfies CorrectionListId
+      }`}
       dataTestId={dataTestId.tasksPage.correctionList.correctionListAccordion}>
       <NavigationList component="div">
-        <SelectableButton
-          isSelected={!selectedNviList}
-          onClick={() => history.push({ search: '' })}
-          sx={{ mb: '1rem' }}>
-          {t('tasks.nvi.correction_list_type.correction_list_duct')}
-        </SelectableButton>
-
         <SelectableButton
           data-testid={dataTestId.tasksPage.correctionList.applicableCategoriesWithNonApplicableChannelButton}
           isSelected={selectedNviList === 'ApplicableCategoriesWithNonApplicableChannel'}

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1998,7 +1998,6 @@
         "antology_without_chapter": "Antologier uten kapittel",
         "applicable_category_in_non_applicable_channel": "Tellende kategorier i ikke-tellende kanaler",
         "book_with_less_than_50_pages": "Bøker med færre enn 50 sider",
-        "correction_list_duct": "Retteliste (DUCT)",
         "non_applicable_category_in_applicable_channel": "Ikke-tellende kategorier i tellende kanaler"
       },
       "delete_note": "Slett melding",


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47382

Ta vekk gammel NVI-retteliste fra DUCT nå som vi har våre egne.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
