### PR TITLE
Show loading indicator for pending NVI status numbers

### DIFF
--- a/src/pages/messages/components/NviStatusTableRow.tsx
+++ b/src/pages/messages/components/NviStatusTableRow.tsx
@@ -1,6 +1,6 @@
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { IconButton, TableCell, TableRow } from '@mui/material';
+import { IconButton, Skeleton, styled, TableCell, TableRow } from '@mui/material';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NviInstitutionStatusResponse } from '../../../types/nvi.types';
@@ -13,24 +13,46 @@ interface NviStatusTableRowProps {
   level?: number;
 }
 
+const StyledSkeleton = styled(Skeleton)({
+  width: '2ch',
+  margin: 'auto',
+});
+
 export const NviStatusTableRow = ({ organization, aggregations, level = 0 }: NviStatusTableRowProps) => {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(level === 0);
   const orgAggregations = aggregations?.[organization.id];
+  aggregations = undefined;
 
   return (
     <>
       <TableRow sx={{ bgcolor: level % 2 === 0 ? undefined : '#FEFBF3' }}>
         <TableCell sx={{ pl: `${1 + level * 1.5}rem`, py: '1rem' }}>{getLanguageString(organization.labels)}</TableCell>
-        <TableCell align="center">{orgAggregations?.status.New?.docCount.toLocaleString() ?? 0}</TableCell>
-        <TableCell align="center">{orgAggregations?.status.Pending?.docCount.toLocaleString() ?? 0}</TableCell>
-        <TableCell align="center">{orgAggregations?.status.Approved?.docCount.toLocaleString() ?? 0}</TableCell>
-        <TableCell align="center">{orgAggregations?.status.Rejected?.docCount.toLocaleString() ?? 0}</TableCell>
-        <TableCell align="center">{orgAggregations?.docCount.toLocaleString() ?? 0}</TableCell>
         <TableCell align="center">
-          {orgAggregations?.points.value.toLocaleString(undefined, { maximumFractionDigits: 2 }) ?? 0}
+          {aggregations ? (orgAggregations?.status.New?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
         </TableCell>
-        <TableCell align="center">{orgAggregations?.dispute?.docCount.toLocaleString() ?? 0}</TableCell>
+        <TableCell align="center">
+          {aggregations ? (orgAggregations?.status.Pending?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
+        </TableCell>
+        <TableCell align="center">
+          {aggregations ? (orgAggregations?.status.Approved?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
+        </TableCell>
+        <TableCell align="center">
+          {aggregations ? (orgAggregations?.status.Rejected?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
+        </TableCell>
+        <TableCell align="center">
+          {aggregations ? (orgAggregations?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
+        </TableCell>
+        <TableCell align="center">
+          {aggregations ? (
+            (orgAggregations?.points.value.toLocaleString(undefined, { maximumFractionDigits: 2 }) ?? 0)
+          ) : (
+            <StyledSkeleton />
+          )}
+        </TableCell>
+        <TableCell align="center">
+          {aggregations ? (orgAggregations?.dispute?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
+        </TableCell>
         <TableCell>
           {level !== 0 && organization.hasPart && organization.hasPart.length > 0 && (
             <IconButton onClick={() => setExpanded(!expanded)} title={t('tasks.nvi.show_subunits')}>


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47687 (Egentlig ikke direkte koblet til denne tasken)

Vis lasteindikator i stedet for å defaulte til 0 mens man venter på data. 

![bilde](https://github.com/user-attachments/assets/de8e3b46-4138-47aa-9a3d-ca2cf1c0a80a)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
