### PR TITLE
Trigger errors to test Crash Analytics

### DIFF
--- a/src/pages/editor/PortfolioSearchPage.tsx
+++ b/src/pages/editor/PortfolioSearchPage.tsx
@@ -1,7 +1,8 @@
-import { Typography } from '@mui/material';
+import { Button, Typography } from '@mui/material';
 import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useCustomerRegistrationSearch } from '../../api/hooks/useFetchCustomerRegistrationSearch';
+import { BetaFunctionality } from '../../components/BetaFunctionality';
 import { SearchForm } from '../../components/SearchForm';
 import { useRegistrationsQueryParams } from '../../utils/hooks/useRegistrationSearchParams';
 import { RegistrationSearch } from '../search/registration_search/RegistrationSearch';
@@ -20,6 +21,28 @@ export const PortfolioSearchPage = ({ title }: PortfolioSearchPageProps) => {
       <Helmet>
         <title>{title}</title>
       </Helmet>
+      <BetaFunctionality>
+        <Button
+          onClick={() => {
+            throw new Error();
+          }}>
+          Default Error
+        </Button>
+        <Button
+          onClick={() => {
+            throw new Error('Custom error text');
+          }}>
+          Custom Error
+        </Button>
+        <Button
+          onClick={() => {
+            new Promise((resolve, reject) => {
+              reject('Reject promise!');
+            });
+          }}>
+          Reject promise
+        </Button>
+      </BetaFunctionality>
       <Typography variant="h1" gutterBottom>
         {title}
       </Typography>


### PR DESCRIPTION
Litt cowboyhatt her🤠, men hear me out:

Vi har nå aktivert Matomo Crash Analytics, men etter noen dager har vi fortsatt ikke fått noen feil i konsollen der.

Legger derfor inn noen hardkodete Errors i beta-tag nå, sånn at vi kan trigge dette selv, og vite om loggingen av errors faktisk virker.

Tenker å ta dette rett inn i `staging` (test), så revertere commiten med en gang jeg har fått verifisert at det virker. Så er dette borte for godt igjen.