### PR TITLE
NP-48078 Add result icon to wizard header

### DIFF
--- a/src/pages/registration/RegistrationForm.tsx
+++ b/src/pages/registration/RegistrationForm.tsx
@@ -12,6 +12,7 @@ import { ConfirmDialog } from '../../components/ConfirmDialog';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
 import { PageHeader } from '../../components/PageHeader';
 import { PageSpinner } from '../../components/PageSpinner';
+import { RegistrationIconHeader } from '../../components/RegistrationIconHeader';
 import { RequiredDescription } from '../../components/RequiredDescription';
 import { RouteLeavingGuard } from '../../components/RouteLeavingGuard';
 import { SkipLink } from '../../components/SkipLink';
@@ -99,7 +100,14 @@ export const RegistrationForm = ({ identifier }: RegistrationFormProps) => {
               modalHeading={t('registration.modal_unsaved_changes_heading')}
               shouldBlockNavigation={dirty}
             />
-            <PageHeader variant="h1">{getTitleString(values.entityDescription?.mainTitle)}</PageHeader>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+              <RegistrationIconHeader
+                publicationInstanceType={values.entityDescription?.reference?.publicationInstance.type}
+                publicationDate={values.entityDescription?.publicationDate}
+                showYearOnly
+              />
+              <PageHeader variant="h1">{getTitleString(values.entityDescription?.mainTitle)}</PageHeader>
+            </Box>
             <RegistrationFormStepper tabNumber={tabNumber} setTabNumber={setTabNumber} />
             <RequiredDescription />
             <BackgroundDiv sx={{ bgcolor: 'secondary.main' }}>


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48078

Legger til resultat-ikon i registreringswizard. Bygger videre på https://github.com/BIBSYSDEV/NVA-Frontend/pull/6603
Rota til historikken i [forrige PR](https://github.com/BIBSYSDEV/NVA-Frontend/pull/6604), derfor oppretter jeg denne på nytt

Før:
![388445315-23cf33a6-b0bb-44d0-9de8-a9c0b25453ea](https://github.com/user-attachments/assets/c09b7193-442e-45bb-92b9-63e91aefd6ae)

Etter:
![388445435-4f79877c-eeba-4da3-bed9-10ed21286b03](https://github.com/user-attachments/assets/0cdb6d00-9edc-45cd-b675-ec7a95d91572)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
