### PR TITLE
Set aria label for result search pagination

### DIFF
--- a/src/components/ListPagination.tsx
+++ b/src/components/ListPagination.tsx
@@ -8,6 +8,7 @@ interface ListPaginationProps extends Omit<ListPaginationBottomProps, 'pageCount
   showPaginationTop?: boolean;
   sortingComponent?: ReactNode;
   alternativePaginationText?: string;
+  paginationAriaLabel?: string;
 }
 
 export const ListPagination = ({
@@ -22,6 +23,7 @@ export const ListPagination = ({
   maxHits,
   rowsPerPageOptions,
   alternativePaginationText,
+  paginationAriaLabel,
 }: ListPaginationProps) => {
   const itemsStart = count > 0 ? (page - 1) * rowsPerPage + 1 : 0;
   const itemsEnd = Math.min(page * rowsPerPage, count);
@@ -43,6 +45,7 @@ export const ListPagination = ({
         pageCounterComponent={pageCounter}
         rowsPerPageOptions={rowsPerPageOptions}
         alternativePaginationText={alternativePaginationText}
+        paginationAriaLabel={paginationAriaLabel}
       />
     </>
   );

--- a/src/components/ListPaginationBottom.tsx
+++ b/src/components/ListPaginationBottom.tsx
@@ -14,6 +14,7 @@ export interface ListPaginationBottomProps {
   maxHits?: number; // Default limit of 10_000 hits in ElasticSearch
   pageCounterComponent: ReactNode;
   alternativePaginationText?: string;
+  paginationAriaLabel?: string;
 }
 
 export const ListPaginationBottom = ({
@@ -26,6 +27,7 @@ export const ListPaginationBottom = ({
   maxHits,
   pageCounterComponent,
   alternativePaginationText,
+  paginationAriaLabel,
 }: ListPaginationBottomProps) => {
   const { t } = useTranslation();
 
@@ -52,6 +54,7 @@ export const ListPaginationBottom = ({
             justifyContent: 'center',
           },
         }}
+        aria-label={paginationAriaLabel}
         page={page}
         count={pages}
         onChange={(_, newPage) => onPageChange(newPage)}

--- a/src/pages/my_page/user_profile/MyResults.tsx
+++ b/src/pages/my_page/user_profile/MyResults.tsx
@@ -55,6 +55,7 @@ export const MyResults = () => {
         </Box>
       ) : registrationsQuery.data && registrationsQuery.data.totalHits > 0 ? (
         <ListPagination
+          paginationAriaLabel={t('common.pagination_project_search')}
           count={registrationsQuery.data.totalHits}
           rowsPerPage={rowsPerPage}
           page={page}

--- a/src/pages/research_profile/ResearchProfile.tsx
+++ b/src/pages/research_profile/ResearchProfile.tsx
@@ -8,8 +8,8 @@ import {
   Divider,
   Grid,
   IconButton,
-  Link as MuiLink,
   List,
+  Link as MuiLink,
   Typography,
 } from '@mui/material';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
@@ -261,6 +261,7 @@ const ResearchProfile = () => {
           <CircularProgress aria-labelledby="registration-label" />
         ) : registrationsQuery.data && registrationsQuery.data.totalHits > 0 ? (
           <ListPagination
+            paginationAriaLabel={t('common.pagination_result_search')}
             count={registrationsQuery.data.totalHits}
             rowsPerPage={registrationRowsPerPage}
             page={registrationsPage}
@@ -287,6 +288,7 @@ const ResearchProfile = () => {
           <CircularProgress aria-labelledby="project-label" />
         ) : projects.length > 0 ? (
           <ListPagination
+            paginationAriaLabel={t('common.pagination_project_search')}
             count={projectsQuery.data?.size ?? 0}
             rowsPerPage={projectRowsPerPage}
             page={projectsPage}

--- a/src/pages/search/registration_search/RegistrationSearch.tsx
+++ b/src/pages/search/registration_search/RegistrationSearch.tsx
@@ -33,6 +33,7 @@ export const RegistrationSearch = ({ registrationQuery }: Pick<SearchPageProps, 
         <ListSkeleton arrayLength={3} minWidth={40} height={100} />
       ) : registrationQuery.data?.hits && registrationQuery.data.hits.length > 0 ? (
         <ListPagination
+          paginationAriaLabel={t('common.pagination_project_search')}
           count={registrationQuery.data.totalHits}
           page={page + 1}
           onPageChange={(newPage) => updatePath(((newPage - 1) * rowsPerPage).toString(), rowsPerPage.toString())}

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -231,6 +231,8 @@
     "other": "Annet",
     "overview": "Oversikt",
     "page_title": "Nasjonalt vitenarkiv",
+    "pagination_project_search": "Paginering for prosjektsøk",
+    "pagination_result_search": "Paginering for resultatsøk",
     "pagination_rows_per_page": "Antall resultater per side:",
     "pagination_showing_interval": "Viser {{start}}-{{end}} av {{total}}",
     "person": "Person",
@@ -311,10 +313,6 @@
     "yes": "Ja"
   },
   "disciplines": {
-    "0001": "Humaniora",
-    "0002": "Samfunnsvitenskap",
-    "0003": "Medisin og helsefag",
-    "0004": "Realfag og teknologi",
     "1003": "Arkeologi og konservering",
     "1005": "Asiatiske og afrikanske studier",
     "1007": "Engelsk",
@@ -386,7 +384,11 @@
     "1162": "Konstruksjonsfag",
     "1166": "Filosofi",
     "1168": "Historie og idéhistorie",
-    "1170": "Kunst, design og arkitektur"
+    "1170": "Kunst, design og arkitektur",
+    "0001": "Humaniora",
+    "0002": "Samfunnsvitenskap",
+    "0003": "Medisin og helsefag",
+    "0004": "Realfag og teknologi"
   },
   "editor": {
     "categories_with_files": "Kategorier med filopplasting",


### PR DESCRIPTION
# Description

Fiks UU-problem for resultatsøk på forskerprofil, da to `<Pagination>`-elementer i dag får samme `aria-label` og blir umilig å skille fra hverandre.

![bilde](https://github.com/user-attachments/assets/9fef4dd2-b8ae-46c1-844a-835dbad26a55)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
