### PR TITLE
NP-47794 Fix result export params

### DIFF
--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -348,7 +348,6 @@ export enum ResultParam {
   Publisher = 'publisher',
   Query = 'query',
   Results = 'results',
-  ScientificIndex = 'scientificIndex',
   ScientificIndexStatus = 'scientificIndexStatus',
   ScientificReportPeriodBeforeParam = 'scientificReportPeriodBefore',
   ScientificReportPeriodSinceParam = 'scientificReportPeriodSince',
@@ -404,7 +403,6 @@ export interface FetchResultsParams {
   [ResultParam.Query]?: string | null;
   [ResultParam.Results]?: number | null;
   [ResultParam.Series]?: string | null;
-  [ResultParam.ScientificIndex]?: string | null;
   [ResultParam.ScientificIndexStatus]?: ScientificIndexStatuses | null;
   [ResultParam.ScientificReportPeriodBeforeParam]?: string | null;
   [ResultParam.ScientificReportPeriodSinceParam]?: string | null;
@@ -517,9 +515,12 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
   if (params.query) {
     searchParams.set(ResultParam.Query, params.query);
   }
-  if (params.scientificIndex) {
-    searchParams.set(ResultParam.ScientificReportPeriodBeforeParam, (+params.scientificIndex + 1).toString());
-    searchParams.set(ResultParam.ScientificReportPeriodSinceParam, params.scientificIndex);
+  if (params.scientificReportPeriodSince) {
+    searchParams.set(
+      ResultParam.ScientificReportPeriodBeforeParam,
+      (+params.scientificReportPeriodSince + 1).toString()
+    );
+    searchParams.set(ResultParam.ScientificReportPeriodSinceParam, params.scientificReportPeriodSince);
   }
   if (params.scientificIndexStatus) {
     searchParams.set(ResultParam.ScientificIndexStatus, params.scientificIndexStatus);

--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -348,7 +348,6 @@ export enum ResultParam {
   Publisher = 'publisher',
   Query = 'query',
   Results = 'results',
-  ScientificIndex = 'scientificIndex',
   ScientificIndexStatus = 'scientificIndexStatus',
   ScientificReportPeriodBeforeParam = 'scientificReportPeriodBefore',
   ScientificReportPeriodSinceParam = 'scientificReportPeriodSince',
@@ -404,7 +403,6 @@ export interface FetchResultsParams {
   [ResultParam.Query]?: string | null;
   [ResultParam.Results]?: number | null;
   [ResultParam.Series]?: string | null;
-  [ResultParam.ScientificIndex]?: string | null;
   [ResultParam.ScientificIndexStatus]?: ScientificIndexStatuses | null;
   [ResultParam.ScientificReportPeriodBeforeParam]?: string | null;
   [ResultParam.ScientificReportPeriodSinceParam]?: string | null;

--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -406,6 +406,7 @@ export interface FetchResultsParams {
   [ResultParam.ScientificIndexStatus]?: ScientificIndexStatuses | null;
   [ResultParam.ScientificReportPeriodBeforeParam]?: string | null;
   [ResultParam.ScientificReportPeriodSinceParam]?: string | null;
+  [ResultParam.ScientificReportPeriodBeforeParam]?: string | null;
   [ResultParam.ScientificValue]?: string | null;
   [ResultParam.Sort]?: SortOrder | null;
   [ResultParam.Tags]?: string | null;
@@ -516,11 +517,10 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
     searchParams.set(ResultParam.Query, params.query);
   }
   if (params.scientificReportPeriodSince) {
-    searchParams.set(
-      ResultParam.ScientificReportPeriodBeforeParam,
-      (+params.scientificReportPeriodSince + 1).toString()
-    );
     searchParams.set(ResultParam.ScientificReportPeriodSinceParam, params.scientificReportPeriodSince);
+  }
+  if (params.scientificReportPeriodBefore) {
+    searchParams.set(ResultParam.ScientificReportPeriodBeforeParam, params.scientificReportPeriodBefore);
   }
   if (params.scientificIndexStatus) {
     searchParams.set(ResultParam.ScientificIndexStatus, params.scientificIndexStatus);

--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -348,6 +348,7 @@ export enum ResultParam {
   Publisher = 'publisher',
   Query = 'query',
   Results = 'results',
+  ScientificIndex = 'scientificIndex',
   ScientificIndexStatus = 'scientificIndexStatus',
   ScientificReportPeriodBeforeParam = 'scientificReportPeriodBefore',
   ScientificReportPeriodSinceParam = 'scientificReportPeriodSince',
@@ -403,6 +404,7 @@ export interface FetchResultsParams {
   [ResultParam.Query]?: string | null;
   [ResultParam.Results]?: number | null;
   [ResultParam.Series]?: string | null;
+  [ResultParam.ScientificIndex]?: string | null;
   [ResultParam.ScientificIndexStatus]?: ScientificIndexStatuses | null;
   [ResultParam.ScientificReportPeriodBeforeParam]?: string | null;
   [ResultParam.ScientificReportPeriodSinceParam]?: string | null;

--- a/src/pages/search/registration_search/RegistrationSearchBar.tsx
+++ b/src/pages/search/registration_search/RegistrationSearchBar.tsx
@@ -36,7 +36,7 @@ const facetParams: string[] = [
   ResultParam.Publisher,
   ResultParam.Files,
   ResultParam.FundingSource,
-  ResultParam.ScientificIndex,
+  ResultParam.ScientificReportPeriodSinceParam,
   ResultParam.Series,
   ResultParam.TopLevelOrganization,
 ];
@@ -309,7 +309,7 @@ export const RegistrationSearchBar = ({ registrationQuery }: Pick<SearchPageProp
                     }
                     break;
                   }
-                  case ResultParam.ScientificIndex: {
+                  case ResultParam.ScientificReportPeriodSinceParam: {
                     fieldName = t('basic_data.nvi.nvi_publication_year');
                     fieldValueText = value;
                     break;

--- a/src/pages/search/registration_search/RegistrationSearchBar.tsx
+++ b/src/pages/search/registration_search/RegistrationSearchBar.tsx
@@ -37,6 +37,7 @@ const facetParams: string[] = [
   ResultParam.Files,
   ResultParam.FundingSource,
   ResultParam.ScientificReportPeriodSinceParam,
+  ResultParam.ScientificReportPeriodBeforeParam,
   ResultParam.Series,
   ResultParam.TopLevelOrganization,
 ];

--- a/src/pages/search/registration_search/filters/RegistrationFacetsFilter.tsx
+++ b/src/pages/search/registration_search/filters/RegistrationFacetsFilter.tsx
@@ -247,7 +247,6 @@ export const RegistrationFacetsFilter = ({ registrationQuery }: Pick<SearchPageP
                   onClickFacet={() => {
                     if (isSelected) {
                       removeFacetFilter(ResultParam.ScientificReportPeriodSinceParam, facet.key);
-                      removeFacetFilter(ResultParam.ScientificReportPeriodBeforeParam, (+facet.key + 1).toString());
                     } else {
                       addFacetFilter(ResultParam.ScientificReportPeriodSinceParam, facet.key);
                       addFacetFilter(ResultParam.ScientificReportPeriodBeforeParam, (+facet.key + 1).toString());

--- a/src/pages/search/registration_search/filters/RegistrationFacetsFilter.tsx
+++ b/src/pages/search/registration_search/filters/RegistrationFacetsFilter.tsx
@@ -233,7 +233,7 @@ export const RegistrationFacetsFilter = ({ registrationQuery }: Pick<SearchPageP
           {scientificIndexFacet
             .sort((a, b) => +b.key - +a.key)
             .map((facet) => {
-              const isSelected = !!registrationParams.scientificIndex?.includes(facet.key);
+              const isSelected = !!registrationParams.scientificReportPeriodSince?.includes(facet.key);
 
               return (
                 <FacetListItem
@@ -244,11 +244,15 @@ export const RegistrationFacetsFilter = ({ registrationQuery }: Pick<SearchPageP
                   isSelected={isSelected}
                   label={facet.key}
                   count={facet.count}
-                  onClickFacet={() =>
-                    isSelected
-                      ? removeFacetFilter(ResultParam.ScientificIndex, facet.key)
-                      : addFacetFilter(ResultParam.ScientificIndex, facet.key)
-                  }
+                  onClickFacet={() => {
+                    if (isSelected) {
+                      removeFacetFilter(ResultParam.ScientificReportPeriodSinceParam, facet.key);
+                      removeFacetFilter(ResultParam.ScientificReportPeriodBeforeParam, (+facet.key + 1).toString());
+                    } else {
+                      addFacetFilter(ResultParam.ScientificReportPeriodSinceParam, facet.key);
+                      addFacetFilter(ResultParam.ScientificReportPeriodBeforeParam, (+facet.key + 1).toString());
+                    }
+                  }}
                 />
               );
             })}

--- a/src/utils/hooks/useRegistrationSearchParams.ts
+++ b/src/utils/hooks/useRegistrationSearchParams.ts
@@ -53,6 +53,7 @@ export const useRegistrationsQueryParams = () => {
     scientificIndexStatus: searchParams.get(ResultParam.ScientificIndexStatus) as ScientificIndexStatuses | null,
     scientificValue: searchParams.get(ResultParam.ScientificValue),
     scientificIndex: searchParams.get(ResultParam.ScientificIndex),
+    scientificReportPeriodSince: searchParams.get(ResultParam.ScientificReportPeriodSinceParam),
     series: searchParams.get(ResultParam.Series),
     sort: searchParams.get(ResultParam.Sort) as SortOrder | null,
     status: status ? (status.split(',') as RegistrationStatus[]) : null,

--- a/src/utils/hooks/useRegistrationSearchParams.ts
+++ b/src/utils/hooks/useRegistrationSearchParams.ts
@@ -53,6 +53,7 @@ export const useRegistrationsQueryParams = () => {
     scientificIndexStatus: searchParams.get(ResultParam.ScientificIndexStatus) as ScientificIndexStatuses | null,
     scientificValue: searchParams.get(ResultParam.ScientificValue),
     scientificReportPeriodSince: searchParams.get(ResultParam.ScientificReportPeriodSinceParam),
+    scientificReportPeriodBefore: searchParams.get(ResultParam.ScientificReportPeriodBeforeParam),
     series: searchParams.get(ResultParam.Series),
     sort: searchParams.get(ResultParam.Sort) as SortOrder | null,
     status: status ? (status.split(',') as RegistrationStatus[]) : null,

--- a/src/utils/hooks/useRegistrationSearchParams.ts
+++ b/src/utils/hooks/useRegistrationSearchParams.ts
@@ -52,7 +52,6 @@ export const useRegistrationsQueryParams = () => {
     results: Number(searchParams.get(SearchParam.Results) ?? defaultRowsPerPage),
     scientificIndexStatus: searchParams.get(ResultParam.ScientificIndexStatus) as ScientificIndexStatuses | null,
     scientificValue: searchParams.get(ResultParam.ScientificValue),
-    scientificIndex: searchParams.get(ResultParam.ScientificIndex),
     scientificReportPeriodSince: searchParams.get(ResultParam.ScientificReportPeriodSinceParam),
     series: searchParams.get(ResultParam.Series),
     sort: searchParams.get(ResultParam.Sort) as SortOrder | null,

--- a/src/utils/searchHelpers.ts
+++ b/src/utils/searchHelpers.ts
@@ -117,6 +117,9 @@ export const removeSearchParamValue = (params: URLSearchParams, key: string, val
   const newValues = selectedValues.filter((selectedValue) => selectedValue !== value);
   if (newValues.length === 0) {
     params.delete(key);
+    if (key === ResultParam.ScientificReportPeriodSinceParam) {
+      params.delete(ResultParam.ScientificReportPeriodBeforeParam);
+    }
   } else {
     params.set(key, newValues.join(','));
   }


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47794

Problem: When setting the params for NVI-period using the facets filters, the params `scientificReportPeriodSince` and `scientificReportPeriodBefore` were combined to `scientificIndex`. This created a mismatch between the url-param and the actual GET-request used for exporting results.

Fix: set both params in the url.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
