### PR TITLE
Np 47390 ensure latest query value is used for search

### DIFF
--- a/src/pages/search/PublicationYearIntervalFilter.tsx
+++ b/src/pages/search/PublicationYearIntervalFilter.tsx
@@ -3,6 +3,7 @@ import { DatePicker, DatePickerProps } from '@mui/x-date-pickers';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { ResultParam } from '../../api/searchApi';
+import { syncParamsWithSearchFields } from '../../utils/searchHelpers';
 
 const commonDatepickerProps: Partial<DatePickerProps<Date>> = {
   views: ['year'],
@@ -32,21 +33,22 @@ export const PublicationYearIntervalFilter = ({ datePickerProps, boxProps }: Pub
     newDate: Date | null,
     param: ResultParam.PublicationYearSince | ResultParam.PublicationYearBefore
   ) => {
+    const syncedParams = syncParamsWithSearchFields(searchParams);
     if (newDate) {
       const year = newDate.getFullYear();
       if (year.toString().length === 4) {
         if (param === ResultParam.PublicationYearBefore) {
-          searchParams.set(param, (year + 1).toString());
+          syncedParams.set(param, (year + 1).toString());
         } else {
-          searchParams.set(param, year.toString());
+          syncedParams.set(param, year.toString());
         }
-        searchParams.delete(ResultParam.From);
-        history.push({ search: searchParams.toString() });
+        syncedParams.delete(ResultParam.From);
+        history.push({ search: syncedParams.toString() });
       }
     } else {
-      searchParams.delete(param);
-      searchParams.delete(ResultParam.From);
-      history.push({ search: searchParams.toString() });
+      syncedParams.delete(param);
+      syncedParams.delete(ResultParam.From);
+      history.push({ search: syncedParams.toString() });
     }
   };
 

--- a/src/pages/search/registration_search/RegistrationSearch.tsx
+++ b/src/pages/search/registration_search/RegistrationSearch.tsx
@@ -4,7 +4,7 @@ import { useHistory } from 'react-router-dom';
 import { ListPagination } from '../../../components/ListPagination';
 import { ListSkeleton } from '../../../components/ListSkeleton';
 import { ROWS_PER_PAGE_OPTIONS } from '../../../utils/constants';
-import { SearchParam } from '../../../utils/searchHelpers';
+import { SearchParam, syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 import { SearchPageProps } from '../SearchPage';
 import { RegistrationSearchResults } from './RegistrationSearchResults';
 import { RegistrationSortSelector } from './RegistrationSortSelector';
@@ -21,9 +21,10 @@ export const RegistrationSearch = ({ registrationQuery }: Pick<SearchPageProps, 
   const page = (fromParam && resultsParam && Math.floor(+fromParam / rowsPerPage)) || 0;
 
   const updatePath = (from: string, results: string) => {
-    params.set(SearchParam.From, from);
-    params.set(SearchParam.Results, results);
-    history.push({ search: params.toString() });
+    const syncedParams = syncParamsWithSearchFields(params);
+    syncedParams.set(SearchParam.From, from);
+    syncedParams.set(SearchParam.Results, results);
+    history.push({ search: syncedParams.toString() });
   };
 
   return (

--- a/src/pages/search/registration_search/RegistrationSearchBar.tsx
+++ b/src/pages/search/registration_search/RegistrationSearchBar.tsx
@@ -161,10 +161,12 @@ export const RegistrationSearchBar = ({ registrationQuery }: Pick<SearchPageProp
                   {values.properties.map((property, index) => (
                     <AdvancedSearchRow
                       key={index}
+                      queryParam={property.fieldName}
                       removeFilter={() => {
                         remove(index);
                         const valueToRemove = typeof property.value === 'string' ? property.value : property.value[0];
-                        const newParams = removeSearchParamValue(searchParams, property.fieldName, valueToRemove);
+                        const syncedParams = syncParamsWithSearchFields(searchParams);
+                        const newParams = removeSearchParamValue(syncedParams, property.fieldName, valueToRemove);
                         newParams.set(ResultParam.From, '0');
                         history.push({ search: newParams.toString() });
                       }}

--- a/src/pages/search/registration_search/RegistrationSearchBar.tsx
+++ b/src/pages/search/registration_search/RegistrationSearchBar.tsx
@@ -14,6 +14,7 @@ import { AggregationFileKeyType, PublicationInstanceType } from '../../../types/
 import { dataTestId } from '../../../utils/dataTestIds';
 import {
   createSearchConfigFromSearchParams,
+  dataSearchFieldAttributeName,
   getFileFacetText,
   isValidIsbn,
   PropertySearch,
@@ -138,7 +139,7 @@ export const RegistrationSearchBar = ({ registrationQuery }: Pick<SearchPageProp
             {({ field }: FieldProps<string>) => (
               <SearchTextField
                 {...field}
-                inputProps={{ 'data-searchfield': ResultParam.Query }}
+                inputProps={{ [dataSearchFieldAttributeName]: ResultParam.Query }}
                 placeholder={t('search.search_placeholder')}
                 clearValue={() => {
                   field.onChange({ target: { value: '', id: field.name } });

--- a/src/pages/search/registration_search/RegistrationSearchBar.tsx
+++ b/src/pages/search/registration_search/RegistrationSearchBar.tsx
@@ -13,11 +13,12 @@ import { ResultParam } from '../../../api/searchApi';
 import { AggregationFileKeyType, PublicationInstanceType } from '../../../types/registration.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import {
-  PropertySearch,
   createSearchConfigFromSearchParams,
   getFileFacetText,
   isValidIsbn,
+  PropertySearch,
   removeSearchParamValue,
+  syncParamsWithSearchFields,
 } from '../../../utils/searchHelpers';
 import { getLanguageString } from '../../../utils/translation-helpers';
 import { getFullCristinName } from '../../../utils/user-helpers';
@@ -137,6 +138,7 @@ export const RegistrationSearchBar = ({ registrationQuery }: Pick<SearchPageProp
             {({ field }: FieldProps<string>) => (
               <SearchTextField
                 {...field}
+                inputProps={{ 'data-searchfield': ResultParam.Query }}
                 placeholder={t('search.search_placeholder')}
                 clearValue={() => {
                   field.onChange({ target: { value: '', id: field.name } });
@@ -332,8 +334,9 @@ export const RegistrationSearchBar = ({ registrationQuery }: Pick<SearchPageProp
                     sx={{ textTransform: 'none' }}
                     endIcon={<ClearIcon />}
                     onClick={() => {
-                      const newParams = removeSearchParamValue(searchParams, param, value);
-                      newParams.set(ResultParam.From, '0');
+                      const syncedParams = syncParamsWithSearchFields(searchParams);
+                      const newParams = removeSearchParamValue(syncedParams, param, value);
+                      newParams.delete(ResultParam.From);
                       history.push({ search: newParams.toString() });
                     }}>
                     {fieldName}: {fieldValueText}

--- a/src/pages/search/registration_search/filters/AdvancedSearchRow.tsx
+++ b/src/pages/search/registration_search/filters/AdvancedSearchRow.tsx
@@ -5,6 +5,7 @@ import { ParseKeys } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { ResultParam } from '../../../../api/searchApi';
 import { dataTestId } from '../../../../utils/dataTestIds';
+import { dataSearchFieldAttributeName } from '../../../../utils/searchHelpers';
 
 interface FilterItem {
   field: string;
@@ -28,10 +29,11 @@ const registrationFilters: FilterItem[] = [
 
 interface AdvancedSearchRowProps {
   baseFieldName: string;
+  queryParam: ResultParam | '';
   removeFilter: () => void;
 }
 
-export const AdvancedSearchRow = ({ removeFilter, baseFieldName }: AdvancedSearchRowProps) => {
+export const AdvancedSearchRow = ({ removeFilter, baseFieldName, queryParam }: AdvancedSearchRowProps) => {
   const { t } = useTranslation();
 
   return (
@@ -62,6 +64,7 @@ export const AdvancedSearchRow = ({ removeFilter, baseFieldName }: AdvancedSearc
             variant="standard"
             size="small"
             label={t('search.search_term_label')}
+            inputProps={queryParam ? { [dataSearchFieldAttributeName]: queryParam } : undefined}
             data-testid={dataTestId.startPage.advancedSearch.advancedValueField}
             fullWidth
           />

--- a/src/pages/search/registration_search/filters/RegistrationFacetsFilter.tsx
+++ b/src/pages/search/registration_search/filters/RegistrationFacetsFilter.tsx
@@ -4,7 +4,7 @@ import { ResultParam } from '../../../../api/searchApi';
 import { dataTestId } from '../../../../utils/dataTestIds';
 import { getIdentifierFromId } from '../../../../utils/general-helpers';
 import { useRegistrationsQueryParams } from '../../../../utils/hooks/useRegistrationSearchParams';
-import { getFileFacetText, removeSearchParamValue } from '../../../../utils/searchHelpers';
+import { getFileFacetText, removeSearchParamValue, syncParamsWithSearchFields } from '../../../../utils/searchHelpers';
 import { getLanguageString } from '../../../../utils/translation-helpers';
 import { FacetItem } from '../../FacetItem';
 import { FacetListItem } from '../../FacetListItem';
@@ -29,18 +29,20 @@ export const RegistrationFacetsFilter = ({ registrationQuery }: Pick<SearchPageP
   const filesFacet = registrationQuery.data?.aggregations?.files ?? [];
 
   const addFacetFilter = (param: string, key: string) => {
-    const currentValues = searchParams.get(param)?.split(',') ?? [];
+    const syncedParams = syncParamsWithSearchFields(searchParams);
+    const currentValues = syncedParams.get(param)?.split(',') ?? [];
     if (currentValues.length === 0) {
-      searchParams.set(param, key);
+      syncedParams.set(param, key);
     } else {
-      searchParams.set(param, [...currentValues, key].join(','));
+      syncedParams.set(param, [...currentValues, key].join(','));
     }
-    searchParams.set(ResultParam.From, '0');
-    history.push({ search: searchParams.toString() });
+    syncedParams.set(ResultParam.From, '0');
+    history.push({ search: syncedParams.toString() });
   };
 
   const removeFacetFilter = (param: string, key: string) => {
-    const newSearchParams = removeSearchParamValue(searchParams, param, key);
+    const syncedParams = syncParamsWithSearchFields(searchParams);
+    const newSearchParams = removeSearchParamValue(syncedParams, param, key);
     newSearchParams.set(ResultParam.From, '0');
     history.push({ search: newSearchParams.toString() });
   };

--- a/src/utils/searchHelpers.ts
+++ b/src/utils/searchHelpers.ts
@@ -157,21 +157,24 @@ export const keepSimilarPreviousData = <T>(
   }
 };
 
+export const dataSearchFieldAttributeName = 'data-searchfield';
 /**
  * Takes one URLSearchParams object and adds or removes values from other HTML input nodes with
  * the "data-searchfield" attribute to ensure that all params are in sync with the HTML.
  */
 export const syncParamsWithSearchFields = (params: URLSearchParams) => {
-  const searchElements = document.querySelectorAll('input[data-searchfield]') as NodeListOf<HTMLInputElement>;
+  const searchFieldElements = document.querySelectorAll(
+    `input[${dataSearchFieldAttributeName}]`
+  ) as NodeListOf<HTMLInputElement>;
 
-  searchElements.forEach((input) => {
-    const dataSearchField = input.getAttribute('data-searchfield');
+  searchFieldElements.forEach((input) => {
+    const fieldName = input.getAttribute(dataSearchFieldAttributeName);
     const value = input.value;
-    if (dataSearchField) {
+    if (fieldName) {
       if (value) {
-        params.set(dataSearchField, value);
-      } else if (params.has(dataSearchField)) {
-        params.delete(dataSearchField);
+        params.set(fieldName, value);
+      } else if (params.has(fieldName)) {
+        params.delete(fieldName);
       }
     }
   });

--- a/src/utils/searchHelpers.ts
+++ b/src/utils/searchHelpers.ts
@@ -156,3 +156,25 @@ export const keepSimilarPreviousData = <T>(
     return previousData;
   }
 };
+
+/**
+ * Takes one URLSearchParams object and adds or removes values from other HTML input nodes with
+ * the "data-searchfield" attribute to ensure that all params are in sync with the HTML.
+ */
+export const syncParamsWithSearchFields = (params: URLSearchParams) => {
+  const searchElements = document.querySelectorAll('input[data-searchfield]') as NodeListOf<HTMLInputElement>;
+
+  searchElements.forEach((input) => {
+    const dataSearchField = input.getAttribute('data-searchfield');
+    const value = input.value;
+    if (dataSearchField) {
+      if (value) {
+        params.set(dataSearchField, value);
+      } else if (params.has(dataSearchField)) {
+        params.delete(dataSearchField);
+      }
+    }
+  });
+
+  return params;
+};

--- a/src/utils/searchHelpers.ts
+++ b/src/utils/searchHelpers.ts
@@ -167,12 +167,11 @@ export const syncParamsWithSearchFields = (params: URLSearchParams) => {
     `input[${dataSearchFieldAttributeName}]`
   ) as NodeListOf<HTMLInputElement>;
 
-  searchFieldElements.forEach((input) => {
-    const fieldName = input.getAttribute(dataSearchFieldAttributeName);
-    const value = input.value;
+  searchFieldElements.forEach((element) => {
+    const fieldName = element.getAttribute(dataSearchFieldAttributeName);
     if (fieldName) {
-      if (value) {
-        params.set(fieldName, value);
+      if (element.value) {
+        params.set(fieldName, element.value);
       } else if (params.has(fieldName)) {
         params.delete(fieldName);
       }


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47390

Dagens søk har problemer med å håndtere felter som har endrede verdier, men som ikke er submitta. 
Eksempel:
1. Gå til https://dev.nva.sikt.no/
2. Skriv "natur" i søkefeltet
3. Velg en fasett/aggreging i venstremenyen
4. Det gjøres nå et nytt søk, men selv om det står "natur" i søkefeltet er ikke det inkludert i søket, siden verdien ikke har blitt submitted på noe vis. Dette oppstår i alle tilfeller hvor man gjør endringer i et fritekstfelt uten å aktivt submitte.

Har et forslag på løsning som virker slik:
- Alle fritekstfelter får et HTML-attributt `data-searchfield` (se docs for `data-*`-attributter [her](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes))
- Når et nytt søk gjennomføres, vil vi først lage et nytt `URLSearchParams`-objekt som har oppdaterte verdier for alle fritekstfelter
  - Dette gjøres i `syncParamsWithSearchFields()` hvor vi henter alle HTML-noder som har attributtet `data-searchfield`, og oppdaterer gjeldende params med de samme verdiene som ligger i HTML-dokumentet.

Var skeptisk til hvordan vi kunne finne en god løsning på dette, men jeg syns egentlig dette ble en ganske fin løsning som ikke har mye kode, og som også er forståelig. Andre bør se over dette og komme med innspill om man er uenig før jeg gjør mer jobb på dette. For når vi er enige om en fremgangsmåte må dette legges inn ganske mange plasser (se checklist i [Jira](https://sikt.atlassian.net/browse/NP-47390)).

Med denne løsningen mener jeg vi skal håndtere alle tilfeller av dette på vår hovedsøkeside: http://localhost:3000/

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
