### PR TITLE
Automatically adding (unidentified) project manager on NFR projects (beta-tagged)

### DIFF
--- a/src/pages/project/helpers/projectContributorHelpers.ts
+++ b/src/pages/project/helpers/projectContributorHelpers.ts
@@ -195,7 +195,7 @@ export const addContributor = (
   return { newContributors };
 };
 
-const createNamesFromInput = (searchTerm: string) => {
+export const createNamesFromInput = (searchTerm: string) => {
   const names = searchTerm.split(' ');
   let firstName, lastName;
 

--- a/src/pages/project/project_wizard/CreateNfrProject.tsx
+++ b/src/pages/project/project_wizard/CreateNfrProject.tsx
@@ -4,8 +4,10 @@ import { Box, Button } from '@mui/material';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NfrProject, ProjectOrganization, SaveCristinProject } from '../../../types/project.types';
+import { LocalStorageKey } from '../../../utils/constants';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { getLanguageString } from '../../../utils/translation-helpers';
+import { createNamesFromInput } from '../helpers/projectContributorHelpers';
 import { CreateProjectAccordion } from './CreateProjectAccordion';
 import { NfrProjectSearch } from './NfrProjectSearch';
 
@@ -25,6 +27,7 @@ export const CreateNfrProject = ({
   coordinatingInstitution,
 }: NFRProjectProps) => {
   const { t } = useTranslation();
+  const betaEnabled = localStorage.getItem(LocalStorageKey.Beta) === 'true';
   const [selectedProject, setSelectedProject] = useState<NfrProject | null>(null);
 
   const onCreateProject = () => {
@@ -34,7 +37,7 @@ export const CreateNfrProject = ({
 
     setSuggestedProjectManager(selectedProject.lead);
 
-    setNewProject({
+    const newNFRProject: SaveCristinProject = {
       ...newProject,
       title: getLanguageString(selectedProject.labels),
       startDate: selectedProject.activeFrom,
@@ -48,7 +51,28 @@ export const CreateNfrProject = ({
           labels: selectedProject.labels,
         },
       ],
-    });
+    };
+
+    if (betaEnabled && selectedProject.lead) {
+      const suggestedProjectManagerNames = createNamesFromInput(selectedProject.lead);
+      newNFRProject.contributors = [
+        {
+          identity: {
+            type: 'Person',
+            firstName: suggestedProjectManagerNames.firstName,
+            lastName: suggestedProjectManagerNames.lastName,
+          },
+          roles: [
+            {
+              type: 'ProjectManager',
+              affiliation: undefined,
+            },
+          ],
+        },
+      ];
+    }
+
+    setNewProject(newNFRProject);
     setShowProjectForm(true);
   };
 


### PR DESCRIPTION
# Description

Link to Jira issue: [https://sikt.atlassian.net/browse/NP-47848](https://sikt.atlassian.net/browse/NP-47848)

If we choose to create a new project from a NFR-project, the contributors tab will now have a suggested project manager:

![image](https://github.com/user-attachments/assets/cde79184-64f2-4794-88f9-fec3b5d3f1c6)

They still have to be identified using the "identifiser prosjektleder"-button, but the search will already be filled in to decrease the number of steps.

Since unidentified contributors are in beta tag awaiting a backend change to stop giving unidentified users an id, an possibly some testing, this code is also beta-tagged.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
