### PR TITLE
Open project wizard in modal from registration

### DIFF
--- a/src/pages/project/ProjectModal.tsx
+++ b/src/pages/project/ProjectModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Modal } from '../../components/Modal';
 import CreateProject from './project_wizard/CreateProject';
 
@@ -7,10 +8,11 @@ interface ProjectModalProps {
 }
 
 export const ProjectModal = ({ isOpen, toggleModal }: ProjectModalProps) => {
+  const { t } = useTranslation();
   console.log('toggleModal in ProjectModal', toggleModal);
   return (
     <Modal
-      title={'test title'}
+      title={t('project.project_modal_title')}
       open={isOpen}
       onClose={toggleModal}
       fullWidth

--- a/src/pages/project/ProjectModal.tsx
+++ b/src/pages/project/ProjectModal.tsx
@@ -1,0 +1,22 @@
+import { Modal } from '../../components/Modal';
+import CreateProject from './project_wizard/CreateProject';
+
+interface ProjectModalProps {
+  isOpen: boolean;
+  toggleModal: () => void;
+}
+
+export const ProjectModal = ({ isOpen, toggleModal }: ProjectModalProps) => {
+  console.log('toggleModal in ProjectModal', toggleModal);
+  return (
+    <Modal
+      title={'test title'}
+      open={isOpen}
+      onClose={toggleModal}
+      fullWidth
+      maxWidth="lg"
+      dataTestId="contributor-modal">
+      <CreateProject toggleModal={toggleModal} />
+    </Modal>
+  );
+};

--- a/src/pages/project/ProjectModal.tsx
+++ b/src/pages/project/ProjectModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Modal } from '../../components/Modal';
 import { CristinProject } from '../../types/project.types';
 import { dataTestId } from '../../utils/dataTestIds';
@@ -10,8 +11,16 @@ interface ProjectModalProps {
 }
 
 export const ProjectModal = ({ isOpen, toggleModal, onProjectCreated }: ProjectModalProps) => {
+  const { t } = useTranslation();
+
   return (
-    <Modal open={isOpen} onClose={toggleModal} fullWidth maxWidth="lg" dataTestId={dataTestId.projectWizard.modal}>
+    <Modal
+      open={isOpen}
+      onClose={toggleModal}
+      fullWidth
+      maxWidth="lg"
+      headingText={t('project.project_modal_title')}
+      dataTestId={dataTestId.projectWizard.modal}>
       <CreateProject toggleModal={toggleModal} onProjectCreated={onProjectCreated} />
     </Modal>
   );

--- a/src/pages/project/ProjectModal.tsx
+++ b/src/pages/project/ProjectModal.tsx
@@ -1,15 +1,17 @@
 import { useTranslation } from 'react-i18next';
 import { Modal } from '../../components/Modal';
+import { CristinProject, ResearchProject } from '../../types/project.types';
 import CreateProject from './project_wizard/CreateProject';
 
 interface ProjectModalProps {
   isOpen: boolean;
   toggleModal: () => void;
+  onProjectCreated: (value: CristinProject | ResearchProject) => void;
 }
 
-export const ProjectModal = ({ isOpen, toggleModal }: ProjectModalProps) => {
+export const ProjectModal = ({ isOpen, toggleModal, onProjectCreated }: ProjectModalProps) => {
   const { t } = useTranslation();
-  console.log('toggleModal in ProjectModal', toggleModal);
+
   return (
     <Modal
       title={t('project.project_modal_title')}
@@ -18,7 +20,7 @@ export const ProjectModal = ({ isOpen, toggleModal }: ProjectModalProps) => {
       fullWidth
       maxWidth="lg"
       dataTestId="contributor-modal">
-      <CreateProject toggleModal={toggleModal} />
+      <CreateProject toggleModal={toggleModal} onProjectCreated={onProjectCreated} />
     </Modal>
   );
 };

--- a/src/pages/project/ProjectModal.tsx
+++ b/src/pages/project/ProjectModal.tsx
@@ -1,25 +1,17 @@
-import { useTranslation } from 'react-i18next';
 import { Modal } from '../../components/Modal';
-import { CristinProject, ResearchProject } from '../../types/project.types';
+import { CristinProject } from '../../types/project.types';
+import { dataTestId } from '../../utils/dataTestIds';
 import CreateProject from './project_wizard/CreateProject';
 
 interface ProjectModalProps {
   isOpen: boolean;
   toggleModal: () => void;
-  onProjectCreated: (value: CristinProject | ResearchProject) => void;
+  onProjectCreated: (value: CristinProject) => void;
 }
 
 export const ProjectModal = ({ isOpen, toggleModal, onProjectCreated }: ProjectModalProps) => {
-  const { t } = useTranslation();
-
   return (
-    <Modal
-      title={t('project.project_modal_title')}
-      open={isOpen}
-      onClose={toggleModal}
-      fullWidth
-      maxWidth="lg"
-      dataTestId="contributor-modal">
+    <Modal open={isOpen} onClose={toggleModal} fullWidth maxWidth="lg" dataTestId={dataTestId.projectWizard.modal}>
       <CreateProject toggleModal={toggleModal} onProjectCreated={onProjectCreated} />
     </Modal>
   );

--- a/src/pages/project/project_wizard/CreateProject.tsx
+++ b/src/pages/project/project_wizard/CreateProject.tsx
@@ -32,8 +32,6 @@ const CreateProject = ({ toggleModal }: CreateProjectProps) => {
   const [showProjectForm, setShowProjectForm] = useState(false);
   const [suggestedProjectManager, setSuggestedProjectManager] = useState('');
 
-  console.log('toggleModal in Create Project', toggleModal);
-
   return (
     <StyledPageContent>
       {showProjectForm ? (

--- a/src/pages/project/project_wizard/CreateProject.tsx
+++ b/src/pages/project/project_wizard/CreateProject.tsx
@@ -11,7 +11,7 @@ import {
   WizardStartPageWrapper,
 } from '../../../components/styled/Wrappers';
 import { RootState } from '../../../redux/store';
-import { CristinProject, emptyProject, ResearchProject } from '../../../types/project.types';
+import { CristinProject, emptyProject } from '../../../types/project.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { UrlPathTemplate } from '../../../utils/urlPaths';
 import { CreateNfrProject } from './CreateNfrProject';
@@ -20,7 +20,7 @@ import { ProjectForm } from './ProjectForm';
 
 interface CreateProjectProps {
   toggleModal?: () => void;
-  onProjectCreated?: (value: CristinProject | ResearchProject) => void;
+  onProjectCreated?: (value: CristinProject) => void;
 }
 
 const CreateProject = ({ toggleModal, onProjectCreated }: CreateProjectProps) => {

--- a/src/pages/project/project_wizard/CreateProject.tsx
+++ b/src/pages/project/project_wizard/CreateProject.tsx
@@ -44,7 +44,7 @@ const CreateProject = ({ toggleModal, onProjectCreated }: CreateProjectProps) =>
         />
       ) : (
         <>
-          <PageHeader>{t('project.create_project')}</PageHeader>
+          {!toggleModal && <PageHeader>{t('project.create_project')}</PageHeader>}
           <WizardStartPageWrapper>
             <CreateNfrProject
               newProject={newProject}

--- a/src/pages/project/project_wizard/CreateProject.tsx
+++ b/src/pages/project/project_wizard/CreateProject.tsx
@@ -11,7 +11,7 @@ import {
   WizardStartPageWrapper,
 } from '../../../components/styled/Wrappers';
 import { RootState } from '../../../redux/store';
-import { emptyProject } from '../../../types/project.types';
+import { CristinProject, emptyProject, ResearchProject } from '../../../types/project.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { UrlPathTemplate } from '../../../utils/urlPaths';
 import { CreateNfrProject } from './CreateNfrProject';
@@ -20,9 +20,10 @@ import { ProjectForm } from './ProjectForm';
 
 interface CreateProjectProps {
   toggleModal?: () => void;
+  onProjectCreated?: (value: CristinProject | ResearchProject) => void;
 }
 
-const CreateProject = ({ toggleModal }: CreateProjectProps) => {
+const CreateProject = ({ toggleModal, onProjectCreated }: CreateProjectProps) => {
   const { t } = useTranslation();
   const history = useHistory();
   const user = useSelector((store: RootState) => store.user);
@@ -35,7 +36,12 @@ const CreateProject = ({ toggleModal }: CreateProjectProps) => {
   return (
     <StyledPageContent>
       {showProjectForm ? (
-        <ProjectForm project={newProject} suggestedProjectManager={suggestedProjectManager} toggleModal={toggleModal} />
+        <ProjectForm
+          project={newProject}
+          suggestedProjectManager={suggestedProjectManager}
+          toggleModal={toggleModal}
+          onProjectCreated={onProjectCreated}
+        />
       ) : (
         <>
           <PageHeader>{t('project.create_project')}</PageHeader>

--- a/src/pages/project/project_wizard/CreateProject.tsx
+++ b/src/pages/project/project_wizard/CreateProject.tsx
@@ -18,7 +18,11 @@ import { CreateNfrProject } from './CreateNfrProject';
 import { EmptyProjectForm } from './EmptyProjectForm';
 import { ProjectForm } from './ProjectForm';
 
-const CreateProject = () => {
+interface CreateProjectProps {
+  toggleModal?: () => void;
+}
+
+const CreateProject = ({ toggleModal }: CreateProjectProps) => {
   const { t } = useTranslation();
   const history = useHistory();
   const user = useSelector((store: RootState) => store.user);
@@ -28,10 +32,12 @@ const CreateProject = () => {
   const [showProjectForm, setShowProjectForm] = useState(false);
   const [suggestedProjectManager, setSuggestedProjectManager] = useState('');
 
+  console.log('toggleModal in Create Project', toggleModal);
+
   return (
     <StyledPageContent>
       {showProjectForm ? (
-        <ProjectForm project={newProject} suggestedProjectManager={suggestedProjectManager} />
+        <ProjectForm project={newProject} suggestedProjectManager={suggestedProjectManager} toggleModal={toggleModal} />
       ) : (
         <>
           <PageHeader>{t('project.create_project')}</PageHeader>
@@ -52,7 +58,7 @@ const CreateProject = () => {
           <StyledRightAlignedFooter sx={{ mt: '2rem' }}>
             <CancelButton
               testId={dataTestId.projectForm.cancelNewProjectButton}
-              onClick={() => history.push(UrlPathTemplate.MyPageMyProjectRegistrations)}
+              onClick={() => (toggleModal ? toggleModal() : history.push(UrlPathTemplate.MyPageMyProjectRegistrations))}
             />
           </StyledRightAlignedFooter>
         </>

--- a/src/pages/project/project_wizard/ProjectForm.tsx
+++ b/src/pages/project/project_wizard/ProjectForm.tsx
@@ -64,13 +64,9 @@ export const ProjectForm = ({ project, suggestedProjectManager, toggleModal }: P
 
       const id = projectWithId ? projectWithId.id : updateProjectResponse.data.id;
 
-      console.log('toggleModal', toggleModal);
-
       if (toggleModal) {
-        console.log('test1');
         toggleModal();
       } else if (id) {
-        console.log('test2');
         goToLandingPage(id);
       }
     } else if (isErrorStatus(updateProjectResponse.status)) {
@@ -140,6 +136,7 @@ export const ProjectForm = ({ project, suggestedProjectManager, toggleModal }: P
                   onClickNext={() => onClickArrow(tabNumber + 1)}
                   onClickPrevious={() => onClickArrow(tabNumber - 1)}
                   onClickLast={() => onClickArrow(ProjectTabs.Connections)}
+                  openedInModal={toggleModal !== undefined}
                 />
               </Box>
             </Form>

--- a/src/pages/project/project_wizard/ProjectForm.tsx
+++ b/src/pages/project/project_wizard/ProjectForm.tsx
@@ -85,10 +85,14 @@ export const ProjectForm = ({ project, suggestedProjectManager, toggleModal, onP
   };
 
   const onCancel = () => {
-    if (projectWithId) {
-      goToLandingPage(projectWithId.id);
+    if (toggleModal) {
+      toggleModal();
     } else {
-      history.push(UrlPathTemplate.MyPageMyProjectRegistrations);
+      if (projectWithId) {
+        goToLandingPage(projectWithId.id);
+      } else {
+        history.push(UrlPathTemplate.MyPageMyProjectRegistrations);
+      }
     }
   };
 

--- a/src/pages/project/project_wizard/ProjectForm.tsx
+++ b/src/pages/project/project_wizard/ProjectForm.tsx
@@ -11,7 +11,7 @@ import { RequiredDescription } from '../../../components/RequiredDescription';
 import { SkipLink } from '../../../components/SkipLink';
 import { TruncatableTypography } from '../../../components/TruncatableTypography';
 import { setNotification } from '../../../redux/notificationSlice';
-import { CristinProject, ProjectTabs, SaveCristinProject } from '../../../types/project.types';
+import { CristinProject, ProjectTabs, ResearchProject, SaveCristinProject } from '../../../types/project.types';
 import { isErrorStatus, isSuccessStatus } from '../../../utils/constants';
 import { getTouchedFields } from '../../../utils/formik-helpers/project-form-helpers';
 import { getProjectPath, UrlPathTemplate } from '../../../utils/urlPaths';
@@ -29,9 +29,10 @@ interface ProjectFormProps {
   project: SaveCristinProject | CristinProject;
   suggestedProjectManager?: string;
   toggleModal?: () => void;
+  onProjectCreated?: (value: CristinProject | ResearchProject) => void;
 }
 
-export const ProjectForm = ({ project, suggestedProjectManager, toggleModal }: ProjectFormProps) => {
+export const ProjectForm = ({ project, suggestedProjectManager, toggleModal, onProjectCreated }: ProjectFormProps) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const history = useHistory();
@@ -65,6 +66,10 @@ export const ProjectForm = ({ project, suggestedProjectManager, toggleModal }: P
       const id = projectWithId ? projectWithId.id : updateProjectResponse.data.id;
 
       if (toggleModal) {
+        if (onProjectCreated) {
+          if (projectWithId) onProjectCreated(projectWithId);
+          else onProjectCreated(updateProjectResponse.data);
+        }
         toggleModal();
       } else if (id) {
         goToLandingPage(id);

--- a/src/pages/project/project_wizard/ProjectForm.tsx
+++ b/src/pages/project/project_wizard/ProjectForm.tsx
@@ -11,7 +11,7 @@ import { RequiredDescription } from '../../../components/RequiredDescription';
 import { SkipLink } from '../../../components/SkipLink';
 import { TruncatableTypography } from '../../../components/TruncatableTypography';
 import { setNotification } from '../../../redux/notificationSlice';
-import { CristinProject, ProjectTabs, ResearchProject, SaveCristinProject } from '../../../types/project.types';
+import { CristinProject, ProjectTabs, SaveCristinProject } from '../../../types/project.types';
 import { isErrorStatus, isSuccessStatus } from '../../../utils/constants';
 import { getTouchedFields } from '../../../utils/formik-helpers/project-form-helpers';
 import { getProjectPath, UrlPathTemplate } from '../../../utils/urlPaths';
@@ -29,7 +29,7 @@ interface ProjectFormProps {
   project: SaveCristinProject | CristinProject;
   suggestedProjectManager?: string;
   toggleModal?: () => void;
-  onProjectCreated?: (value: CristinProject | ResearchProject) => void;
+  onProjectCreated?: (value: CristinProject) => void;
 }
 
 export const ProjectForm = ({ project, suggestedProjectManager, toggleModal, onProjectCreated }: ProjectFormProps) => {
@@ -145,7 +145,7 @@ export const ProjectForm = ({ project, suggestedProjectManager, toggleModal, onP
                   onClickNext={() => onClickArrow(tabNumber + 1)}
                   onClickPrevious={() => onClickArrow(tabNumber - 1)}
                   onClickLast={() => onClickArrow(ProjectTabs.Connections)}
-                  openedInModal={toggleModal !== undefined}
+                  openedInModal={!!toggleModal}
                 />
               </Box>
             </Form>

--- a/src/pages/project/project_wizard/ProjectForm.tsx
+++ b/src/pages/project/project_wizard/ProjectForm.tsx
@@ -28,9 +28,10 @@ import { ProjectFormStepper } from './ProjectFormStepper';
 interface ProjectFormProps {
   project: SaveCristinProject | CristinProject;
   suggestedProjectManager?: string;
+  toggleModal?: () => void;
 }
 
-export const ProjectForm = ({ project, suggestedProjectManager }: ProjectFormProps) => {
+export const ProjectForm = ({ project, suggestedProjectManager, toggleModal }: ProjectFormProps) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const history = useHistory();
@@ -60,9 +61,16 @@ export const ProjectForm = ({ project, suggestedProjectManager }: ProjectFormPro
           variant: 'success',
         })
       );
+
       const id = projectWithId ? projectWithId.id : updateProjectResponse.data.id;
 
-      if (id) {
+      console.log('toggleModal', toggleModal);
+
+      if (toggleModal) {
+        console.log('test1');
+        toggleModal();
+      } else if (id) {
+        console.log('test2');
         goToLandingPage(id);
       }
     } else if (isErrorStatus(updateProjectResponse.status)) {

--- a/src/pages/project/project_wizard/ProjectFormActions.tsx
+++ b/src/pages/project/project_wizard/ProjectFormActions.tsx
@@ -19,6 +19,7 @@ interface ProjectFormActionsProps {
   onClickNext: () => void;
   onClickPrevious: () => void;
   onClickLast: () => void;
+  openedInModal?: boolean;
 }
 
 export const ProjectFormActions = ({
@@ -27,6 +28,7 @@ export const ProjectFormActions = ({
   onClickNext,
   onClickPrevious,
   onClickLast,
+  openedInModal = false,
 }: ProjectFormActionsProps) => {
   const { t } = useTranslation();
   const { values, isSubmitting, errors, touched } = useFormikContext<CristinProject>();
@@ -52,7 +54,7 @@ export const ProjectFormActions = ({
             loading={isSubmitting}
             disabled={disable}
             data-testid={dataTestId.projectWizard.formActions.saveProjectButton}>
-            {t('common.save_and_view')}
+            {openedInModal ? t('project.save_and_close') : t('common.save_and_view')}
           </LoadingButton>
         )}
         {!isLastTab && (

--- a/src/pages/registration/description_tab/projects_field/ProjectsField.tsx
+++ b/src/pages/registration/description_tab/projects_field/ProjectsField.tsx
@@ -1,5 +1,4 @@
 import AddIcon from '@mui/icons-material/Add';
-import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { Autocomplete, Box, Button, Divider, Typography } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { Field, FieldProps } from 'formik';
@@ -12,12 +11,13 @@ import { CristinProject, ResearchProject } from '../../../../types/project.types
 import { DescriptionFieldNames } from '../../../../types/publicationFieldNames';
 import { dataTestId } from '../../../../utils/dataTestIds';
 import { useDebounce } from '../../../../utils/hooks/useDebounce';
-import { UrlPathTemplate } from '../../../../utils/urlPaths';
+import { ProjectModal } from '../../../project/ProjectModal';
 import { HelperTextModal } from '../../HelperTextModal';
 import { ProjectItem } from './ProjectItem';
 
 export const ProjectsField = () => {
   const { t } = useTranslation();
+  const [openNewProject, setOpenNewProject] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const debouncedSearchTerm = useDebounce(searchTerm);
 
@@ -27,6 +27,8 @@ export const ProjectsField = () => {
     queryFn: () => searchForProjects(10, 1, { query: debouncedSearchTerm }),
     meta: { errorMessage: t('feedback.error.project_search') },
   });
+
+  const toggleOpenNewProject = () => setOpenNewProject(!openNewProject);
 
   const projects = projectsQuery.data?.hits ?? [];
 
@@ -120,12 +122,10 @@ export const ProjectsField = () => {
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
                   <Button
                     data-testid={dataTestId.registrationWizard.description.createProjectButton}
-                    href={UrlPathTemplate.ProjectsNew}
-                    target="_blank"
+                    onClick={toggleOpenNewProject}
                     startIcon={<AddIcon />}>
                     {t('project.create_new_project')}
                   </Button>
-                  <OpenInNewIcon />
                 </Box>
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
                   {field.value.map((project) => (
@@ -137,6 +137,7 @@ export const ProjectsField = () => {
           }}
         </Field>
       </Box>
+      <ProjectModal isOpen={openNewProject} toggleModal={toggleOpenNewProject} />
     </>
   );
 };

--- a/src/pages/registration/description_tab/projects_field/ProjectsField.tsx
+++ b/src/pages/registration/description_tab/projects_field/ProjectsField.tsx
@@ -1,7 +1,7 @@
 import AddIcon from '@mui/icons-material/Add';
 import { Autocomplete, Box, Button, Divider, Typography } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
-import { Field, FieldProps } from 'formik';
+import { Field, FieldProps, useFormikContext } from 'formik';
 import { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { searchForProjects } from '../../../../api/cristinApi';
@@ -9,6 +9,7 @@ import { AutocompleteProjectOption } from '../../../../components/AutocompletePr
 import { AutocompleteTextField } from '../../../../components/AutocompleteTextField';
 import { CristinProject, ResearchProject } from '../../../../types/project.types';
 import { DescriptionFieldNames } from '../../../../types/publicationFieldNames';
+import { Registration } from '../../../../types/registration.types';
 import { dataTestId } from '../../../../utils/dataTestIds';
 import { useDebounce } from '../../../../utils/hooks/useDebounce';
 import { ProjectModal } from '../../../project/ProjectModal';
@@ -17,6 +18,7 @@ import { ProjectItem } from './ProjectItem';
 
 export const ProjectsField = () => {
   const { t } = useTranslation();
+  const { values, setFieldValue } = useFormikContext<Registration>();
   const [openNewProject, setOpenNewProject] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const debouncedSearchTerm = useDebounce(searchTerm);
@@ -29,6 +31,15 @@ export const ProjectsField = () => {
   });
 
   const toggleOpenNewProject = () => setOpenNewProject(!openNewProject);
+
+  const addProject = (value: CristinProject | ResearchProject) => {
+    const projectToPersist: ResearchProject = {
+      type: 'ResearchProject',
+      id: value.id,
+      name: 'title' in value ? value.title : 'name' in value ? value.name : '',
+    };
+    setFieldValue(DescriptionFieldNames.Projects, values.projects.concat([projectToPersist]));
+  };
 
   const projects = projectsQuery.data?.hits ?? [];
 
@@ -137,7 +148,7 @@ export const ProjectsField = () => {
           }}
         </Field>
       </Box>
-      <ProjectModal isOpen={openNewProject} toggleModal={toggleOpenNewProject} />
+      <ProjectModal isOpen={openNewProject} toggleModal={toggleOpenNewProject} onProjectCreated={addProject} />
     </>
   );
 };

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1205,6 +1205,7 @@
     "project_id": "Prosjekt-ID",
     "project_info": "Prosjektinfo",
     "project_manager": "Prosjektleder",
+    "project_modal_title": "Nytt prosjekt",
     "save_and_close": "Lagre og lukk",
     "project_manager_from_nfr": "Prosjektleder fra NFR: {{name}}",
     "project_manager_is_unidentified": "Prosjektleder er uidentifisert",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1205,6 +1205,8 @@
     "project_id": "Prosjekt-ID",
     "project_info": "Prosjektinfo",
     "project_manager": "Prosjektleder",
+    "project_modal_title": "Nytt prosjekt",
+    "save_and_close": "Lagre og lukk",
     "project_manager_from_nfr": "Prosjektleder fra NFR: {{name}}",
     "project_manager_is_unidentified": "Prosjektleder er uidentifisert",
     "project_participant": "Prosjektdeltaker",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1205,7 +1205,6 @@
     "project_id": "Prosjekt-ID",
     "project_info": "Prosjektinfo",
     "project_manager": "Prosjektleder",
-    "project_modal_title": "Nytt prosjekt",
     "save_and_close": "Lagre og lukk",
     "project_manager_from_nfr": "Prosjektleder fra NFR: {{name}}",
     "project_manager_is_unidentified": "Prosjektleder er uidentifisert",

--- a/src/utils/dataTestIds.ts
+++ b/src/utils/dataTestIds.ts
@@ -258,6 +258,7 @@ export const dataTestId = {
     scientificSummaryAccordion: 'scientific-summary-accordion',
   },
   projectWizard: {
+    modal: 'new-project-modal',
     stepper: {
       projectDescriptionStepButton: 'nav-tabpanel-project-description',
       projectDetailsStepButton: 'nav-tabpanel-project-details',


### PR DESCRIPTION
# Description

Link to Jira issue: [https://sikt.atlassian.net/browse/NP-47743](https://sikt.atlassian.net/browse/NP-47743)

When making a new registration it should be possible to make a new project without having to leave the registration view (i.e. in a popup). This was possible earlier, so we are re-fetching old functionality in a new layout.

Once the project is created it is automatically added to the registration as well:

![image](https://github.com/user-attachments/assets/cd6461e1-8854-4232-bf94-28a919d5f6e5)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
