### PR TITLE
Block navigation to Homepage from Wizard (when dirty)

### DIFF
--- a/src/components/RouteLeavingGuard.tsx
+++ b/src/components/RouteLeavingGuard.tsx
@@ -77,7 +77,8 @@ const goFromRegistrationWizardToLandingPage = (currentPath: string, newPath: str
   const splittedPath = UrlPathTemplate.RegistrationWizard.split(':identifier');
   const currentPathIsRegistrationWizard =
     currentPath.startsWith(splittedPath[0]) && currentPath.endsWith(splittedPath[1]);
-  const newPathIsLandingPage = currentPath.startsWith(newPath) && !newPath.endsWith(splittedPath[1]);
+  const newPathIsLandingPage =
+    currentPath.startsWith(newPath) && !newPath.endsWith(splittedPath[1]) && newPath !== UrlPathTemplate.Home;
 
   return currentPathIsRegistrationWizard && newPathIsLandingPage;
 };


### PR DESCRIPTION
# Description


Fixed an issue where users could navigate away from wizard with unsaved changes by clicking the Logo

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
