### PR TITLE
Np 47874 show log when user cannot do anything on tasks

### DIFF
--- a/src/pages/public_registration/ActionPanel.tsx
+++ b/src/pages/public_registration/ActionPanel.tsx
@@ -70,11 +70,7 @@ export const ActionPanel = ({
   const canSeeTasksPanel =
     shouldSeePublishingAccordion || shouldSeeDoiAccordion || shouldSeeSupportAccordion || shouldSeeDelete;
 
-  if (!canSeeTasksPanel) {
-    return null;
-  }
-
-  const [tabValue, setTabValue] = useState(0);
+  const [tabValue, setTabValue] = useState(canSeeTasksPanel ? 0 : 1);
 
   return (
     <Paper
@@ -87,13 +83,17 @@ export const ActionPanel = ({
         sx={{ bgcolor: 'primary.main', px: '0.5rem' }}
         textColor="inherit"
         TabIndicatorProps={{ style: { backgroundColor: 'white', height: '0.4rem' } }}>
+        {canSeeTasksPanel && (
+          <Tab
+            value={0}
+            label={t('common.tasks')}
+            data-testid={dataTestId.registrationLandingPage.tasksPanel.tabPanelTasks}
+            id="action-panel-tab-0"
+            aria-controls="action-panel-tab-panel-0"
+          />
+        )}
         <Tab
-          label={t('common.tasks')}
-          data-testid={dataTestId.registrationLandingPage.tasksPanel.tabPanelTasks}
-          id="action-panel-tab-0"
-          aria-controls="action-panel-tab-panel-0"
-        />
-        <Tab
+          value={1}
           label={t('common.log')}
           data-testid={dataTestId.registrationLandingPage.tasksPanel.tabPanelLog}
           id="action-panel-tab-1"

--- a/src/pages/public_registration/ActionPanel.tsx
+++ b/src/pages/public_registration/ActionPanel.tsx
@@ -12,6 +12,11 @@ import { ActionPanelContent } from './ActionPanelContent';
 import { LogPanel } from './LogPanel';
 import { PublicRegistrationContentProps } from './PublicRegistrationContent';
 
+enum TabValue {
+  Tasks,
+  Log,
+}
+
 interface ActionPanelProps extends PublicRegistrationContentProps {
   tickets: Ticket[];
   refetchRegistrationAndTickets: () => Promise<void>;
@@ -70,7 +75,7 @@ export const ActionPanel = ({
   const canSeeTasksPanel =
     shouldSeePublishingAccordion || shouldSeeDoiAccordion || shouldSeeSupportAccordion || shouldSeeDelete;
 
-  const [tabValue, setTabValue] = useState(canSeeTasksPanel ? 0 : 1);
+  const [tabValue, setTabValue] = useState(canSeeTasksPanel ? TabValue.Tasks : TabValue.Log);
 
   return (
     <Paper
@@ -85,7 +90,7 @@ export const ActionPanel = ({
         TabIndicatorProps={{ style: { backgroundColor: 'white', height: '0.4rem' } }}>
         {canSeeTasksPanel && (
           <Tab
-            value={0}
+            value={TabValue.Tasks}
             label={t('common.tasks')}
             data-testid={dataTestId.registrationLandingPage.tasksPanel.tabPanelTasks}
             id="action-panel-tab-0"
@@ -93,7 +98,7 @@ export const ActionPanel = ({
           />
         )}
         <Tab
-          value={1}
+          value={TabValue.Log}
           label={t('common.log')}
           data-testid={dataTestId.registrationLandingPage.tasksPanel.tabPanelLog}
           id="action-panel-tab-1"
@@ -123,7 +128,7 @@ export const ActionPanel = ({
 
 interface TabPanelProps {
   children: ReactNode;
-  tabValue: number;
+  tabValue: TabValue;
   index: number;
 }
 


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47874

Vis loggen som default når bruker ikke har tilgang til å gjøre noe i oppgave-taben. Dette gjelder f.eks. om man bare er NVI-kurator. Tidligere fikk man alltid se en fane for oppgvaver som kunne være helt tom om man ikke hadde lov til å gjøre noe.

Det som er gjort er i praksis å flytte tilgangssjekken en komponent opp, og så vise bare logg-fanen om det er det eneste man har lov til.

![bilde](https://github.com/user-attachments/assets/0600ece7-80a0-47ef-94e1-3829feef6976)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
