### PR TITLE
NP-47241 Remove a few circular dependencies

### DIFF
--- a/src/components/CategorySearchFilter.tsx
+++ b/src/components/CategorySearchFilter.tsx
@@ -3,11 +3,11 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { ResultParam, TicketSearchParam } from '../api/searchApi';
-import { StyledFilterTitle } from '../pages/search/advanced_search/AdvancedSearchPage';
 import { CategoryFilterDialog } from '../pages/search/advanced_search/CategoryFilterDialog';
 import { PublicationInstanceType } from '../types/registration.types';
 import { dataTestId } from '../utils/dataTestIds';
 import { CategoryChip } from './CategorySelector';
+import { StyledFilterHeading } from './styled/Wrappers';
 
 interface CategorySearchFilterProps {
   searchParam: ResultParam.CategoryShould | TicketSearchParam.PublicationType;
@@ -26,7 +26,7 @@ export const CategorySearchFilter = ({ searchParam, disabled, hideHeading }: Cat
 
   return (
     <section>
-      {!hideHeading && <StyledFilterTitle>{t('common.category')}</StyledFilterTitle>}
+      {!hideHeading && <StyledFilterHeading>{t('common.category')}</StyledFilterHeading>}
       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem' }}>
         {selectedCategories.slice(0, 3).map((category) => (
           <CategoryChip

--- a/src/components/styled/Wrappers.tsx
+++ b/src/components/styled/Wrappers.tsx
@@ -116,3 +116,8 @@ export const StyledInfoBanner = styled(Box)(({ theme }) => ({
   borderRadius: '0.25rem',
   color: 'white',
 }));
+
+export const StyledFilterHeading = styled(Typography)({
+  marginBottom: '0.2rem',
+  fontWeight: 'bold',
+});

--- a/src/pages/search/advanced_search/AdvancedSearchPage.tsx
+++ b/src/pages/search/advanced_search/AdvancedSearchPage.tsx
@@ -16,6 +16,7 @@ import { useRegistrationSearch } from '../../../api/hooks/useRegistrationSearch'
 import { ResultParam } from '../../../api/searchApi';
 import { CategorySearchFilter } from '../../../components/CategorySearchFilter';
 import { SearchForm } from '../../../components/SearchForm';
+import { StyledFilterHeading } from '../../../components/styled/Wrappers';
 import { ScientificIndexStatuses } from '../../../types/nvi.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { useRegistrationsQueryParams } from '../../../utils/hooks/useRegistrationSearchParams';
@@ -35,11 +36,6 @@ import { VocabularSearchField } from './VocabularSearchField';
 const StyledDivider = styled(Divider)(({ theme }) => ({
   backgroundColor: theme.palette.primary.main,
 }));
-
-export const StyledFilterTitle = styled(Typography)({
-  marginBottom: '0.2rem',
-  fontWeight: 'bold',
-});
 
 const gridRowDivider = (
   <Grid item xs={12}>
@@ -75,7 +71,7 @@ export const AdvancedSearchPage = () => {
       <Grid container rowGap={2} sx={{ px: { xs: '0.5rem', md: 0 } }}>
         <Typography variant="h2">{t('search.advanced_search.advanced_search')}</Typography>
         <Grid item xs={12}>
-          <StyledFilterTitle>{t('search.advanced_search.title_search')}</StyledFilterTitle>
+          <StyledFilterHeading>{t('search.advanced_search.title_search')}</StyledFilterHeading>
           <Box sx={{ display: 'flex', gap: '0.5rem' }}>
             <SearchForm
               sx={{ flex: '1 0 15rem' }}
@@ -89,7 +85,7 @@ export const AdvancedSearchPage = () => {
 
         <Grid item container direction={isLargeScreen ? 'row' : 'column'} xs={12} gap={2}>
           <Grid item sx={{ width: 'fit-content' }}>
-            <StyledFilterTitle>{t('search.advanced_search.publishing_period')}</StyledFilterTitle>
+            <StyledFilterHeading>{t('search.advanced_search.publishing_period')}</StyledFilterHeading>
             <PublicationYearIntervalFilter />
           </Grid>
 
@@ -102,14 +98,14 @@ export const AdvancedSearchPage = () => {
           {isLargeScreen && <StyledDivider orientation="vertical" flexItem />}
 
           <Grid item>
-            <StyledFilterTitle id="language-select-label">{t('common.language')}</StyledFilterTitle>
+            <StyledFilterHeading id="language-select-label">{t('common.language')}</StyledFilterHeading>
             <LanguageFilter />
           </Grid>
 
           {isLargeScreen && <StyledDivider orientation="vertical" flexItem />}
 
           <Grid item>
-            <StyledFilterTitle>{t('common.nvi')}</StyledFilterTitle>
+            <StyledFilterHeading>{t('common.nvi')}</StyledFilterHeading>
             <FormControlLabel
               data-testid={dataTestId.startPage.advancedSearch.scientificIndexStatusCheckbox}
               control={<Checkbox name="scientificIndexStatus" />}
@@ -122,9 +118,9 @@ export const AdvancedSearchPage = () => {
           {isLargeScreen && <StyledDivider orientation="vertical" flexItem />}
 
           <Grid item>
-            <StyledFilterTitle id="file-status-select-label">
+            <StyledFilterHeading id="file-status-select-label">
               {t('registration.files_and_license.files')}
-            </StyledFilterTitle>
+            </StyledFilterHeading>
             <FileStatusSelect />
           </Grid>
         </Grid>
@@ -133,7 +129,7 @@ export const AdvancedSearchPage = () => {
 
         <Grid container item direction={isLargeScreen ? 'row' : 'column'} xs={12} gap={2}>
           <Grid item>
-            <StyledFilterTitle>{t('registration.contributors.contributor')}</StyledFilterTitle>
+            <StyledFilterHeading>{t('registration.contributors.contributor')}</StyledFilterHeading>
             <SearchForm paramName={ResultParam.ContributorName} placeholder={t('search.search_for_contributor')} />
           </Grid>
 
@@ -173,12 +169,12 @@ export const AdvancedSearchPage = () => {
 
         <Grid container item direction={isLargeScreen ? 'row' : 'column'} xs={12} gap={2}>
           <Grid item>
-            <StyledFilterTitle>{t('common.financier')}</StyledFilterTitle>
+            <StyledFilterHeading>{t('common.financier')}</StyledFilterHeading>
             <FundingSourceFilter />
           </Grid>
 
           <Grid item>
-            <StyledFilterTitle>{t('project.grant_id')}</StyledFilterTitle>
+            <StyledFilterHeading>{t('project.grant_id')}</StyledFilterHeading>
             <SearchForm
               paramName={ResultParam.FundingIdentifier}
               placeholder={t('search.search_for_funding_identifier')}
@@ -188,7 +184,7 @@ export const AdvancedSearchPage = () => {
           {isLargeScreen && <StyledDivider orientation="vertical" flexItem />}
 
           <Grid item>
-            <StyledFilterTitle>{t('registration.resource_type.course_code')}</StyledFilterTitle>
+            <StyledFilterHeading>{t('registration.resource_type.course_code')}</StyledFilterHeading>
             <SearchForm
               dataTestId={dataTestId.startPage.advancedSearch.courseField}
               paramName={ResultParam.Course}
@@ -199,7 +195,7 @@ export const AdvancedSearchPage = () => {
           {isLargeScreen && <StyledDivider orientation="vertical" flexItem />}
 
           <Grid item>
-            <StyledFilterTitle>{t('editor.vocabulary')}</StyledFilterTitle>
+            <StyledFilterHeading>{t('editor.vocabulary')}</StyledFilterHeading>
             <VocabularSearchField />
           </Grid>
         </Grid>

--- a/src/pages/search/advanced_search/JournalFilter.tsx
+++ b/src/pages/search/advanced_search/JournalFilter.tsx
@@ -10,12 +10,12 @@ import {
   AutocompleteListboxWithExpansionProps,
 } from '../../../components/AutocompleteListboxWithExpansion';
 import { AutocompleteTextField } from '../../../components/AutocompleteTextField';
+import { StyledFilterHeading } from '../../../components/styled/Wrappers';
 import { Journal } from '../../../types/registration.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
 import { keepSimilarPreviousData } from '../../../utils/searchHelpers';
 import { PublicationChannelOption } from '../../registration/resource_type_tab/components/PublicationChannelOption';
-import { StyledFilterTitle } from './AdvancedSearchPage';
 
 export const JournalFilter = () => {
   const { t } = useTranslation();
@@ -61,7 +61,7 @@ export const JournalFilter = () => {
 
   return (
     <section>
-      <StyledFilterTitle>{t('registration.resource_type.journal')}</StyledFilterTitle>
+      <StyledFilterHeading>{t('registration.resource_type.journal')}</StyledFilterHeading>
       <Autocomplete
         size="small"
         sx={{ minWidth: '15rem' }}

--- a/src/pages/search/advanced_search/OrganizationFilters.tsx
+++ b/src/pages/search/advanced_search/OrganizationFilters.tsx
@@ -14,11 +14,11 @@ import {
 } from '../../../components/AutocompleteListboxWithExpansion';
 import { AutocompleteTextField } from '../../../components/AutocompleteTextField';
 import { OrganizationRenderOption } from '../../../components/OrganizationRenderOption';
+import { StyledFilterHeading } from '../../../components/styled/Wrappers';
 import { RootState } from '../../../redux/store';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
 import { getLanguageString } from '../../../utils/translation-helpers';
-import { StyledFilterTitle } from './AdvancedSearchPage';
 import { OrganizationHierarchyFilter } from './OrganizationHierarchyFilter';
 
 interface OrganizationFiltersProps {
@@ -81,7 +81,7 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
 
   return (
     <section>
-      <StyledFilterTitle>{t('common.institution')}</StyledFilterTitle>
+      <StyledFilterHeading>{t('common.institution')}</StyledFilterHeading>
       <Box
         sx={{
           display: 'flex',

--- a/src/pages/search/advanced_search/PublisherFilter.tsx
+++ b/src/pages/search/advanced_search/PublisherFilter.tsx
@@ -10,12 +10,12 @@ import {
   AutocompleteListboxWithExpansionProps,
 } from '../../../components/AutocompleteListboxWithExpansion';
 import { AutocompleteTextField } from '../../../components/AutocompleteTextField';
+import { StyledFilterHeading } from '../../../components/styled/Wrappers';
 import { Publisher } from '../../../types/registration.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
 import { keepSimilarPreviousData } from '../../../utils/searchHelpers';
 import { PublicationChannelOption } from '../../registration/resource_type_tab/components/PublicationChannelOption';
-import { StyledFilterTitle } from './AdvancedSearchPage';
 
 export const PublisherFilter = () => {
   const { t } = useTranslation();
@@ -61,7 +61,7 @@ export const PublisherFilter = () => {
 
   return (
     <section>
-      <StyledFilterTitle>{t('common.publisher')}</StyledFilterTitle>
+      <StyledFilterHeading>{t('common.publisher')}</StyledFilterHeading>
       <Autocomplete
         size="small"
         sx={{ minWidth: '15rem' }}

--- a/src/pages/search/advanced_search/SeriesFilter.tsx
+++ b/src/pages/search/advanced_search/SeriesFilter.tsx
@@ -10,12 +10,12 @@ import {
   AutocompleteListboxWithExpansionProps,
 } from '../../../components/AutocompleteListboxWithExpansion';
 import { AutocompleteTextField } from '../../../components/AutocompleteTextField';
+import { StyledFilterHeading } from '../../../components/styled/Wrappers';
 import { Series } from '../../../types/registration.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
 import { keepSimilarPreviousData } from '../../../utils/searchHelpers';
 import { PublicationChannelOption } from '../../registration/resource_type_tab/components/PublicationChannelOption';
-import { StyledFilterTitle } from './AdvancedSearchPage';
 
 export const SeriesFilter = () => {
   const { t } = useTranslation();
@@ -61,7 +61,7 @@ export const SeriesFilter = () => {
 
   return (
     <section>
-      <StyledFilterTitle>{t('registration.resource_type.series')}</StyledFilterTitle>
+      <StyledFilterHeading>{t('registration.resource_type.series')}</StyledFilterHeading>
       <Autocomplete
         size="small"
         sx={{ minWidth: '15rem' }}


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47241

Fjern sirkulære avhengigheter relatert til felt-headings i søk som kommer som advarsel når vi bygger appen. Gjenstår fortsatt noen warnings jeg lar være i denne omgang.

Før (`npm run build`):
![bilde](https://github.com/user-attachments/assets/4f74b594-586b-44b5-80ac-8ce97a33e186)

Etter:
![bilde](https://github.com/user-attachments/assets/0cd83691-b49b-42c1-a007-08ad017c3284)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
