### PR TITLE
Configure logging of console errors

### DIFF
--- a/src/matomo/matomo.ts
+++ b/src/matomo/matomo.ts
@@ -18,4 +18,26 @@ export const initializeMatomo = (matomoContainerUrl: string) => {
   newScriptElement.async = true;
   newScriptElement.src = matomoContainerUrl;
   firstScriptElement.parentNode?.insertBefore(newScriptElement, firstScriptElement);
+
+  // Log global JavaScript errors
+  window.onerror = function (message, source, lineno, colno, error) {
+    _mtm.push({
+      event: 'JavaScript Error',
+      errorMessage: message,
+      errorSource: `${source}:${lineno}:${colno}`,
+      errorStack: error ? error.stack : '',
+    });
+  };
+
+  // Log console errors
+  /* eslint-disable no-console */
+  const originalConsoleError = console.error;
+  console.error = function (message, ...optionalParams) {
+    _mtm.push({
+      event: 'trackJsError',
+      error: message,
+      optionalParams: optionalParams,
+    });
+    originalConsoleError.apply(console, [message, ...optionalParams]); // Ensure error is still shown in console
+  };
 };


### PR DESCRIPTION
PR for å verifisere at errors logges til matomo viste seg at det ikke virker helt som ønsket: https://github.com/BIBSYSDEV/NVA-Frontend/pull/6367 (NB! den PRen må/bør reverteres før vi ruller ut videre til prod)

Legger ved forsøk på å konfigurere eksplisitt logging her