### PR TITLE
Changed "Result" to "Searchresult" and fixed small bug I found

### DIFF
--- a/src/pages/project/project_wizard/EmptyProjectForm.tsx
+++ b/src/pages/project/project_wizard/EmptyProjectForm.tsx
@@ -62,9 +62,9 @@ export const EmptyProjectForm = ({ newProject, setNewProject, setShowProjectForm
             <ProjectListItem project={titleSearch.duplicateProject} />
           </Box>
         )}
-        {debouncedTitle && !titleSearch.isPending && titleSearch.duplicateProject && (
+        {debouncedTitle && !titleSearch.isPending && !titleSearch.duplicateProject && (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
-            <Typography sx={{ fontWeight: 'bold' }}>{t('common.result')}</Typography>
+            <Typography sx={{ fontWeight: 'bold' }}>{t('project.duplicate_project_heading')}</Typography>
             <Typography>{t('project.no_duplicate_title')}</Typography>
           </Box>
         )}

--- a/src/pages/project/project_wizard/ProjectDescriptionForm.tsx
+++ b/src/pages/project/project_wizard/ProjectDescriptionForm.tsx
@@ -57,6 +57,7 @@ export const ProjectDescriptionForm = ({ thisIsRekProject }: ProjectDescriptionF
               name={duplicateProjectSearch.duplicateProject.title}
               linkTo={getProjectPath(duplicateProjectSearch.duplicateProject.id)}
               warning={t('project.duplicate_title_warning')}
+              listHeader={t('project.duplicate_project_heading')}
             />
           )}
           <Field name={ProjectFieldName.AcademicSummaryNo}>

--- a/src/pages/registration/DuplicateWarning.tsx
+++ b/src/pages/registration/DuplicateWarning.tsx
@@ -9,9 +9,10 @@ interface DuplicateWarningProps extends Pick<BoxProps, 'sx'> {
   warning: string;
   linkTo?: string;
   name?: string;
+  listHeader?: string;
 }
 
-export const DuplicateWarning = ({ name, linkTo, warning, sx }: DuplicateWarningProps) => {
+export const DuplicateWarning = ({ name, listHeader, linkTo, warning, sx }: DuplicateWarningProps) => {
   const { t } = useTranslation();
   return (
     <Box
@@ -28,7 +29,7 @@ export const DuplicateWarning = ({ name, linkTo, warning, sx }: DuplicateWarning
       <StyledInfoBanner>{warning}</StyledInfoBanner>
       {name && linkTo && (
         <>
-          <Typography sx={{ fontWeight: 'bold' }}>{t('common.result')}</Typography>
+          <Typography sx={{ fontWeight: 'bold' }}>{listHeader ? listHeader : t('common.result')}</Typography>
           <Link target="_blank" data-testid={dataTestId.registrationLandingPage.duplicateRegistrationLink} to={linkTo}>
             <Box sx={{ display: 'flex', gap: '0.5rem' }}>
               <Typography sx={{ textDecoration: 'underline', cursor: 'pointer' }}>{name}</Typography>

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1158,6 +1158,7 @@
     "create_project": "Nytt prosjekt",
     "duplicate_project_warning": "Det finnes et prosjekt i NVA med samme tittel. Vennligst ikke registrer prosjektet dersom det er samme prosjekt, slik at du ikke oppretter duplikater.",
     "duplicate_title_warning": "Det finnes et prosjekt i NVA med samme tittel. Vennligst avbryt registreringen dersom det er det samme prosjektet som du prøver å registrere, slik at du ikke oppretter duplikater.",
+    "duplicate_project_heading": "Søkeresultat",
     "edit_project": "Endre prosjekt",
     "error": {
       "contributor_already_added_with_same_role_and_affiliation": "Prosjektdeltaker er allerede lagt til med samme rolle og tilknytning."


### PR DESCRIPTION
# Description

Link to Jira issue: [https://sikt.atlassian.net/browse/NP-47890](https://sikt.atlassian.net/browse/NP-47890)

In the project wizard, when the title exists on other project, changed the title of the list from "result" to "search result" (two places). Also found and fixed small bug where both result and "no results found" would show at the same time.

![image](https://github.com/user-attachments/assets/8b8e1cef-a6cf-483f-88cc-7c2e6b34e00b)

![image](https://github.com/user-attachments/assets/984eb639-3c5c-4ce2-be5a-ac43ead00985)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
