### PR TITLE
Show add icon when chip is not selected

### DIFF
--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -1,3 +1,5 @@
+import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
+import CancelIcon from '@mui/icons-material/Cancel';
 import FilterVintageIcon from '@mui/icons-material/FilterVintage';
 import SearchIcon from '@mui/icons-material/Search';
 import { Box, Chip, TextField, Tooltip, Typography } from '@mui/material';
@@ -194,6 +196,8 @@ interface CategoryChipProps {
 export const CategoryChip = ({ category, onClickChip, disabled = !!category.disableText }: CategoryChipProps) => {
   const { t } = useTranslation();
 
+  const toggleCategory = onClickChip ? () => onClickChip(category.value) : undefined;
+
   return (
     <Tooltip title={category.disableText}>
       <span>
@@ -208,9 +212,11 @@ export const CategoryChip = ({ category, onClickChip, disabled = !!category.disa
               />
             ) : undefined
           }
+          deleteIcon={category.selected ? <CancelIcon /> : <AddCircleOutlineIcon />}
           variant={category.selected ? 'filled' : 'outlined'}
           color="primary"
-          onClick={onClickChip ? () => onClickChip(category.value) : undefined}
+          onDelete={toggleCategory}
+          onClick={toggleCategory}
           label={category.text}
         />
       </span>


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47791

Vis "+"-ikon når en chip ikke er valgt.

![bilde](https://github.com/user-attachments/assets/e79edf30-746c-463d-8de5-11f75504c255)
 

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
