### PR TITLE
NP-47920 Add a fixed wait to ensure formik has correct form state

### DIFF
--- a/src/components/RouteLeavingGuard.tsx
+++ b/src/components/RouteLeavingGuard.tsx
@@ -1,7 +1,6 @@
 import { Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { Prompt, useHistory } from 'react-router-dom';
-import { UrlPathTemplate } from '../utils/urlPaths';
 import { ConfirmDialog } from './ConfirmDialog';
 
 interface RouteLeavingGuardProps {
@@ -42,12 +41,7 @@ export const RouteLeavingGuard = ({
         message={(nextLocation) => {
           const currentPath = `${history.location.pathname}${history.location.search}`;
           const newPath = `${nextLocation.pathname}${nextLocation.search}${nextLocation.hash}`;
-          if (
-            !confirmedNavigation &&
-            shouldBlockNavigation &&
-            currentPath !== newPath &&
-            !goFromRegistrationWizardToLandingPage(history.location.pathname, nextLocation.pathname)
-          ) {
+          if (!confirmedNavigation && shouldBlockNavigation && currentPath !== newPath) {
             setShowModal(true);
             setNextPath(newPath);
             return false;
@@ -68,17 +62,4 @@ export const RouteLeavingGuard = ({
       </ConfirmDialog>
     </>
   );
-};
-
-// NOTE:
-// This is a workaround to allow navigating to Landing Page programatically from Wizard, due to changes for React v18(?).
-// This solution may lead to some unexpected behaviour, and should be revisited if we find a better solution.
-const goFromRegistrationWizardToLandingPage = (currentPath: string, newPath: string) => {
-  const splittedPath = UrlPathTemplate.RegistrationWizard.split(':identifier');
-  const currentPathIsRegistrationWizard =
-    currentPath.startsWith(splittedPath[0]) && currentPath.endsWith(splittedPath[1]);
-  const newPathIsLandingPage =
-    currentPath.startsWith(newPath) && !newPath.endsWith(splittedPath[1]) && newPath !== UrlPathTemplate.Home;
-
-  return currentPathIsRegistrationWizard && newPathIsLandingPage;
 };

--- a/src/pages/registration/RegistrationFormActions.tsx
+++ b/src/pages/registration/RegistrationFormActions.tsx
@@ -64,7 +64,6 @@ export const RegistrationFormActions = ({
         ['registration', updateRegistrationResponse.data.identifier],
         updateRegistrationResponse.data
       );
-      dispatch(setNotification({ message: t('feedback.success.update_registration'), variant: 'success' }));
 
       const newErrors = validateForm(updateRegistrationResponse.data);
       resetForm({
@@ -72,6 +71,12 @@ export const RegistrationFormActions = ({
         errors: newErrors,
         touched: setNestedObjectValues(newErrors, true),
       });
+
+      // Add a fixed wait to ensure that Formik has updated the form before navigating.
+      // Without this we experienced some issues with RouteLeavingGuard on some browsers (NP-47920).
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      dispatch(setNotification({ message: t('feedback.success.update_registration'), variant: 'success' }));
 
       if (isLastTab) {
         if (history.location.state?.previousPath) {


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47920

Unngå at bruker får varsel om at formen har ulagrede endringer etter å ha lagret. Skulle gjerne hatt en bedre løsning enn å legge inn en wait, men har ikke funnet noe bedre enda hvertfall..

NB! Denne burde nok testes noen dager i dev før vi ruller ut til test og prod

Feilen ble introdusert, og forsøkt mitigert, her: https://github.com/BIBSYSDEV/NVA-Frontend/pull/5728

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
