### PR TITLE
Np 47442 move delete draft button

### DIFF
--- a/src/pages/public_registration/ActionPanel.tsx
+++ b/src/pages/public_registration/ActionPanel.tsx
@@ -52,7 +52,8 @@ export const ActionPanel = ({
   const hasOtherPublishingRights =
     userHasAccessRight(registration, 'unpublish') ||
     userHasAccessRight(registration, 'republish') ||
-    userHasAccessRight(registration, 'terminate');
+    userHasAccessRight(registration, 'terminate') ||
+    userHasAccessRight(registration, 'delete');
 
   const customerHasConfiguredDoi = customer?.doiAgent.username;
   const canCreateDoiTicket =
@@ -70,10 +71,8 @@ export const ActionPanel = ({
     !!customerHasConfiguredDoi &&
     (canCreateDoiTicket || canApproveDoiTicket);
   const shouldSeeSupportAccordion = canCreateSupportTicket || canApproveSupportTicket;
-  const shouldSeeDelete = userHasAccessRight(registration, 'delete');
 
-  const canSeeTasksPanel =
-    shouldSeePublishingAccordion || shouldSeeDoiAccordion || shouldSeeSupportAccordion || shouldSeeDelete;
+  const canSeeTasksPanel = shouldSeePublishingAccordion || shouldSeeDoiAccordion || shouldSeeSupportAccordion;
 
   const [tabValue, setTabValue] = useState(canSeeTasksPanel ? TabValue.Tasks : TabValue.Log);
 
@@ -113,7 +112,6 @@ export const ActionPanel = ({
           shouldSeePublishingAccordion={shouldSeePublishingAccordion}
           shouldSeeDoiAccordion={shouldSeeDoiAccordion}
           shouldSeeSupportAccordion={shouldSeeSupportAccordion}
-          shouldSeeDelete={shouldSeeDelete}
           publishingRequestTickets={publishingRequestTickets}
           newestDoiRequestTicket={newestDoiRequestTicket}
           newestSupportTicket={newestSupportTicket}

--- a/src/pages/public_registration/ActionPanelContent.tsx
+++ b/src/pages/public_registration/ActionPanelContent.tsx
@@ -1,18 +1,11 @@
-import { Box, Button, Typography } from '@mui/material';
-import { useMutation } from '@tanstack/react-query';
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'react-router-dom';
-import { addTicketMessage, deleteRegistration } from '../../api/registrationApi';
-import { ConfirmDialog } from '../../components/ConfirmDialog';
+import { addTicketMessage } from '../../api/registrationApi';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
 import { setNotification } from '../../redux/notificationSlice';
 import { RootState } from '../../redux/store';
 import { PublishingTicket, Ticket } from '../../types/publication_types/ticket.types';
 import { isErrorStatus, isSuccessStatus } from '../../utils/constants';
-import { getTitleString } from '../../utils/registration-helpers';
-import { UrlPathTemplate } from '../../utils/urlPaths';
 import { PublicRegistrationContentProps } from './PublicRegistrationContent';
 import { DoiRequestAccordion } from './action_accordions/DoiRequestAccordion';
 import { PublishingAccordion } from './action_accordions/PublishingAccordion';
@@ -24,7 +17,6 @@ interface ActionPanelContentProps extends PublicRegistrationContentProps {
   shouldSeePublishingAccordion: boolean;
   shouldSeeDoiAccordion: boolean;
   shouldSeeSupportAccordion: boolean;
-  shouldSeeDelete: boolean;
   publishingRequestTickets: PublishingTicket[];
   newestDoiRequestTicket?: Ticket;
   newestSupportTicket?: Ticket;
@@ -37,15 +29,12 @@ export const ActionPanelContent = ({
   shouldSeePublishingAccordion,
   shouldSeeDoiAccordion,
   shouldSeeSupportAccordion,
-  shouldSeeDelete,
   publishingRequestTickets,
   newestDoiRequestTicket,
   newestSupportTicket,
 }: ActionPanelContentProps) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
-  const history = useHistory();
-  const currentPath = history.location.pathname;
   const customer = useSelector((store: RootState) => store.customer);
 
   const addMessage = async (ticketId: string, message: string) => {
@@ -58,34 +47,6 @@ export const ActionPanelContent = ({
       return true;
     }
   };
-
-  const [showDeleteModal, setShowDeleteModal] = useState(false);
-
-  const draftRegistrationMutation = useMutation({
-    mutationFn: () => deleteRegistration(registration.identifier),
-    onSuccess: () => {
-      dispatch(
-        setNotification({
-          message: t('feedback.success.delete_registration'),
-          variant: 'success',
-        })
-      );
-
-      if (currentPath.startsWith(UrlPathTemplate.MyPageMessages)) {
-        history.push(UrlPathTemplate.MyPageMyMessages);
-      } else if (currentPath.startsWith(UrlPathTemplate.RegistrationNew)) {
-        history.push(UrlPathTemplate.MyPageMyRegistrations);
-      }
-    },
-    onError: () => {
-      dispatch(
-        setNotification({
-          message: t('feedback.error.delete_registration'),
-          variant: 'error',
-        })
-      );
-    },
-  });
 
   return (
     <>
@@ -124,32 +85,6 @@ export const ActionPanelContent = ({
             refetchData={refetchData}
           />
         </ErrorBoundary>
-      )}
-
-      {shouldSeeDelete && (
-        <Box sx={{ m: '0.5rem', mt: '1rem' }}>
-          <Button
-            sx={{ bgcolor: 'white' }}
-            size="small"
-            fullWidth
-            variant="outlined"
-            onClick={() => setShowDeleteModal(true)}>
-            {t('common.delete')}
-          </Button>
-
-          <ConfirmDialog
-            open={!!showDeleteModal}
-            title={t('my_page.registrations.delete_registration')}
-            onAccept={draftRegistrationMutation.mutate}
-            onCancel={() => setShowDeleteModal(false)}
-            isLoading={draftRegistrationMutation.isPending}>
-            <Typography>
-              {t('my_page.registrations.delete_registration_message', {
-                title: getTitleString(registration?.entityDescription?.mainTitle),
-              })}
-            </Typography>
-          </ConfirmDialog>
-        </Box>
       )}
     </>
   );

--- a/src/pages/public_registration/action_accordions/DeleteDraftRegistration.tsx
+++ b/src/pages/public_registration/action_accordions/DeleteDraftRegistration.tsx
@@ -50,7 +50,7 @@ export const DeleteDraftRegistration = ({ registration }: DeleteDraftRegistratio
   return (
     <section>
       <Typography fontWeight="bold">{t('common.delete')}</Typography>
-      <Trans t={t} i18nKey="registration.public_page.tasks_panel.delete_draft_registration_description">
+      <Trans i18nKey="registration.public_page.tasks_panel.delete_draft_registration_description">
         <Typography gutterBottom />
       </Trans>
 
@@ -66,7 +66,7 @@ export const DeleteDraftRegistration = ({ registration }: DeleteDraftRegistratio
       </Button>
 
       <ConfirmDialog
-        open={!!showDeleteModal}
+        open={showDeleteModal}
         title={t('my_page.registrations.delete_registration')}
         onAccept={draftRegistrationMutation.mutate}
         onCancel={() => setShowDeleteModal(false)}

--- a/src/pages/public_registration/action_accordions/DeleteDraftRegistration.tsx
+++ b/src/pages/public_registration/action_accordions/DeleteDraftRegistration.tsx
@@ -8,6 +8,7 @@ import { useHistory } from 'react-router-dom';
 import { deleteRegistration } from '../../../api/registrationApi';
 import { ConfirmDialog } from '../../../components/ConfirmDialog';
 import { setNotification } from '../../../redux/notificationSlice';
+import { PreviousPathLocationState, PreviousSearchLocationState } from '../../../types/locationState.types';
 import { Registration } from '../../../types/registration.types';
 import { getTitleString } from '../../../utils/registration-helpers';
 import { UrlPathTemplate } from '../../../utils/urlPaths';
@@ -19,7 +20,7 @@ interface DeleteDraftRegistrationProps {
 export const DeleteDraftRegistration = ({ registration }: DeleteDraftRegistrationProps) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
-  const history = useHistory();
+  const history = useHistory<(PreviousSearchLocationState & PreviousPathLocationState) | undefined>();
 
   const [showDeleteModal, setShowDeleteModal] = useState(false);
 
@@ -29,9 +30,17 @@ export const DeleteDraftRegistration = ({ registration }: DeleteDraftRegistratio
       dispatch(setNotification({ message: t('feedback.success.delete_registration'), variant: 'success' }));
 
       if (history.location.pathname.startsWith(UrlPathTemplate.MyPageMessages)) {
-        history.push(UrlPathTemplate.MyPageMyMessages);
+        history.push({
+          pathname: UrlPathTemplate.MyPageMyMessages,
+          search: history.location.state?.previousSearch,
+        });
       } else if (history.location.pathname.startsWith(UrlPathTemplate.RegistrationNew)) {
-        history.push(UrlPathTemplate.MyPageMyRegistrations);
+        history.push(history.location.state?.previousPath || UrlPathTemplate.MyPageMyRegistrations);
+      } else if (history.location.pathname.startsWith(UrlPathTemplate.TasksDialogue)) {
+        history.push({
+          pathname: UrlPathTemplate.TasksDialogue,
+          search: history.location.state?.previousSearch,
+        });
       }
     },
     onError: () => dispatch(setNotification({ message: t('feedback.error.delete_registration'), variant: 'error' })),

--- a/src/pages/public_registration/action_accordions/DeleteDraftRegistration.tsx
+++ b/src/pages/public_registration/action_accordions/DeleteDraftRegistration.tsx
@@ -1,0 +1,71 @@
+import DeleteIcon from '@mui/icons-material/Delete';
+import { Button, Typography } from '@mui/material';
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import { deleteRegistration } from '../../../api/registrationApi';
+import { ConfirmDialog } from '../../../components/ConfirmDialog';
+import { setNotification } from '../../../redux/notificationSlice';
+import { Registration } from '../../../types/registration.types';
+import { getTitleString } from '../../../utils/registration-helpers';
+import { UrlPathTemplate } from '../../../utils/urlPaths';
+
+interface DeleteDraftRegistrationProps {
+  registration: Registration;
+}
+
+export const DeleteDraftRegistration = ({ registration }: DeleteDraftRegistrationProps) => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const history = useHistory();
+
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  const draftRegistrationMutation = useMutation({
+    mutationFn: () => deleteRegistration(registration.identifier),
+    onSuccess: () => {
+      dispatch(setNotification({ message: t('feedback.success.delete_registration'), variant: 'success' }));
+
+      if (history.location.pathname.startsWith(UrlPathTemplate.MyPageMessages)) {
+        history.push(UrlPathTemplate.MyPageMyMessages);
+      } else if (history.location.pathname.startsWith(UrlPathTemplate.RegistrationNew)) {
+        history.push(UrlPathTemplate.MyPageMyRegistrations);
+      }
+    },
+    onError: () => dispatch(setNotification({ message: t('feedback.error.delete_registration'), variant: 'error' })),
+  });
+
+  return (
+    <section>
+      <Typography fontWeight="bold">{t('common.delete')}</Typography>
+      <Trans t={t} i18nKey="registration.public_page.tasks_panel.delete_draft_registration_description">
+        <Typography gutterBottom />
+      </Trans>
+
+      <Button
+        sx={{ bgcolor: 'white' }}
+        size="small"
+        fullWidth
+        startIcon={<DeleteIcon />}
+        variant="outlined"
+        onClick={() => setShowDeleteModal(true)}>
+        {t('common.delete')}
+      </Button>
+
+      <ConfirmDialog
+        open={!!showDeleteModal}
+        title={t('my_page.registrations.delete_registration')}
+        onAccept={draftRegistrationMutation.mutate}
+        onCancel={() => setShowDeleteModal(false)}
+        isLoading={draftRegistrationMutation.isPending}>
+        <Typography>
+          {t('my_page.registrations.delete_registration_message', {
+            title: getTitleString(registration?.entityDescription?.mainTitle),
+          })}
+        </Typography>
+      </ConfirmDialog>
+    </section>
+  );
+};

--- a/src/pages/public_registration/action_accordions/DeleteDraftRegistration.tsx
+++ b/src/pages/public_registration/action_accordions/DeleteDraftRegistration.tsx
@@ -10,6 +10,7 @@ import { ConfirmDialog } from '../../../components/ConfirmDialog';
 import { setNotification } from '../../../redux/notificationSlice';
 import { PreviousPathLocationState, PreviousSearchLocationState } from '../../../types/locationState.types';
 import { Registration } from '../../../types/registration.types';
+import { dataTestId } from '../../../utils/dataTestIds';
 import { getTitleString } from '../../../utils/registration-helpers';
 import { UrlPathTemplate } from '../../../utils/urlPaths';
 
@@ -54,6 +55,7 @@ export const DeleteDraftRegistration = ({ registration }: DeleteDraftRegistratio
       </Trans>
 
       <Button
+        data-testid={dataTestId.registrationLandingPage.tasksPanel.deleteRegistrationButton}
         sx={{ bgcolor: 'white' }}
         size="small"
         fullWidth

--- a/src/pages/public_registration/action_accordions/MoreActionsCollapse.tsx
+++ b/src/pages/public_registration/action_accordions/MoreActionsCollapse.tsx
@@ -21,9 +21,9 @@ export const MoreActionsCollapse = ({ registration }: MoreActionsCollapseProps) 
 
   const isPublished = registration.status === 'PUBLISHED' || registration.status === 'PUBLISHED_METADATA';
   const isUnpublished = registration.status === 'UNPUBLISHED';
-  const canDeleteDraft = registration.status === 'DRAFT' && userHasAccessRight(registration, 'delete');
+  const canDeleteRegistration = userHasAccessRight(registration, 'delete');
 
-  if (!(isPublished || isUnpublished || canDeleteDraft)) {
+  if (!(isPublished || isUnpublished || canDeleteRegistration)) {
     return null;
   }
 
@@ -48,7 +48,7 @@ export const MoreActionsCollapse = ({ registration }: MoreActionsCollapseProps) 
               <TerminateRegistration registration={registration} />
             </>
           )}
-          {canDeleteDraft && <DeleteDraftRegistration registration={registration} />}
+          {canDeleteRegistration && <DeleteDraftRegistration registration={registration} />}
         </Box>
       )}
     </Box>

--- a/src/pages/public_registration/action_accordions/MoreActionsCollapse.tsx
+++ b/src/pages/public_registration/action_accordions/MoreActionsCollapse.tsx
@@ -5,6 +5,8 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Registration } from '../../../types/registration.types';
 import { dataTestId } from '../../../utils/dataTestIds';
+import { userHasAccessRight } from '../../../utils/registration-helpers';
+import { DeleteDraftRegistration } from './DeleteDraftRegistration';
 import { RepublishRegistration } from './RepublishRegistration';
 import { TerminateRegistration } from './TerminateRegistration';
 import { UnpublishRegistration } from './UnpublishRegistration';
@@ -19,8 +21,9 @@ export const MoreActionsCollapse = ({ registration }: MoreActionsCollapseProps) 
 
   const isPublished = registration.status === 'PUBLISHED' || registration.status === 'PUBLISHED_METADATA';
   const isUnpublished = registration.status === 'UNPUBLISHED';
+  const canDeleteDraft = registration.status === 'DRAFT' && userHasAccessRight(registration, 'delete');
 
-  if (!(isPublished || isUnpublished)) {
+  if (!(isPublished || isUnpublished || canDeleteDraft)) {
     return null;
   }
 
@@ -45,6 +48,7 @@ export const MoreActionsCollapse = ({ registration }: MoreActionsCollapseProps) 
               <TerminateRegistration registration={registration} />
             </>
           )}
+          {canDeleteDraft && <DeleteDraftRegistration registration={registration} />}
         </Box>
       )}
     </Box>

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1504,6 +1504,7 @@
         "assign_doi": "Tildel DOI",
         "assign_doi_about": "For at andre skal kunne benytte DOI, må du tildele denne. Metadata må være publisert.",
         "confirm_republish_description": "Republiser resultatet om det skal være tilgjengelig i NVA. Dette vil føre til at resultatet vil vises blant søkeresultater igjen.",
+        "delete_draft_registration_description": "<0>Ved å slette registreringen så er den permanent slettet.</0><0>Det er ikke mulig å gjenopprette informasjon som er registrert, inkludert filer, i etterkant.</0>",
         "describe_doi_rejection_reason": "Du må begrunne avslaget på ønsket om DOI på dette forskningsresultatet.",
         "draft_doi_description": "<0>En reservert DOI gjør at du (og de du deler DOI med) kan sitere forskningsresultatet i andre arbeid før det publiseres.</0><1><0>Les mer om DOI<0></0></0></1><0>Ønsker du DOI på dette resultatet, trykk på \"{{buttonText}}\".</0>",
         "duplicate_title_description_details": "<0>Det skal ikke opprettes duplikater i NVA. Sjekk om din registrering tilsvarer det som alt er publisert.</0><0>Om resultatet som er publisert har feil eller mangler så be registrator eller bidragsyter som er tilknyttet resultatet om å endre det.</0>",
@@ -1537,8 +1538,7 @@
         "waiting_for_rejected_doi": "Det kan ta litt tid før en reservert DOI forsvinner. Last innholdet på nytt for å sjekke igjen.",
         "you_can_publish_everything": "Beskrivelsen (metadata) av forskningsresultatet og opplastede filer blir offentlig synlig når du velger \"$t(registration.public_page.tasks_panel.publish_registration)\".",
         "you_can_publish_metadata": "Beskrivelsen (metadata) av forskningsresultatet blir offentlig synlig når du velger \"$t(registration.public_page.tasks_panel.publish_registration)\".",
-        "you_can_publish_metadata_files_info": "Når fil(er) og valgt lisens er godkjent av kurator blir de offentlig tilgjengelig.",
-        "delete_draft_registration_description": "<0>Ved å slette registreringen så er den permanent slettet.</0><0>Det er ikke mulig å gjenopprette informasjon som er registrert, inkludert filer, i etterkant.</0>"
+        "you_can_publish_metadata_files_info": "Når fil(er) og valgt lisens er godkjent av kurator blir de offentlig tilgjengelig."
       },
       "validation_errors": "Valideringsfeil"
     },

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -310,10 +310,6 @@
     "yes": "Ja"
   },
   "disciplines": {
-    "0001": "Humaniora",
-    "0002": "Samfunnsvitenskap",
-    "0003": "Medisin og helsefag",
-    "0004": "Realfag og teknologi",
     "1003": "Arkeologi og konservering",
     "1005": "Asiatiske og afrikanske studier",
     "1007": "Engelsk",
@@ -385,7 +381,11 @@
     "1162": "Konstruksjonsfag",
     "1166": "Filosofi",
     "1168": "Historie og idéhistorie",
-    "1170": "Kunst, design og arkitektur"
+    "1170": "Kunst, design og arkitektur",
+    "0001": "Humaniora",
+    "0002": "Samfunnsvitenskap",
+    "0003": "Medisin og helsefag",
+    "0004": "Realfag og teknologi"
   },
   "editor": {
     "categories_with_files": "Kategorier med filopplasting",
@@ -1537,7 +1537,8 @@
         "waiting_for_rejected_doi": "Det kan ta litt tid før en reservert DOI forsvinner. Last innholdet på nytt for å sjekke igjen.",
         "you_can_publish_everything": "Beskrivelsen (metadata) av forskningsresultatet og opplastede filer blir offentlig synlig når du velger \"$t(registration.public_page.tasks_panel.publish_registration)\".",
         "you_can_publish_metadata": "Beskrivelsen (metadata) av forskningsresultatet blir offentlig synlig når du velger \"$t(registration.public_page.tasks_panel.publish_registration)\".",
-        "you_can_publish_metadata_files_info": "Når fil(er) og valgt lisens er godkjent av kurator blir de offentlig tilgjengelig."
+        "you_can_publish_metadata_files_info": "Når fil(er) og valgt lisens er godkjent av kurator blir de offentlig tilgjengelig.",
+        "delete_draft_registration_description": "<0>Ved å slette registreringen så er den permanent slettet.</0><0>Det er ikke mulig å gjenopprette informasjon som er registrert, inkludert filer, i etterkant.</0>"
       },
       "validation_errors": "Valideringsfeil"
     },

--- a/src/utils/dataTestIds.ts
+++ b/src/utils/dataTestIds.ts
@@ -348,6 +348,7 @@ export const dataTestId = {
       cancelRejectionButton: 'cancel-rejection-button',
       createDoiButton: 'button-create-doi',
       deleteMessageButton: 'delete-message-button',
+      deleteRegistrationButton: 'delete-registration-button',
       doiRequestAccordion: 'doi-request-accordion',
       duplicateRegistrationLink: 'duplicate-registration-link',
       messageOptionsButton: 'message-options-button',


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47442

Flytt slett-knappen for kladder fra å være nederst i høyremeny til å bli nederst i publiseringsboksen.

Før:
![bilde](https://github.com/user-attachments/assets/ddbaae70-ecc4-4714-b130-1728ca5c9447)

Etter:
![bilde](https://github.com/user-attachments/assets/aff203ad-63a5-42e8-9afd-bb856896b9d6)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
