### PR TITLE
NP-47390 Sync params for all fields on advanced search

### DIFF
--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { ResultParam } from '../api/searchApi';
 import { SearchTextField } from '../pages/search/SearchTextField';
-import { SearchParam } from '../utils/searchHelpers';
+import { dataSearchFieldAttributeName, SearchParam, syncParamsWithSearchFields } from '../utils/searchHelpers';
 
 interface SearchFormProps extends Pick<BoxProps, 'sx'>, Pick<TextFieldProps, 'label' | 'placeholder'> {
   paramName?: string;
@@ -28,21 +28,20 @@ export const SearchForm = ({ sx, label, placeholder, dataTestId, paramName = 'qu
       component="form"
       onSubmit={(event) => {
         event.preventDefault();
+        const syncedParams = syncParamsWithSearchFields(searchParams);
         if (inputValue) {
-          searchParams.set(paramName, inputValue);
+          syncedParams.set(paramName, inputValue);
         } else {
-          searchParams.delete(paramName);
+          syncedParams.delete(paramName);
         }
 
-        if (searchParams.get(ResultParam.From)) {
-          searchParams.delete(ResultParam.From);
-        } else if (searchParams.get(SearchParam.Page)) {
-          searchParams.delete(SearchParam.Page);
-        }
+        syncedParams.delete(ResultParam.From);
+        syncedParams.delete(SearchParam.Page);
 
         history.push({ search: searchParams.toString() });
       }}>
       <SearchTextField
+        inputProps={{ [dataSearchFieldAttributeName]: paramName }}
         dataTestId={dataTestId}
         name={paramName}
         label={label}

--- a/src/pages/search/advanced_search/AdvancedSearchPage.tsx
+++ b/src/pages/search/advanced_search/AdvancedSearchPage.tsx
@@ -20,6 +20,7 @@ import { StyledFilterHeading } from '../../../components/styled/Wrappers';
 import { ScientificIndexStatuses } from '../../../types/nvi.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { useRegistrationsQueryParams } from '../../../utils/hooks/useRegistrationSearchParams';
+import { syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 import { ExportResultsButton } from '../ExportResultsButton';
 import { PublicationYearIntervalFilter } from '../PublicationYearIntervalFilter';
 import { RegistrationSearch } from '../registration_search/RegistrationSearch';
@@ -56,14 +57,15 @@ export const AdvancedSearchPage = () => {
     keepDataWhileLoading: true,
   });
 
-  const handleNviReportedCheckbox = (event: React.SyntheticEvent, checked: boolean) => {
+  const handleNviReportedCheckbox = (_: unknown, checked: boolean) => {
+    const syncedParams = syncParamsWithSearchFields(params);
     if (checked) {
-      params.set(ResultParam.ScientificIndexStatus, ScientificIndexStatuses.Reported);
+      syncedParams.set(ResultParam.ScientificIndexStatus, ScientificIndexStatuses.Reported);
     } else {
-      params.delete(ResultParam.ScientificIndexStatus);
+      syncedParams.delete(ResultParam.ScientificIndexStatus);
     }
 
-    history.push({ search: params.toString() });
+    history.push({ search: syncedParams.toString() });
   };
 
   return (

--- a/src/pages/search/advanced_search/CategoryFilterDialog.tsx
+++ b/src/pages/search/advanced_search/CategoryFilterDialog.tsx
@@ -5,6 +5,7 @@ import { useHistory } from 'react-router-dom';
 import { ResultParam, TicketSearchParam } from '../../../api/searchApi';
 import { CategorySelector } from '../../../components/CategorySelector';
 import { PublicationInstanceType } from '../../../types/registration.types';
+import { syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 
 interface CategoryFilterDialogProps {
   open: boolean;
@@ -56,14 +57,16 @@ export const CategoryFilterDialog = ({
           variant="outlined"
           onClick={() => {
             const params = new URLSearchParams(history.location.search);
+            const syncedParams = syncParamsWithSearchFields(params);
             const newCategoryShould = selectedCategories.join(',');
             if (newCategoryShould) {
-              params.set(searchParam, newCategoryShould);
+              syncedParams.set(searchParam, newCategoryShould);
             } else {
-              params.delete(searchParam);
+              syncedParams.delete(searchParam);
             }
-            params.set(ResultParam.From, '0');
-            history.push({ search: params.toString() });
+            syncedParams.delete(ResultParam.From);
+
+            history.push({ search: syncedParams.toString() });
             closeDialog();
           }}>
           {t('common.use')}

--- a/src/pages/search/advanced_search/FileStatusSelect.tsx
+++ b/src/pages/search/advanced_search/FileStatusSelect.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { ResultParam } from '../../../api/searchApi';
 import { dataTestId } from '../../../utils/dataTestIds';
+import { syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 
 enum FileStatus {
   hasPublicFiles = 'hasPublicFiles',
@@ -17,14 +18,15 @@ export const FileStatusSelect = () => {
 
   const handleChange = (event: SelectChangeEvent) => {
     const newValue = event.target.value;
+    const syncedParams = syncParamsWithSearchFields(searchParams);
 
     if (newValue) {
-      searchParams.set(ResultParam.Files, newValue);
+      syncedParams.set(ResultParam.Files, newValue);
     } else {
-      searchParams.delete(ResultParam.Files);
-      searchParams.delete(ResultParam.From);
+      syncedParams.delete(ResultParam.Files);
     }
-    history.push({ search: searchParams.toString() });
+    syncedParams.delete(ResultParam.From);
+    history.push({ search: syncedParams.toString() });
   };
 
   return (

--- a/src/pages/search/advanced_search/FundingSourceFilter.tsx
+++ b/src/pages/search/advanced_search/FundingSourceFilter.tsx
@@ -7,6 +7,7 @@ import { ResultParam } from '../../../api/searchApi';
 import { AutocompleteTextField } from '../../../components/AutocompleteTextField';
 import { FundingSource } from '../../../types/project.types';
 import { dataTestId } from '../../../utils/dataTestIds';
+import { syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 import { getLanguageString } from '../../../utils/translation-helpers';
 
 export const FundingSourceFilter = () => {
@@ -25,13 +26,15 @@ export const FundingSourceFilter = () => {
   const fundingSourcesList = fundingSourcesQuery.data?.sources ?? [];
 
   const handleChange = (selectedValue: FundingSource | null) => {
+    const syncedParams = syncParamsWithSearchFields(searchParams);
     if (selectedValue) {
-      searchParams.set(ResultParam.FundingSource, selectedValue.identifier);
+      syncedParams.set(ResultParam.FundingSource, selectedValue.identifier);
     } else {
-      searchParams.delete(ResultParam.FundingSource);
+      syncedParams.delete(ResultParam.FundingSource);
     }
+    syncedParams.delete(ResultParam.From);
 
-    history.push({ search: searchParams.toString() });
+    history.push({ search: syncedParams.toString() });
   };
 
   return (

--- a/src/pages/search/advanced_search/JournalFilter.tsx
+++ b/src/pages/search/advanced_search/JournalFilter.tsx
@@ -14,7 +14,7 @@ import { StyledFilterHeading } from '../../../components/styled/Wrappers';
 import { Journal } from '../../../types/registration.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
-import { keepSimilarPreviousData } from '../../../utils/searchHelpers';
+import { keepSimilarPreviousData, syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 import { PublicationChannelOption } from '../../registration/resource_type_tab/components/PublicationChannelOption';
 
 export const JournalFilter = () => {
@@ -48,13 +48,15 @@ export const JournalFilter = () => {
   });
 
   const handleChange = (selectedValue: Journal | null) => {
+    const syncedParams = syncParamsWithSearchFields(searchParams);
     if (selectedValue) {
-      searchParams.set(ResultParam.Journal, selectedValue.identifier);
+      syncedParams.set(ResultParam.Journal, selectedValue.identifier);
     } else {
-      searchParams.delete(ResultParam.Journal);
+      syncedParams.delete(ResultParam.Journal);
     }
+    syncedParams.delete(ResultParam.From);
 
-    history.push({ search: searchParams.toString() });
+    history.push({ search: syncedParams.toString() });
   };
 
   const isFetching = journalParam ? selectedJournalQuery.isPending : journalOptionsQuery.isFetching;

--- a/src/pages/search/advanced_search/LanguageFilter.tsx
+++ b/src/pages/search/advanced_search/LanguageFilter.tsx
@@ -6,6 +6,7 @@ import { useHistory } from 'react-router';
 import { ResultParam } from '../../../api/searchApi';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { registrationLanguageOptions } from '../../../utils/registration-helpers';
+import { syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 
 export const LanguageFilter = () => {
   const { t, i18n } = useTranslation();
@@ -19,6 +20,7 @@ export const LanguageFilter = () => {
   };
 
   const updateSelectedLanguages = (selectedUris: string[]) => {
+    const syncedParams = syncParamsWithSearchFields(searchParams);
     if (selectedUris && selectedUris.length > 0) {
       const languages = selectedUris
         .map(
@@ -28,15 +30,16 @@ export const LanguageFilter = () => {
         .filter(Boolean);
 
       if (languages.length > 0) {
-        searchParams.set(ResultParam.PublicationLanguageShould, languages.join(','));
+        syncedParams.set(ResultParam.PublicationLanguageShould, languages.join(','));
       } else {
-        searchParams.delete(ResultParam.PublicationLanguageShould);
+        syncedParams.delete(ResultParam.PublicationLanguageShould);
       }
     } else {
-      searchParams.delete(ResultParam.PublicationLanguageShould);
+      syncedParams.delete(ResultParam.PublicationLanguageShould);
     }
+    syncedParams.delete(ResultParam.From);
 
-    history.push({ search: searchParams.toString() });
+    history.push({ search: syncedParams.toString() });
   };
 
   const selectedLanguages = languageParam

--- a/src/pages/search/advanced_search/OrganizationFilters.tsx
+++ b/src/pages/search/advanced_search/OrganizationFilters.tsx
@@ -1,6 +1,6 @@
 import { Autocomplete, Box, Checkbox, Chip, FormControlLabel, Skeleton } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
-import { useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
@@ -18,6 +18,7 @@ import { StyledFilterHeading } from '../../../components/styled/Wrappers';
 import { RootState } from '../../../redux/store';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
+import { syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 import { getLanguageString } from '../../../utils/translation-helpers';
 import { OrganizationHierarchyFilter } from './OrganizationHierarchyFilter';
 
@@ -67,16 +68,18 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
 
   const isLoading = topLevelOrganizationQuery.isFetching || organizationSearchQuery.isFetching;
 
-  const handleCheckedExcludeSubunits = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleCheckedExcludeSubunits = (event: ChangeEvent<HTMLInputElement>) => {
+    const syncedParams = syncParamsWithSearchFields(params);
     if (topLevelOrgParam) {
       if (event.target.checked) {
-        params.set(ResultParam.ExcludeSubunits, 'true');
+        syncedParams.set(ResultParam.ExcludeSubunits, 'true');
       } else {
-        params.delete(ResultParam.ExcludeSubunits);
+        syncedParams.delete(ResultParam.ExcludeSubunits);
       }
+      syncedParams.delete(ResultParam.From);
     }
 
-    history.push({ search: params.toString() });
+    history.push({ search: syncedParams.toString() });
   };
 
   return (

--- a/src/pages/search/advanced_search/PublisherFilter.tsx
+++ b/src/pages/search/advanced_search/PublisherFilter.tsx
@@ -14,7 +14,7 @@ import { StyledFilterHeading } from '../../../components/styled/Wrappers';
 import { Publisher } from '../../../types/registration.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
-import { keepSimilarPreviousData } from '../../../utils/searchHelpers';
+import { keepSimilarPreviousData, syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 import { PublicationChannelOption } from '../../registration/resource_type_tab/components/PublicationChannelOption';
 
 export const PublisherFilter = () => {
@@ -48,13 +48,15 @@ export const PublisherFilter = () => {
   });
 
   const handleChange = (selectedValue: Publisher | null) => {
+    const syncedParams = syncParamsWithSearchFields(searchParams);
     if (selectedValue) {
-      searchParams.set(ResultParam.Publisher, selectedValue.identifier);
+      syncedParams.set(ResultParam.Publisher, selectedValue.identifier);
     } else {
-      searchParams.delete(ResultParam.Publisher);
+      syncedParams.delete(ResultParam.Publisher);
     }
+    syncedParams.delete(ResultParam.From);
 
-    history.push({ search: searchParams.toString() });
+    history.push({ search: syncedParams.toString() });
   };
 
   const isFetching = publisherParam ? selectedPublisherQuery.isPending : publisherOptionsQuery.isFetching;

--- a/src/pages/search/advanced_search/ScientificValueFilter.tsx
+++ b/src/pages/search/advanced_search/ScientificValueFilter.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { ResultParam } from '../../../api/searchApi';
 import { dataTestId } from '../../../utils/dataTestIds';
+import { syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 
 export enum ScientificValueLevels {
   LevelZero = 'Unassigned,LevelZero',

--- a/src/pages/search/advanced_search/ScientificValueFilter.tsx
+++ b/src/pages/search/advanced_search/ScientificValueFilter.tsx
@@ -1,5 +1,5 @@
 import { Checkbox, FormControlLabel, FormGroup } from '@mui/material';
-import React from 'react';
+import { ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { ResultParam } from '../../../api/searchApi';
@@ -23,7 +23,7 @@ export const ScientificValueFilter = () => {
     levelTwo: scientificValueParam.includes(ScientificValueLevels.LevelTwo),
   };
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     const name = event.target.name as keyof typeof selectedScientificValues;
     const newSelectedScientificValues = {
       ...selectedScientificValues,
@@ -38,12 +38,15 @@ export const ScientificValueFilter = () => {
       .filter(Boolean)
       .join(',');
 
+    const syncedParams = syncParamsWithSearchFields(searchParams);
+
     if (scientificValues.length > 0) {
-      searchParams.set(ResultParam.ScientificValue, scientificValues);
+      syncedParams.set(ResultParam.ScientificValue, scientificValues);
     } else {
-      searchParams.delete(ResultParam.ScientificValue);
+      syncedParams.delete(ResultParam.ScientificValue);
     }
-    history.push({ search: searchParams.toString() });
+    syncedParams.delete(ResultParam.From);
+    history.push({ search: syncedParams.toString() });
   };
 
   return (

--- a/src/pages/search/advanced_search/SeriesFilter.tsx
+++ b/src/pages/search/advanced_search/SeriesFilter.tsx
@@ -14,7 +14,7 @@ import { StyledFilterHeading } from '../../../components/styled/Wrappers';
 import { Series } from '../../../types/registration.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
-import { keepSimilarPreviousData } from '../../../utils/searchHelpers';
+import { keepSimilarPreviousData, syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 import { PublicationChannelOption } from '../../registration/resource_type_tab/components/PublicationChannelOption';
 
 export const SeriesFilter = () => {
@@ -48,13 +48,15 @@ export const SeriesFilter = () => {
   });
 
   const handleChange = (selectedValue: Series | null) => {
+    const syncedParams = syncParamsWithSearchFields(searchParams);
     if (selectedValue) {
-      searchParams.set(ResultParam.Series, selectedValue.identifier);
+      syncedParams.set(ResultParam.Series, selectedValue.identifier);
     } else {
-      searchParams.delete(ResultParam.Series);
+      syncedParams.delete(ResultParam.Series);
     }
+    syncedParams.delete(ResultParam.From);
 
-    history.push({ search: searchParams.toString() });
+    history.push({ search: syncedParams.toString() });
   };
 
   const isFetching = seriesParam ? selectedSeriesQuery.isPending : seriesOptionsQuery.isFetching;

--- a/src/pages/search/advanced_search/VocabularSearchField.tsx
+++ b/src/pages/search/advanced_search/VocabularSearchField.tsx
@@ -6,6 +6,7 @@ import { AutocompleteTextField } from '../../../components/AutocompleteTextField
 import { HrcsActivityOption } from '../../../components/HrcsActivityAutocompleteOption';
 import { hrcsCategories } from '../../../resources/vocabularies/hrcsCategories';
 import { dataTestId } from '../../../utils/dataTestIds';
+import { syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 import { getLanguageString } from '../../../utils/translation-helpers';
 import { hrcsActivityOptions } from '../../registration/description_tab/vocabularies/HrcsActivityInput';
 
@@ -29,12 +30,14 @@ export const VocabularSearchField = () => {
       value={selectedValue}
       renderOption={({ key, ...props }, option) => <HrcsActivityOption key={option.id} props={props} option={option} />}
       onChange={(_, value) => {
+        const syncedParams = syncParamsWithSearchFields(searchParams);
         if (value) {
-          searchParams.set(ResultParam.Vocabulary, value.id);
+          syncedParams.set(ResultParam.Vocabulary, value.id);
         } else {
-          searchParams.delete(ResultParam.Vocabulary);
+          syncedParams.delete(ResultParam.Vocabulary);
         }
-        history.push({ search: searchParams.toString() });
+        syncedParams.delete(ResultParam.From);
+        history.push({ search: syncedParams.toString() });
       }}
       getOptionLabel={(option) => getLanguageString(option.label)}
       groupBy={(option) =>


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47390

Sørg for at siste verdi av søkefelter alltid brukes når bruker trigger nytt søk på avansert søk. Har også lagt til nullstilling av paginering når man endrer søket, som vi manglet ganske mange plasser.

Basert på https://github.com/BIBSYSDEV/NVA-Frontend/pull/6307. Kommer flere PRer som løser det samme flere andre plasser

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
