### PR TITLE
Np 47677 avoid searching for duplicate after publishing

### DIFF
--- a/src/api/hooks/useDuplicateRegistrationSearch.ts
+++ b/src/api/hooks/useDuplicateRegistrationSearch.ts
@@ -22,28 +22,26 @@ export const useDuplicateRegistrationSearch = ({
   });
 
   const registrationsWithSimilarName = titleSearch.data?.hits ?? [];
-  const duplicateRegistration = registrationsWithSimilarName.find((reg) => {
-    if (!title) {
-      return false;
-    }
+  const duplicateRegistration = !title
+    ? undefined
+    : registrationsWithSimilarName.find((reg) => {
+        const isSameRegistration = reg.identifier === identifier;
+        const hasSameName = reg.entityDescription?.mainTitle.toLowerCase() === title.toLowerCase();
 
-    const isSameRegistration = reg.identifier === identifier;
-    const hasSameName = reg.entityDescription?.mainTitle.toLowerCase() === title.toLowerCase();
+        if (!hasSameName || isSameRegistration) {
+          return false;
+        }
 
-    if (!hasSameName || isSameRegistration) {
-      return false;
-    }
+        if (publishedYear && reg.entityDescription?.publicationDate?.year !== publishedYear) {
+          return false;
+        }
 
-    if (publishedYear && reg.entityDescription?.publicationDate?.year !== publishedYear) {
-      return false;
-    }
+        if (category && reg.entityDescription?.reference?.publicationInstance?.type !== category) {
+          return false;
+        }
 
-    if (category && reg.entityDescription?.reference?.publicationInstance?.type !== category) {
-      return false;
-    }
-
-    return true;
-  });
+        return true;
+      });
 
   return {
     titleSearchPending: enabled && titleSearch.isPending,

--- a/src/api/hooks/useDuplicateRegistrationSearch.ts
+++ b/src/api/hooks/useDuplicateRegistrationSearch.ts
@@ -1,26 +1,24 @@
-import { useQuery } from '@tanstack/react-query';
-import { useTranslation } from 'react-i18next';
-import { fetchResults, FetchResultsParams } from '../searchApi';
+import { PublicationInstanceType } from '../../types/registration.types';
+import { useRegistrationSearch } from './useRegistrationSearch';
 
-export const useDuplicateRegistrationSearch = (
-  title: string | undefined,
-  identifier?: string,
-  publishedYear?: string,
-  category?: string
-) => {
-  const { t } = useTranslation();
+interface UseDuplicateRegistrationSearchParams {
+  enabled?: boolean;
+  title?: string;
+  identifier?: string;
+  publishedYear?: string;
+  category?: PublicationInstanceType | '';
+}
 
-  const searchConfig: FetchResultsParams = {
-    title: title,
-  };
-
-  const enabled = !!title;
-
-  const titleSearch = useQuery({
-    enabled: enabled,
-    queryKey: ['registrations', searchConfig],
-    queryFn: () => fetchResults(searchConfig),
-    meta: { errorMessage: t('feedback.error.get_registrations') },
+export const useDuplicateRegistrationSearch = ({
+  title,
+  enabled = !!title,
+  identifier,
+  publishedYear,
+  category,
+}: UseDuplicateRegistrationSearchParams) => {
+  const titleSearch = useRegistrationSearch({
+    enabled: enabled && !!title,
+    params: { title },
   });
 
   const registrationsWithSimilarName = titleSearch.data?.hits ?? [];
@@ -36,7 +34,7 @@ export const useDuplicateRegistrationSearch = (
       return false;
     }
 
-    if (publishedYear && reg?.entityDescription?.publicationDate?.year !== publishedYear) {
+    if (publishedYear && reg.entityDescription?.publicationDate?.year !== publishedYear) {
       return false;
     }
 

--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -529,7 +529,7 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
     searchParams.set(ResultParam.Tags, encodeURIComponent(params.tags));
   }
   if (params.title) {
-    searchParams.set(ResultParam.Title, encodeURIComponent(params.title));
+    searchParams.set(ResultParam.Title, params.title);
   }
   if (params.topLevelOrganization) {
     searchParams.set(ResultParam.TopLevelOrganization, encodeURIComponent(params.topLevelOrganization));

--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -529,7 +529,7 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
     searchParams.set(ResultParam.Tags, encodeURIComponent(params.tags));
   }
   if (params.title) {
-    searchParams.set(ResultParam.Title, params.title);
+    searchParams.set(ResultParam.Title, encodeURIComponent(params.title));
   }
   if (params.topLevelOrganization) {
     searchParams.set(ResultParam.TopLevelOrganization, encodeURIComponent(params.topLevelOrganization));

--- a/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
@@ -78,12 +78,13 @@ export const PublishingAccordion = ({
   const [openRejectionDialog, setOpenRejectionDialog] = useState(false);
   const [rejectionReason, setRejectionReason] = useState('');
 
-  const { titleSearchPending, duplicateRegistration } = useDuplicateRegistrationSearch(
-    registration.entityDescription?.mainTitle || '',
-    registration.identifier,
-    registration.entityDescription?.publicationDate?.year,
-    registration.entityDescription?.reference?.publicationInstance?.type
-  );
+  const { titleSearchPending, duplicateRegistration } = useDuplicateRegistrationSearch({
+    enabled: registration.status === RegistrationStatus.Draft && !!registration.entityDescription?.mainTitle,
+    title: registration.entityDescription?.mainTitle,
+    identifier: registration.identifier,
+    publishedYear: registration.entityDescription?.publicationDate?.year,
+    category: registration.entityDescription?.reference?.publicationInstance?.type,
+  });
 
   const [isLoading, setIsLoading] = useState(LoadingState.None);
   const [displayDuplicateWarningModal, setDisplayDuplicateWarningModal] = useState(false);

--- a/src/pages/registration/DescriptionPanel.tsx
+++ b/src/pages/registration/DescriptionPanel.tsx
@@ -23,10 +23,10 @@ export const DescriptionPanel = () => {
   const { values, setFieldValue } = useFormikContext<Registration>();
   const [title, setTitle] = useState('');
   const debouncedTitle = useDebounce(title);
-  const { titleSearchPending, duplicateRegistration } = useDuplicateRegistrationSearch(
-    debouncedTitle || values.entityDescription?.mainTitle,
-    values.identifier
-  );
+  const { titleSearchPending, duplicateRegistration } = useDuplicateRegistrationSearch({
+    title: debouncedTitle || values.entityDescription?.mainTitle,
+    identifier: values.identifier,
+  });
 
   return (
     <InputContainerBox>

--- a/src/pages/registration/ResourceTypePanel.tsx
+++ b/src/pages/registration/ResourceTypePanel.tsx
@@ -35,10 +35,10 @@ import { DatasetForm } from './resource_type_tab/sub_type_forms/research_data_ty
 export const ResourceTypePanel = () => {
   const { t } = useTranslation();
   const { values } = useFormikContext<Registration>();
-  const { duplicateRegistration } = useDuplicateRegistrationSearch(
-    values.entityDescription?.mainTitle || '',
-    values.identifier
-  );
+  const { duplicateRegistration } = useDuplicateRegistrationSearch({
+    title: values.entityDescription?.mainTitle,
+    identifier: values.identifier,
+  });
   const instanceType = values.entityDescription?.reference?.publicationInstance?.type ?? '';
   const mainType = getMainRegistrationType(instanceType);
 


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47677

Unngå å søke etter duplikater når posten allerede er publisert. Dette trigget en feil for [denne](https://sikt.atlassian.net/browse/NP-47675) posten i test, da søket feiler. Dette vil ikke trigge et søk nå lenger, som kan ses [her](http://localhost:3000/registration/0191e03bdc60-721d4cbd-1f0e-4db5-a553-25c4e05c2eee/) (localhost) for en post med tegn i tittelen som fører til feil i søket. Merk at man må ha redigeringstilgang på posten for at dette skal skje.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
