### PR TITLE
Handle failed loading of chunks on more browsers

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -12,13 +12,24 @@ enum ErrorType {
   Other,
 }
 
+/**
+ * Browsers have different error messages when a chunk is not found.
+ * This error is often triggered when a new version of the app is deployed with different chunk names than the current version.
+ * When this happens the user must reload the page to get the new chunks.
+ */
+const chunkNotFoundErrorMessages = [
+  'TypeError: Failed to fetch dynamically imported module', // Chrome, Edge
+  'TypeError: Importing a module script failed', // Safari
+  'TypeError: error loading dynamically imported module', // Firefox
+];
+
 class ErrorBoundaryClass extends Component<PropsWithChildren<ErrorBoundaryClassProps>> {
   state = { error: ErrorType.None };
 
   static getDerivedStateFromError(error: any) {
-    return /TypeError: error loading dynamically imported module/.test(error)
-      ? { error: ErrorType.Chunk }
-      : { error: ErrorType.Other };
+    const errorString = error.toString().toLowerCase();
+    const isUpdatedAppError = chunkNotFoundErrorMessages.some((message) => errorString.includes(message.toLowerCase()));
+    return isUpdatedAppError ? { error: ErrorType.Chunk } : { error: ErrorType.Other };
   }
 
   componentDidUpdate(prevProps: ErrorBoundaryClassProps) {


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47462

Etter mange runder frem og tilbake fant jeg endelig ut hvorfor mange opplever at appen krasjer når vi deployer ny versjon. Grunnen er at ulike nettlesere gir ulike feilmeldinger når den ikke får til å laste chunk fordi appen er oppdatert med nye chunk-navn. Dette har derfor bare virket på Firefox som jeg selv har.

Har verifisert at denne nte løsningen virker på Firefox, Chrome, Edge, og Safari (via browserstack.com)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
