### PR TITLE
NP-47679 Improve support for MathJax

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,13 +8,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Nasjonalt vitenarkiv" />
     <link rel="manifest" href="/manifest.json" />
-    <script>
-      MathJax = {
-        tex: {
-          inlineMath: [['$', '$']],
-        },
-      };
-    </script>
     <style>
       mjx-container {
         /* Avoid line-breaks for mathjax elements */

--- a/src/utils/mathJaxHelpers.ts
+++ b/src/utils/mathJaxHelpers.ts
@@ -14,5 +14,5 @@ export const typesetMathJax = () => {
 };
 
 export const stringIncludesMathJax = (input = '') => {
-  return input.includes('$');
+  return input.includes('\\') || input.includes('$');
 };

--- a/src/utils/testfiles/mockRegistration.ts
+++ b/src/utils/testfiles/mockRegistration.ts
@@ -115,9 +115,9 @@ export const mockMathJaxRegistration: JournalRegistration = {
   ...mockRegistration,
   entityDescription: {
     ...mockRegistration.entityDescription,
-    mainTitle: 'The title $$\\sqrt{25} = 5~\\hbox {ost}$$ and $A_{FB}^{\\mathrm{b}\\overline{\\mathrm{b}}}$',
+    mainTitle: 'The title \\[\\sqrt{25} = 5~\\hbox{ost}\\] and \\(A_{FB}^{\\mathrm{b}\\overline{\\mathrm{b}}}\\)',
     abstract:
-      'This is abastract -> $$\\sqrt{25} = 5~\\hbox {ost}$$ and $X_{AB}^{\\mathrm{c}\\overline{\\mathrm{d}}}$ and so on it goes.',
+      'This is abstract -> \\[\\sqrt{25} = 5~\\hbox{ost}\\] and \\(X_{AB}^{\\mathrm{c}\\overline{\\mathrm{d}}}\\) and so on it goes.',
   },
 };
 

--- a/src/utils/testfiles/mockRegistration.ts
+++ b/src/utils/testfiles/mockRegistration.ts
@@ -115,9 +115,9 @@ export const mockMathJaxRegistration: JournalRegistration = {
   ...mockRegistration,
   entityDescription: {
     ...mockRegistration.entityDescription,
-    mainTitle: 'The title \\[\\sqrt{25} = 5~\\hbox{ost}\\] and \\(A_{FB}^{\\mathrm{b}\\overline{\\mathrm{b}}}\\)',
+    mainTitle: 'The title \\(\\sqrt{25} = 5~\\hbox{ost}\\) and \\(A_{FB}^{\\mathrm{b}\\overline{\\mathrm{b}}}\\)',
     abstract:
-      'This is abstract -> \\[\\sqrt{25} = 5~\\hbox{ost}\\] and \\(X_{AB}^{\\mathrm{c}\\overline{\\mathrm{d}}}\\) and so on it goes.',
+      'This is abstract -> \\(\\sqrt{25} = 5~\\hbox{ost}\\) and \\(X_{AB}^{\\mathrm{c}\\overline{\\mathrm{d}}}\\) and so on it goes.',
   },
 };
 


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47679

Bedre støtte for MathJax ved å fjerne noe config vi kanskje aldri skulle lagt inn. Husker ikke helt hvorfor det ble lagt inn, men tror det var for å kreve dobbel `$$` for å aktivere MathJax, men det virker ikke bra når vi importerer fra andre systemer. Merk at disse endringen _kan_ føre til at noe annet ikke virker som før, men tror vi er tjent med å bevege oss over til default config uansett.

For å teste kan man feks søk på en eller annen variant av `sqrt`.

Før:
![bilde](https://github.com/user-attachments/assets/2bd72a54-ea7a-4389-bd7b-bb92f05a83b2)

Etter:
![bilde](https://github.com/user-attachments/assets/46f77a92-6b68-4cff-86e5-2e4ee5456bae)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
