### PR TITLE
Fix tests for new version of Amazon Linux

### DIFF
--- a/buildspecs/cypress_tests.yml
+++ b/buildspecs/cypress_tests.yml
@@ -12,8 +12,8 @@ phases:
     runtime-versions:
       nodejs: latest
     commands:
-      # https://docs.cypress.io/guides/continuous-integration/introduction#Dependencies
-      - yum install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2 nss libXScrnSaver alsa-lib xdg-utils
+      # https://docs.cypress.io/guides/getting-started/installing-cypress#Amazon-Linux-2023
+      - dnf install -y xorg-x11-server-Xvfb gtk3-devel nss alsa-lib
       - npm ci
   build:
     commands:


### PR DESCRIPTION
Følger cypress docs: https://docs.cypress.io/guides/getting-started/installing-cypress#Amazon-Linux-2023

Har byttet fra `Amazon Linux 2 x86_64 standard:4.0` til `Amazon Linux 2023 x86_64 standard:5.0` for å gå over til nyere versjon av node når vi bygger til PR: https://docs.aws.amazon.com/codebuild/latest/userguide/available-runtimes.html.

Til nå har vi vært på node v16 som "døde" [i fjor](https://nodejs.org/en/about/previous-releases) i codebuild. Denne gamle versjonen førte til at noen andre pakker ikke lot seg bumpe, f.eks. https://github.com/BIBSYSDEV/NVA-Frontend/pull/6302.