### PR TITLE
Remove deprecated mui props

### DIFF
--- a/src/components/AreaOfResponsibiltySelector.tsx
+++ b/src/components/AreaOfResponsibiltySelector.tsx
@@ -64,13 +64,7 @@ export const AreaOfResponsibilitySelector = ({ sx, paramName, resetPagination }:
       defaultValue={getLanguageString(organizationOptions[0].labels)}
       title={getLanguageString(organizationOptions[0].labels)}
       label={t('editor.curators.area_of_responsibility')}
-      InputLabelProps={{ shrink: true }}
-      inputProps={{
-        style: {
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-        },
-      }}
+      slotProps={{ htmlInput: { style: { overflow: 'hidden', textOverflow: 'ellipsis' } } }}
     />
   ) : (
     <Autocomplete

--- a/src/components/AutocompleteTextField.tsx
+++ b/src/components/AutocompleteTextField.tsx
@@ -20,22 +20,24 @@ export const AutocompleteTextField = ({
     variant="filled"
     {...params}
     fullWidth
-    InputProps={{
-      ...params.InputProps,
-      startAdornment: (
-        <>
-          {params.InputProps.startAdornment}
-          {showSearchIcon && <SearchIcon color="disabled" />}
-        </>
-      ),
-      endAdornment: (
-        <>
-          {isLoading && <CircularProgress size={20} aria-labelledby={params.InputLabelProps.id} />}
-          {params.InputProps.endAdornment}
-        </>
-      ),
-    }}
     error={!!errorMessage}
     helperText={errorMessage}
+    slotProps={{
+      input: {
+        ...params.InputProps,
+        startAdornment: (
+          <>
+            {params.InputProps.startAdornment}
+            {showSearchIcon && <SearchIcon color="disabled" />}
+          </>
+        ),
+        endAdornment: (
+          <>
+            {isLoading && <CircularProgress size={20} aria-labelledby={params.InputLabelProps.id} />}
+            {params.InputProps.endAdornment}
+          </>
+        ),
+      },
+    }}
   />
 );

--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -99,7 +99,7 @@ export const CategorySelector = ({
           type="search"
           variant="filled"
           label={t('common.search')}
-          InputProps={{ endAdornment: <SearchIcon /> }}
+          slotProps={{ input: { endAdornment: <SearchIcon /> } }}
           onChange={(event) => setSearchValue(event.target.value)}
         />
         {setSelectedCategories ? (

--- a/src/components/ContributorSearchField.tsx
+++ b/src/components/ContributorSearchField.tsx
@@ -63,9 +63,7 @@ export const ContributorSearchField = ({
         }}
         placeholder={t('common.search_placeholder')}
         label={t('common.search')}
-        InputProps={{
-          startAdornment: <SearchIcon />,
-        }}
+        slotProps={{ input: { startAdornment: <SearchIcon /> } }}
         sx={{ my: '1rem' }}
       />
       {personQuery.isFetching ? (

--- a/src/components/MessageForm.tsx
+++ b/src/components/MessageForm.tsx
@@ -46,7 +46,27 @@ export const MessageForm = ({
               <TextField
                 {...field}
                 data-testid={dataTestId.tasksPage.messageField}
-                inputProps={{ maxLength: maxMessageLength }}
+                slotProps={{
+                  htmlInput: { maxLength: maxMessageLength },
+                  formHelperText: { sx: { textAlign: 'end' } },
+                  input: {
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        {isSubmitting ? (
+                          <CircularProgress aria-label={buttonTitle ?? t('common.send')} size="1.5rem" />
+                        ) : (
+                          <IconButton
+                            type="submit"
+                            color="primary"
+                            data-testid={dataTestId.tasksPage.messageSendButton}
+                            title={buttonTitle ?? t('common.send')}>
+                            <SendIcon />
+                          </IconButton>
+                        )}
+                      </InputAdornment>
+                    ),
+                  },
+                }}
                 sx={hideRequiredAsterisk ? { '& .MuiInputLabel-asterisk': { display: 'none' } } : undefined}
                 disabled={isSubmitting}
                 variant="filled"
@@ -57,24 +77,6 @@ export const MessageForm = ({
                 required
                 label={fieldLabel ?? t('common.message')}
                 helperText={`${field.value.length}/${maxMessageLength}`}
-                FormHelperTextProps={{ sx: { textAlign: 'end' } }}
-                InputProps={{
-                  endAdornment: (
-                    <InputAdornment position="end">
-                      {isSubmitting ? (
-                        <CircularProgress aria-label={buttonTitle ?? t('common.send')} size="1.5rem" />
-                      ) : (
-                        <IconButton
-                          type="submit"
-                          color="primary"
-                          data-testid={dataTestId.tasksPage.messageSendButton}
-                          title={buttonTitle ?? t('common.send')}>
-                          <SendIcon />
-                        </IconButton>
-                      )}
-                    </InputAdornment>
-                  ),
-                }}
               />
             )}
           </Field>

--- a/src/components/NationalIdNumberField.tsx
+++ b/src/components/NationalIdNumberField.tsx
@@ -23,19 +23,21 @@ export const NationalIdNumberField = ({ nationalId }: NationIdNumberFieldProps) 
       disabled
       value={showFullNin ? nationalId : getMaskedNationalIdentityNumber(nationalId)}
       label={t('common.national_id_number')}
-      InputProps={{
-        endAdornment: (
-          <Tooltip
-            title={
-              showFullNin
-                ? t('basic_data.person_register.hide_full_nin')
-                : t('basic_data.person_register.show_full_nin')
-            }>
-            <IconButton onClick={() => setShowFullNin(!showFullNin)}>
-              {showFullNin ? <VisibilityIcon /> : <VisibilityOffIcon />}
-            </IconButton>
-          </Tooltip>
-        ),
+      slotProps={{
+        input: {
+          endAdornment: (
+            <Tooltip
+              title={
+                showFullNin
+                  ? t('basic_data.person_register.hide_full_nin')
+                  : t('basic_data.person_register.show_full_nin')
+              }>
+              <IconButton onClick={() => setShowFullNin(!showFullNin)}>
+                {showFullNin ? <VisibilityIcon /> : <VisibilityOffIcon />}
+              </IconButton>
+            </Tooltip>
+          ),
+        },
       }}
     />
   );

--- a/src/components/SelectCustomerInstitutionDialog.tsx
+++ b/src/components/SelectCustomerInstitutionDialog.tsx
@@ -108,10 +108,8 @@ export const SelectCustomerInstitutionDialog = ({ allowedCustomerIds }: SelectCu
           renderInput={(params) => (
             <TextField
               {...params}
-              InputLabelProps={{
-                'aria-label': t('common.select_institution'),
-              }}
               placeholder={t('project.search_for_institution')}
+              slotProps={{ inputLabel: { 'aria-label': t('common.select_institution') } }}
             />
           )}
         />

--- a/src/components/SortSelector.tsx
+++ b/src/components/SortSelector.tsx
@@ -35,9 +35,6 @@ export const SortSelector = ({ orderKey, options, paginationKey, sortKey, ...tex
       data-testid={dataTestId.startPage.orderBySelect}
       select
       value={selectedOption}
-      inputProps={{
-        'aria-label': textFieldProps['aria-label'],
-      }}
       onChange={(event) => {
         // These typing workarounds are needed because of the way MenuItem handle object values: https://github.com/mui/material-ui/issues/14286
         const value = event.target.value as unknown as SortSelectorOption;
@@ -45,7 +42,8 @@ export const SortSelector = ({ orderKey, options, paginationKey, sortKey, ...tex
         params.set(sortKey, value.sortOrder);
         params.delete(paginationKey);
         history.push({ search: params.toString() });
-      }}>
+      }}
+      slotProps={{ htmlInput: { 'aria-label': textFieldProps['aria-label'] } }}>
       {options.map((option) => (
         <MenuItem key={option.i18nKey} value={option as any}>
           {t(option.i18nKey)}

--- a/src/components/SortSelectorWithoutParams.tsx
+++ b/src/components/SortSelectorWithoutParams.tsx
@@ -21,14 +21,14 @@ export const SortSelectorWithoutParams = <T extends SortSelectorOption>({
       data-testid={dataTestId.startPage.orderBySelect}
       select
       value={value}
-      inputProps={{ 'aria-label': t('search.sort_by') }}
       size="small"
       variant="standard"
       onChange={(event) => {
         // These typing workarounds are needed because of the way MenuItem handle object values: https://github.com/mui/material-ui/issues/14286
         const value = event.target.value as unknown as T;
         setValue(value);
-      }}>
+      }}
+      slotProps={{ htmlInput: { 'aria-label': t('search.sort_by') } }}>
       {options.map((option) => (
         <MenuItem key={option.i18nKey} value={option as any}>
           {t(option.i18nKey)}

--- a/src/components/institution/SelectInstitutionForm.tsx
+++ b/src/components/institution/SelectInstitutionForm.tsx
@@ -166,14 +166,13 @@ export const SelectInstitutionForm = ({
                     slotProps={{
                       listbox: {
                         component: AutocompleteListboxWithExpansion,
-
                         ...({
                           hasMoreHits:
                             !!organizationSearchQuery.data?.size && organizationSearchQuery.data.size > searchSize,
                           onShowMoreHits: () => setSearchSize(searchSize + defaultOrganizationSearchSize),
                           isLoadingMoreHits:
                             organizationSearchQuery.isFetching && searchSize > institutionOptions.length,
-                        } satisfies AutocompleteListboxWithExpansionProps as any),
+                        } satisfies AutocompleteListboxWithExpansionProps),
                       },
                     }}
                   />

--- a/src/components/institution/SelectInstitutionForm.tsx
+++ b/src/components/institution/SelectInstitutionForm.tsx
@@ -140,15 +140,6 @@ export const SelectInstitutionForm = ({
                     renderOption={({ key, ...props }, option) => (
                       <OrganizationRenderOption key={option.id} props={props} option={option} />
                     )}
-                    ListboxComponent={AutocompleteListboxWithExpansion}
-                    ListboxProps={
-                      {
-                        hasMoreHits:
-                          !!organizationSearchQuery.data?.size && organizationSearchQuery.data.size > searchSize,
-                        onShowMoreHits: () => setSearchSize(searchSize + defaultOrganizationSearchSize),
-                        isLoadingMoreHits: organizationSearchQuery.isFetching && searchSize > institutionOptions.length,
-                      } satisfies AutocompleteListboxWithExpansionProps as any
-                    }
                     filterOptions={(options) => options}
                     onInputChange={(_, value, reason) => {
                       if (field.value) {
@@ -172,6 +163,19 @@ export const SelectInstitutionForm = ({
                         fullWidth
                       />
                     )}
+                    slotProps={{
+                      listbox: {
+                        component: AutocompleteListboxWithExpansion,
+
+                        ...({
+                          hasMoreHits:
+                            !!organizationSearchQuery.data?.size && organizationSearchQuery.data.size > searchSize,
+                          onShowMoreHits: () => setSearchSize(searchSize + defaultOrganizationSearchSize),
+                          isLoadingMoreHits:
+                            organizationSearchQuery.isFetching && searchSize > institutionOptions.length,
+                        } satisfies AutocompleteListboxWithExpansionProps as any),
+                      },
+                    }}
                   />
                 )}
               </Field>

--- a/src/pages/basic_data/app_admin/CustomerDoiPasswordField.tsx
+++ b/src/pages/basic_data/app_admin/CustomerDoiPasswordField.tsx
@@ -81,19 +81,21 @@ export const CustomerDoiPasswordField = ({ doiAgentId, disabled }: CustomerDoiPa
                 variant="filled"
                 error={touched && !!error}
                 helperText={<ErrorMessage name={field.name} />}
-                InputProps={{
-                  endAdornment: (
-                    <Tooltip
-                      title={
-                        showPassword
-                          ? t('basic_data.institutions.password_hide')
-                          : t('basic_data.institutions.password_show')
-                      }>
-                      <IconButton onClick={() => setShowPassword(!showPassword)}>
-                        {showPassword ? <VisibilityIcon /> : <VisibilityOffIcon />}
-                      </IconButton>
-                    </Tooltip>
-                  ),
+                slotProps={{
+                  input: {
+                    endAdornment: (
+                      <Tooltip
+                        title={
+                          showPassword
+                            ? t('basic_data.institutions.password_hide')
+                            : t('basic_data.institutions.password_show')
+                        }>
+                        <IconButton onClick={() => setShowPassword(!showPassword)}>
+                          {showPassword ? <VisibilityIcon /> : <VisibilityOffIcon />}
+                        </IconButton>
+                      </Tooltip>
+                    ),
+                  },
                 }}
               />
             )}

--- a/src/pages/basic_data/app_admin/OrganizationSearchField.tsx
+++ b/src/pages/basic_data/app_admin/OrganizationSearchField.tsx
@@ -88,12 +88,11 @@ export const OrganizationSearchField = ({
       slotProps={{
         listbox: {
           component: AutocompleteListboxWithExpansion,
-
           ...({
             hasMoreHits: !!organizationSearchQuery.data?.size && organizationSearchQuery.data.size > searchSize,
             onShowMoreHits: () => setSearchSize(searchSize + defaultOrganizationSearchSize),
             isLoadingMoreHits: organizationSearchQuery.isFetching && searchSize > options.length,
-          } satisfies AutocompleteListboxWithExpansionProps as any),
+          } satisfies AutocompleteListboxWithExpansionProps),
         },
       }}
     />

--- a/src/pages/basic_data/app_admin/OrganizationSearchField.tsx
+++ b/src/pages/basic_data/app_admin/OrganizationSearchField.tsx
@@ -70,14 +70,6 @@ export const OrganizationSearchField = ({
       renderOption={({ key, ...props }, option) => (
         <OrganizationRenderOption key={option.id} props={props} option={option} />
       )}
-      ListboxComponent={AutocompleteListboxWithExpansion}
-      ListboxProps={
-        {
-          hasMoreHits: !!organizationSearchQuery.data?.size && organizationSearchQuery.data.size > searchSize,
-          onShowMoreHits: () => setSearchSize(searchSize + defaultOrganizationSearchSize),
-          isLoadingMoreHits: organizationSearchQuery.isFetching && searchSize > options.length,
-        } satisfies AutocompleteListboxWithExpansionProps as any
-      }
       renderInput={(params) => (
         <AutocompleteTextField
           onBlur={fieldInputProps?.onBlur}
@@ -93,6 +85,17 @@ export const OrganizationSearchField = ({
           showSearchIcon={!selectedValue?.id}
         />
       )}
+      slotProps={{
+        listbox: {
+          component: AutocompleteListboxWithExpansion,
+
+          ...({
+            hasMoreHits: !!organizationSearchQuery.data?.size && organizationSearchQuery.data.size > searchSize,
+            onShowMoreHits: () => setSearchSize(searchSize + defaultOrganizationSearchSize),
+            isLoadingMoreHits: organizationSearchQuery.isFetching && searchSize > options.length,
+          } satisfies AutocompleteListboxWithExpansionProps as any),
+        },
+      }}
     />
   );
 };

--- a/src/pages/basic_data/app_admin/central_import/CompareDoiField.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CompareDoiField.tsx
@@ -15,7 +15,7 @@ export const CompareDoiField = ({ doi }: { doi: string }) => {
         disabled
         multiline
         value={doi}
-        InputLabelProps={{ shrink: true }}
+        slotProps={{ inputLabel: { shrink: true } }}
       />
       {doi && (
         <Button

--- a/src/pages/basic_data/app_admin/central_import/CompareFields.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CompareFields.tsx
@@ -35,7 +35,7 @@ export const CompareFields = ({
           multiline
           label={candidateLabel}
           value={candidateValue}
-          InputLabelProps={{ shrink: true }}
+          slotProps={{ inputLabel: { shrink: true } }}
         />
       )}
       {onOverwrite ? (
@@ -59,7 +59,7 @@ export const CompareFields = ({
           multiline
           label={registrationLabel}
           value={registrationValue}
-          InputLabelProps={{ shrink: true }}
+          slotProps={{ inputLabel: { shrink: true } }}
         />
       )}
     </>

--- a/src/pages/basic_data/app_admin/central_import/DuplicateSearchFilterForm.tsx
+++ b/src/pages/basic_data/app_admin/central_import/DuplicateSearchFilterForm.tsx
@@ -74,7 +74,6 @@ export const DuplicateSearchFilterForm = ({
               {({ field }: FieldProps<string>) => (
                 <Box sx={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', alignItems: 'center' }}>
                   <TextField
-                    inputProps={{ 'aria-labelledby': 'doi-label' }}
                     data-testid={dataTestId.basicData.centralImport.textFieldDoi}
                     variant="outlined"
                     {...field}
@@ -83,6 +82,7 @@ export const DuplicateSearchFilterForm = ({
                     size="small"
                     multiline
                     disabled={!values.isDoiChecked}
+                    slotProps={{ htmlInput: { 'aria-labelledby': 'doi-label' } }}
                   />
                   {field.value && isValidUrl(field.value) && (
                     <Button
@@ -119,7 +119,6 @@ export const DuplicateSearchFilterForm = ({
             <Field name={'title'}>
               {({ field }: FieldProps<string>) => (
                 <TextField
-                  inputProps={{ 'aria-labelledby': 'title-label' }}
                   data-testid={dataTestId.basicData.centralImport.textFieldTitle}
                   fullWidth
                   {...field}
@@ -127,6 +126,7 @@ export const DuplicateSearchFilterForm = ({
                   size="small"
                   multiline
                   disabled={!values.isTitleChecked}
+                  slotProps={{ htmlInput: { 'aria-labelledby': 'title-label' } }}
                 />
               )}
             </Field>
@@ -148,7 +148,6 @@ export const DuplicateSearchFilterForm = ({
             <Field name={'author'}>
               {({ field }: FieldProps<string>) => (
                 <TextField
-                  inputProps={{ 'aria-labelledby': 'author-label' }}
                   data-testid={dataTestId.basicData.centralImport.textFieldAuthor}
                   fullWidth
                   {...field}
@@ -156,6 +155,7 @@ export const DuplicateSearchFilterForm = ({
                   size="small"
                   multiline
                   disabled={!values.isAuthorChecked}
+                  slotProps={{ htmlInput: { 'aria-labelledby': 'author-label' } }}
                 />
               )}
             </Field>
@@ -177,13 +177,13 @@ export const DuplicateSearchFilterForm = ({
             <Field name={'issn'}>
               {({ field }: FieldProps<string>) => (
                 <TextField
-                  inputProps={{ 'aria-labelledby': 'issn-label' }}
                   data-testid={dataTestId.basicData.centralImport.textFieldIssn}
                   fullWidth
                   {...field}
                   variant="outlined"
                   size="small"
                   disabled={!values.isIssnChecked}
+                  slotProps={{ htmlInput: { 'aria-labelledby': 'issn-label' } }}
                 />
               )}
             </Field>
@@ -205,13 +205,13 @@ export const DuplicateSearchFilterForm = ({
             <Field name={'yearPublished'}>
               {({ field }: FieldProps<string>) => (
                 <TextField
-                  inputProps={{ 'aria-labelledby': 'year-label' }}
                   data-testid={dataTestId.basicData.centralImport.textFieldYear}
                   fullWidth
                   {...field}
                   variant="outlined"
                   size="small"
                   disabled={!values.isYearPublishedChecked}
+                  slotProps={{ htmlInput: { 'aria-labelledby': 'year-label' } }}
                 />
               )}
             </Field>

--- a/src/pages/basic_data/institution_admin/AddAffiliationSection.tsx
+++ b/src/pages/basic_data/institution_admin/AddAffiliationSection.tsx
@@ -78,12 +78,12 @@ export const AddAffiliationSection = () => {
                 disabled={isDisabled}
                 fullWidth
                 type="number"
-                inputProps={{ min: '0', max: '100' }}
                 variant="filled"
                 label={t('basic_data.add_employee.position_percent')}
                 error={touched && !!error}
                 helperText={<ErrorMessage name={field.name} />}
                 data-testid={dataTestId.basicData.personAdmin.positionPercent}
+                slotProps={{ htmlInput: { min: '0', max: '100' } }}
               />
             )}
           </Field>

--- a/src/pages/basic_data/institution_admin/FindPersonPanel.tsx
+++ b/src/pages/basic_data/institution_admin/FindPersonPanel.tsx
@@ -88,11 +88,11 @@ export const FindPersonPanel = () => {
                       disabled={isSubmitting || confirmedIdentity}
                       required={!confirmedIdentity}
                       fullWidth
-                      inputProps={{ maxLength: 11 }}
                       variant="filled"
                       label={t('common.national_id_number')}
                       error={touched && !!error}
                       helperText={<ErrorMessage name={field.name} />}
+                      slotProps={{ htmlInput: { maxLength: 11 } }}
                     />
                   )}
                 </Field>

--- a/src/pages/basic_data/institution_admin/FindPersonPanel.tsx
+++ b/src/pages/basic_data/institution_admin/FindPersonPanel.tsx
@@ -139,7 +139,7 @@ export const FindPersonPanel = () => {
                   <Trans
                     t={t}
                     i18nKey="basic_data.add_employee.missing_nin_description"
-                    components={[<Typography paragraph key="1" />]}
+                    components={[<Typography sx={{ mb: '1rem' }} key="1" />]}
                   />
                 </ConfirmDialog>
               </>

--- a/src/pages/basic_data/institution_admin/edit_user/AffiliationFormSection.tsx
+++ b/src/pages/basic_data/institution_admin/edit_user/AffiliationFormSection.tsx
@@ -67,12 +67,12 @@ export const AffiliationFormSection = () => {
                   disabled={isSubmitting}
                   fullWidth
                   type="number"
-                  inputProps={{ min: '0', max: '100' }}
                   variant="filled"
                   label={t('basic_data.add_employee.position_percent')}
                   error={touched && !!error}
                   helperText={touched && error}
                   data-testid={dataTestId.basicData.personAdmin.positionPercent}
+                  slotProps={{ htmlInput: { min: '0', max: '100' } }}
                 />
               )}
             </Field>

--- a/src/pages/basic_data/institution_admin/person_register/PersonRegisterPage.tsx
+++ b/src/pages/basic_data/institution_admin/person_register/PersonRegisterPage.tsx
@@ -68,15 +68,17 @@ export const PersonRegisterPage = () => {
         value={searchQuery}
         onChange={(event) => setSearchQuery(event.target.value)}
         label={t('common.search_by_name')}
-        InputLabelProps={{ id: 'search-by-name-label' }}
         fullWidth
         sx={{ mb: '1rem', maxWidth: '25rem' }}
-        InputProps={{
-          endAdornment: employeeSearchQuery.isFetching && (
-            <InputAdornment position="end">
-              <CircularProgress size={20} aria-labelledby="search-by-name-label" />
-            </InputAdornment>
-          ),
+        slotProps={{
+          input: {
+            endAdornment: employeeSearchQuery.isFetching && (
+              <InputAdornment position="end">
+                <CircularProgress size={20} aria-labelledby="search-by-name-label" />
+              </InputAdornment>
+            ),
+          },
+          inputLabel: { id: 'search-by-name-label' },
         }}
       />
 

--- a/src/pages/editor/EditorDoi.tsx
+++ b/src/pages/editor/EditorDoi.tsx
@@ -21,13 +21,13 @@ export const EditorDoi = () => {
       ) : (
         <>
           {!customer.doiAgent.username ? (
-            <Typography paragraph fontWeight="bold">
+            <Typography sx={{ mb: '1rem' }} fontWeight="bold">
               <Trans t={t} i18nKey="editor.doi.institution_cannot_create_doi">
                 <MuiLink href={'mailto:kontakt@sikt.no'} target="_blank" rel="noopener noreferrer" />
               </Trans>
             </Typography>
           ) : (
-            <Typography paragraph fontWeight="bold">
+            <Typography sx={{ mb: '1rem' }} fontWeight="bold">
               {t('editor.doi.institution_can_create_doi')}
             </Typography>
           )}

--- a/src/pages/editor/InstitutionSupport.tsx
+++ b/src/pages/editor/InstitutionSupport.tsx
@@ -55,12 +55,14 @@ export const InstitutionSupport = () => {
                     label={t('common.url')}
                     placeholder={t('editor.retention_strategy.rrs_link')}
                     variant="filled"
-                    InputProps={{
-                      startAdornment: (
-                        <InputAdornment position="start">
-                          <LinkIcon />
-                        </InputAdornment>
-                      ),
+                    slotProps={{
+                      input: {
+                        startAdornment: (
+                          <InputAdornment position="start">
+                            <LinkIcon />
+                          </InputAdornment>
+                        ),
+                      },
                     }}
                   />
                 )}

--- a/src/pages/editor/InstitutionSupport.tsx
+++ b/src/pages/editor/InstitutionSupport.tsx
@@ -42,7 +42,7 @@ export const InstitutionSupport = () => {
               <Typography gutterBottom variant="h2">
                 {t('editor.institution.institution_support')}
               </Typography>
-              <Typography paragraph>{t('editor.institution.institution_support_description')}</Typography>
+              <Typography sx={{ mb: '1rem' }}>{t('editor.institution.institution_support_description')}</Typography>
 
               <Field name={'serviceCenter.uri'}>
                 {({ field }: FieldProps<string>) => (

--- a/src/pages/editor/RightsRetentionStrategySettings.tsx
+++ b/src/pages/editor/RightsRetentionStrategySettings.tsx
@@ -100,12 +100,14 @@ export const RightsRetentionStrategySettings = () => {
                         variant="filled"
                         fullWidth
                         disabled={isNullRrs || isSubmitting}
-                        InputProps={{
-                          startAdornment: (
-                            <InputAdornment position="start">
-                              <LinkIcon />
-                            </InputAdornment>
-                          ),
+                        slotProps={{
+                          input: {
+                            startAdornment: (
+                              <InputAdornment position="start">
+                                <LinkIcon />
+                              </InputAdornment>
+                            ),
+                          },
                         }}
                       />
                     </FormLabel>

--- a/src/pages/editor/VocabularySettings.tsx
+++ b/src/pages/editor/VocabularySettings.tsx
@@ -81,7 +81,7 @@ export const VocabularySettings = () => {
       <Helmet>
         <title id="vocabulary-label">{t('editor.vocabulary')}</title>
       </Helmet>
-      <Typography paragraph color="primary" fontWeight="600">
+      <Typography sx={{ mb: '1rem' }} color="primary" fontWeight="600">
         {t('editor.select_vocabulary_description')}
       </Typography>
 

--- a/src/pages/editor/curators/OrganizationCurators.tsx
+++ b/src/pages/editor/curators/OrganizationCurators.tsx
@@ -76,13 +76,15 @@ export const OrganizationCurators = ({ heading, canEditUsers = false }: Organiza
             <TextField
               select
               sx={{ width: '9rem', '.MuiSelect-select': { display: 'flex', gap: '0.5rem' } }}
-              SelectProps={{ sx: { bgcolor: 'registration.main' } }}
               size="small"
               value={searchType}
-              inputProps={{ 'aria-label': t('common.type') }}
               onChange={(event) => {
                 setSearchType(event.target.value as unknown as SearchTypeValue);
                 setSearchValue('');
+              }}
+              slotProps={{
+                htmlInput: { 'aria-label': t('common.type') },
+                select: { sx: { bgcolor: 'registration.main' } },
               }}>
               <MenuItem value={SearchTypeValue.Unit} sx={{ display: 'flex', gap: '0.5rem' }}>
                 <AccountBalanceIcon fontSize="small" />

--- a/src/pages/errorpages/Forbidden.tsx
+++ b/src/pages/errorpages/Forbidden.tsx
@@ -8,10 +8,10 @@ export const Forbidden = () => {
 
   return (
     <Box data-testid="forbidden" sx={{ mt: '4rem' }}>
-      <Typography variant="h2" component="h1" paragraph>
+      <Typography variant="h2" component="h1" sx={{ mb: '1rem' }}>
         {t('authorization.forbidden')}
       </Typography>
-      <Typography paragraph>{t('authorization.forbidden_description')}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{t('authorization.forbidden_description')}</Typography>
       <MuiLink component={Link} to={UrlPathTemplate.Home}>
         <Typography>{t('authorization.back_to_home')}</Typography>
       </MuiLink>

--- a/src/pages/errorpages/NotPublished.tsx
+++ b/src/pages/errorpages/NotPublished.tsx
@@ -8,7 +8,7 @@ export const NotPublished = () => {
 
   return (
     <Box data-testid="not_published" sx={{ mt: '4rem' }}>
-      <Typography variant="h2" component="h1" paragraph>
+      <Typography variant="h2" component="h1" sx={{ mb: '1rem' }}>
         {t('authorization.registration_not_published')}
       </Typography>
       <MuiLink component={Link} to={UrlPathTemplate.Home}>

--- a/src/pages/infopages/AboutContent.tsx
+++ b/src/pages/infopages/AboutContent.tsx
@@ -12,11 +12,11 @@ export const AboutContent = () => {
         <Typography component="li">{t('about.description.paragraph0.bullet_point1')}</Typography>
       </ul>
 
-      <Typography paragraph>{t('about.description.paragraph1')}</Typography>
-      <Typography paragraph>{t('about.description.paragraph2')}</Typography>
-      <Typography paragraph>{t('about.description.paragraph3')}</Typography>
-      <Typography paragraph>{t('about.description.paragraph4')}</Typography>
-      <Typography paragraph>
+      <Typography sx={{ mb: '1rem' }}>{t('about.description.paragraph1')}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{t('about.description.paragraph2')}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{t('about.description.paragraph3')}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{t('about.description.paragraph4')}</Typography>
+      <Typography sx={{ mb: '1rem' }}>
         <Trans t={t} i18nKey="about.description.paragraph5">
           <MuiLink href={'mailto:kontakt@sikt.no'} target="_blank" rel="noopener noreferrer">
             (i18n content: support email)

--- a/src/pages/infopages/PrivacyPolicy.tsx
+++ b/src/pages/infopages/PrivacyPolicy.tsx
@@ -11,20 +11,12 @@ const PrivacyPolicy = () => {
     <StyledPageContent>
       <PageHeader>{t('privacy.privacy_statement')}</PageHeader>
 
-      <Box
-        sx={{
-          table: {
-            mt: '0.5rem',
-          },
-          ul: {
-            marginTop: '0',
-          },
-        }}>
+      <Box sx={{ table: { mt: '0.5rem' }, ul: { marginTop: '0' } }}>
         <Typography variant="h2">{t('privacy.about.heading')}</Typography>
-        <Typography paragraph>{t('privacy.about.paragraph')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.about.paragraph')}</Typography>
 
         <Typography variant="h2">{t('privacy.what_are_personal_data.heading')}</Typography>
-        <Typography paragraph>
+        <Typography sx={{ mb: '1rem' }}>
           <Trans t={t} i18nKey="privacy.what_are_personal_data.paragraph">
             <a target="_blank" rel="noreferrer" href="https://lovdata.no/lov/2018-06-15-38/§2">
               (i18n content: Personal Data Act Section 2)
@@ -36,9 +28,9 @@ const PrivacyPolicy = () => {
         </Typography>
 
         <Typography variant="h2">{t('privacy.service_in_brief.heading')}</Typography>
-        <Typography paragraph>{t('privacy.service_in_brief.paragraph0')}</Typography>
-        <Typography paragraph>{t('privacy.service_in_brief.paragraph1')}</Typography>
-        <Typography paragraph>{t('privacy.service_in_brief.paragraph2')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.service_in_brief.paragraph0')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.service_in_brief.paragraph1')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.service_in_brief.paragraph2')}</Typography>
 
         <Typography variant="h2">{t('privacy.purpose.heading')}</Typography>
         <Typography>{t('privacy.purpose.paragraph')}</Typography>
@@ -65,22 +57,22 @@ const PrivacyPolicy = () => {
         </TableContainer>
 
         <Typography variant="h2">{t('privacy.registered_personal_data.heading')}</Typography>
-        <Typography paragraph>
+        <Typography sx={{ mb: '1rem' }}>
           <Trans t={t} i18nKey="privacy.registered_personal_data.paragraph0">
             <a target="_blank" rel="noreferrer" href="https://lovdata.no/lov/2018-06-15-38/gdpr/a6">
               (i18n content: GDPR Article 6)
             </a>
           </Trans>
         </Typography>
-        <Typography paragraph>
+        <Typography sx={{ mb: '1rem' }}>
           <Trans t={t} i18nKey="privacy.registered_personal_data.paragraph1">
             <a target="_blank" rel="noreferrer" href="https://lovdata.no/lov/2018-06-15-38/gdpr/a6">
               (i18n content: GDPR Article 6)
             </a>
           </Trans>
         </Typography>
-        <Typography paragraph>{t('privacy.registered_personal_data.paragraph2')}</Typography>
-        <Typography paragraph>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.registered_personal_data.paragraph2')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>
           <Trans t={t} i18nKey="privacy.registered_personal_data.paragraph3">
             <a target="_blank" rel="noreferrer" href="https://lovdata.no/lov/2018-06-15-38/§8">
               (i18n content: Personal Data Act Section 8)
@@ -90,7 +82,7 @@ const PrivacyPolicy = () => {
             </a>
           </Trans>
         </Typography>
-        <Typography paragraph>{t('privacy.registered_personal_data.paragraph4')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.registered_personal_data.paragraph4')}</Typography>
 
         <Typography variant="h3">{t('privacy.registered_personal_data.table.user_data.heading')}</Typography>
         <TableContainer sx={{ mb: '2rem' }}>
@@ -177,7 +169,7 @@ const PrivacyPolicy = () => {
           </Table>
         </TableContainer>
 
-        <Typography paragraph>{t('privacy.registered_personal_data.paragraph5')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.registered_personal_data.paragraph5')}</Typography>
         <Typography>{t('privacy.registered_personal_data.paragraph6.intro')}</Typography>
         <ul>
           {[...Array(3)].map((_, index) => (
@@ -186,17 +178,17 @@ const PrivacyPolicy = () => {
             </Typography>
           ))}
         </ul>
-        <Typography paragraph>{t('privacy.registered_personal_data.paragraph7')}</Typography>
-        <Typography paragraph>{t('privacy.registered_personal_data.paragraph8')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.registered_personal_data.paragraph7')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.registered_personal_data.paragraph8')}</Typography>
 
         <Typography variant="h2">{t('privacy.automatic_case_processing.heading')}</Typography>
-        <Typography paragraph>{t('privacy.automatic_case_processing.paragraph0')}</Typography>
-        <Typography paragraph>{t('privacy.automatic_case_processing.paragraph1')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.automatic_case_processing.paragraph0')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.automatic_case_processing.paragraph1')}</Typography>
 
         <Typography variant="h2">{t('privacy.disclosure_of_data.heading')}</Typography>
-        <Typography paragraph>{t('privacy.disclosure_of_data.paragraph0')}</Typography>
-        <Typography paragraph>{t('privacy.disclosure_of_data.paragraph1')}</Typography>
-        <Typography paragraph>{t('privacy.disclosure_of_data.paragraph2')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.disclosure_of_data.paragraph0')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.disclosure_of_data.paragraph1')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.disclosure_of_data.paragraph2')}</Typography>
         <Typography>{t('privacy.disclosure_of_data.paragraph3.intro')}</Typography>
         <TableContainer sx={{ mb: '2rem' }}>
           <Table size="small">
@@ -217,8 +209,8 @@ const PrivacyPolicy = () => {
             </TableBody>
           </Table>
         </TableContainer>
-        <Typography paragraph>{t('privacy.disclosure_of_data.paragraph4')}</Typography>
-        <Typography paragraph>{t('privacy.disclosure_of_data.paragraph5')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.disclosure_of_data.paragraph4')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.disclosure_of_data.paragraph5')}</Typography>
         <Typography>{t('privacy.disclosure_of_data.paragraph6.intro')}</Typography>
         <TableContainer sx={{ mb: '2rem' }}>
           <Table size="small">
@@ -243,17 +235,17 @@ const PrivacyPolicy = () => {
         </TableContainer>
 
         <Typography variant="h2">{t('privacy.security_for_personal_data.heading')}</Typography>
-        <Typography paragraph>{t('privacy.security_for_personal_data.paragraph0')}</Typography>
-        <Typography paragraph>{t('privacy.security_for_personal_data.paragraph1')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.security_for_personal_data.paragraph0')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.security_for_personal_data.paragraph1')}</Typography>
 
         <Typography variant="h2">{t('privacy.your_rights.heading')}</Typography>
         <Typography variant="h3">{t('privacy.your_rights.section0.heading')}</Typography>
-        <Typography paragraph>{t('privacy.your_rights.section0.paragraph0')}</Typography>
-        <Typography paragraph>{t('privacy.your_rights.section0.paragraph1')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.your_rights.section0.paragraph0')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.your_rights.section0.paragraph1')}</Typography>
 
         <Typography variant="h3">{t('privacy.your_rights.section1.heading')}</Typography>
-        <Typography paragraph>{t('privacy.your_rights.section1.paragraph0')}</Typography>
-        <Typography paragraph>{t('privacy.your_rights.section1.paragraph1')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.your_rights.section1.paragraph0')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.your_rights.section1.paragraph1')}</Typography>
 
         <Typography variant="h3">{t('privacy.your_rights.section2.heading')}</Typography>
         <Typography>
@@ -268,12 +260,12 @@ const PrivacyPolicy = () => {
           <Typography component="li">{t('privacy.your_rights.section2.paragraph0.bullet_point1')}</Typography>
           <Typography component="li">{t('privacy.your_rights.section2.paragraph0.bullet_point2')}</Typography>
         </ul>
-        <Typography paragraph>{t('privacy.your_rights.section2.paragraph1')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.your_rights.section2.paragraph1')}</Typography>
 
         <Typography variant="h3">{t('privacy.your_rights.section3.heading')}</Typography>
-        <Typography paragraph>{t('privacy.your_rights.section3.paragraph0')}</Typography>
-        <Typography paragraph>{t('privacy.your_rights.section3.paragraph1')}</Typography>
-        <Typography paragraph>{t('privacy.your_rights.section3.paragraph2')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.your_rights.section3.paragraph0')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.your_rights.section3.paragraph1')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.your_rights.section3.paragraph2')}</Typography>
 
         <Typography variant="h3">{t('privacy.your_rights.section4.heading')}</Typography>
         <Typography>
@@ -288,7 +280,7 @@ const PrivacyPolicy = () => {
           <Typography component="li">{t('privacy.your_rights.section4.paragraph0.bullet_point1')}</Typography>
           <Typography component="li">{t('privacy.your_rights.section4.paragraph0.bullet_point2')}</Typography>
         </ul>
-        <Typography paragraph>{t('privacy.your_rights.section4.paragraph1')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.your_rights.section4.paragraph1')}</Typography>
         <Typography>{t('privacy.your_rights.section4.paragraph2.intro')}</Typography>
         <ul>
           <Typography component="li">{t('privacy.your_rights.section4.paragraph2.bullet_point0')}</Typography>
@@ -296,14 +288,14 @@ const PrivacyPolicy = () => {
         </ul>
 
         <Typography variant="h3">{t('privacy.your_rights.section5.heading')}</Typography>
-        <Typography paragraph>{t('privacy.your_rights.section5.paragraph0')}</Typography>
-        <Typography paragraph>{t('privacy.your_rights.section5.paragraph1')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.your_rights.section5.paragraph0')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.your_rights.section5.paragraph1')}</Typography>
 
         <Typography variant="h2">{t('privacy.contact.heading')}</Typography>
         <Typography variant="h3">{t('privacy.contact.section0.heading')}</Typography>
-        <Typography paragraph>{t('privacy.contact.section0.paragraph')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.contact.section0.paragraph')}</Typography>
         <Typography variant="h3">{t('privacy.contact.section1.heading')}</Typography>
-        <Typography paragraph>{t('privacy.contact.section1.paragraph')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('privacy.contact.section1.paragraph')}</Typography>
 
         <Typography>{t('privacy.contact.section2.intro')}</Typography>
         <Typography>

--- a/src/pages/infopages/SignedOutPage.tsx
+++ b/src/pages/infopages/SignedOutPage.tsx
@@ -23,7 +23,7 @@ const SignedOutPage = () => {
       <Typography variant="h1" gutterBottom>
         {t('authorization.signed_out')}
       </Typography>
-      <Typography paragraph>{t('authorization.expired_token_info')}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{t('authorization.expired_token_info')}</Typography>
 
       <Box sx={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
         <Button

--- a/src/pages/messages/components/NviCandidateActions.tsx
+++ b/src/pages/messages/components/NviCandidateActions.tsx
@@ -162,7 +162,7 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
           <>
             <Trans
               i18nKey="tasks.nvi.approve_nvi_candidate_description"
-              components={[<Typography paragraph key="1" />]}
+              components={[<Typography sx={{ mb: '1rem' }} key="1" />]}
               values={{ buttonText: t('tasks.nvi.approve_nvi_candidate') }}
             />
             <LoadingButton
@@ -182,7 +182,7 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
 
         {myApproval?.status !== 'Rejected' && (
           <>
-            <Typography paragraph>
+            <Typography sx={{ mb: '1rem' }}>
               {t('tasks.nvi.reject_nvi_candidate_description', { buttonText: t('tasks.nvi.reject_nvi_candidate') })}
             </Typography>
             <Button
@@ -214,7 +214,7 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
         <Typography variant="h3" gutterBottom component="h2">
           {t('tasks.nvi.note')}
         </Typography>
-        <Typography paragraph>{t('tasks.nvi.message_description')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('tasks.nvi.message_description')}</Typography>
         <MessageForm
           hideRequiredAsterisk
           confirmAction={async (text) => await createNoteMutation.mutateAsync({ text })}

--- a/src/pages/messages/components/NviCandidateRejectionDialog.tsx
+++ b/src/pages/messages/components/NviCandidateRejectionDialog.tsx
@@ -43,7 +43,6 @@ export const NviCandidateRejectionDialog = ({
             value={reason}
             onChange={(event) => setReason(event.target.value)}
             data-testid={dataTestId.tasksPage.nvi.rejectionModalTextField}
-            inputProps={{ minLength: minReasonLength, maxLength: maxReasonLength }}
             variant="filled"
             multiline
             minRows={3}
@@ -51,7 +50,10 @@ export const NviCandidateRejectionDialog = ({
             required
             label={t('tasks.nvi.reject_nvi_candidate_form_label')}
             helperText={`${reason.length}/${maxReasonLength}`}
-            FormHelperTextProps={{ sx: { textAlign: 'end' } }}
+            slotProps={{
+              htmlInput: { minLength: minReasonLength, maxLength: maxReasonLength },
+              formHelperText: { sx: { textAlign: 'end' } },
+            }}
           />
         </DialogContent>
 

--- a/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
+++ b/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
@@ -166,12 +166,11 @@ export const MyFieldAndBackground = () => {
                       slotProps={{
                         listbox: {
                           component: AutocompleteListboxWithExpansion,
-
                           ...({
                             hasMoreHits: !!keywordsQuery.data?.size && keywordsQuery.data.size > searchSize,
                             onShowMoreHits: () => setSearchSize(searchSize + defaultOrganizationSearchSize),
                             isLoadingMoreHits: keywordsQuery.isFetching && searchSize > keywordsResult.length,
-                          } satisfies AutocompleteListboxWithExpansionProps as any),
+                          } satisfies AutocompleteListboxWithExpansionProps),
                         },
                       }}
                     />

--- a/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
+++ b/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
@@ -115,7 +115,7 @@ export const MyFieldAndBackground = () => {
                 <Typography variant="h3" gutterBottom>
                   {t('my_page.my_profile.field_and_background.field')}
                 </Typography>
-                <Typography paragraph>{t('my_page.my_profile.field_and_background.field_text')}</Typography>
+                <Typography sx={{ mb: '1rem' }}>{t('my_page.my_profile.field_and_background.field_text')}</Typography>
                 <Field name={'keywords'}>
                   {({ field }: FieldProps<Keywords[]>) => (
                     <Autocomplete

--- a/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
+++ b/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
@@ -134,14 +134,6 @@ export const MyFieldAndBackground = () => {
                           <Typography>{getLanguageString(option.labels)}</Typography>
                         </li>
                       )}
-                      ListboxComponent={AutocompleteListboxWithExpansion}
-                      ListboxProps={
-                        {
-                          hasMoreHits: !!keywordsQuery.data?.size && keywordsQuery.data.size > searchSize,
-                          onShowMoreHits: () => setSearchSize(searchSize + defaultOrganizationSearchSize),
-                          isLoadingMoreHits: keywordsQuery.isFetching && searchSize > keywordsResult.length,
-                        } satisfies AutocompleteListboxWithExpansionProps as any
-                      }
                       renderTags={(value, getTagProps) =>
                         value.map((option, index) => (
                           <Chip
@@ -171,6 +163,17 @@ export const MyFieldAndBackground = () => {
                           showSearchIcon={field.value.length === 0}
                         />
                       )}
+                      slotProps={{
+                        listbox: {
+                          component: AutocompleteListboxWithExpansion,
+
+                          ...({
+                            hasMoreHits: !!keywordsQuery.data?.size && keywordsQuery.data.size > searchSize,
+                            onShowMoreHits: () => setSearchSize(searchSize + defaultOrganizationSearchSize),
+                            isLoadingMoreHits: keywordsQuery.isFetching && searchSize > keywordsResult.length,
+                          } satisfies AutocompleteListboxWithExpansionProps as any),
+                        },
+                      }}
                     />
                   )}
                 </Field>
@@ -190,15 +193,17 @@ export const MyFieldAndBackground = () => {
                   {({ field }: FieldProps<string>) => (
                     <TextField
                       {...field}
-                      inputProps={{ maxLength: maxMessageLength }}
                       label={t('my_page.my_profile.background_no')}
                       variant="filled"
                       multiline
                       rows="3"
                       placeholder={t('my_page.my_profile.field_and_background.background_placeholder')}
                       helperText={`${field.value.length}/${maxMessageLength}`}
-                      FormHelperTextProps={{ sx: { textAlign: 'end' } }}
                       sx={{ my: '1rem' }}
+                      slotProps={{
+                        htmlInput: { maxLength: maxMessageLength },
+                        formHelperText: { sx: { textAlign: 'end' } },
+                      }}
                     />
                   )}
                 </Field>
@@ -206,14 +211,16 @@ export const MyFieldAndBackground = () => {
                   {({ field }: FieldProps<string>) => (
                     <TextField
                       {...field}
-                      inputProps={{ maxLength: maxMessageLength }}
                       label={t('my_page.my_profile.background_en')}
                       variant="filled"
                       multiline
                       rows="3"
                       placeholder={t('my_page.my_profile.field_and_background.background_placeholder')}
                       helperText={`${field.value.length}/${maxMessageLength}`}
-                      FormHelperTextProps={{ sx: { textAlign: 'end' } }}
+                      slotProps={{
+                        htmlInput: { maxLength: maxMessageLength },
+                        formHelperText: { sx: { textAlign: 'end' } },
+                      }}
                     />
                   )}
                 </Field>

--- a/src/pages/my_page/user_profile/UserOrcidHelperModal.tsx
+++ b/src/pages/my_page/user_profile/UserOrcidHelperModal.tsx
@@ -22,8 +22,12 @@ export const UserOrcidHelperModal = () => {
         </Button>
         <Collapse in={showMore}>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem', my: '0.5rem' }}>
-            <Typography paragraph>{t('my_page.my_profile.orcid.helper_text_modal.detailed_paragraph_1')}</Typography>
-            <Typography paragraph>{t('my_page.my_profile.orcid.helper_text_modal.detailed_paragraph_2')}</Typography>
+            <Typography sx={{ mb: '1rem' }}>
+              {t('my_page.my_profile.orcid.helper_text_modal.detailed_paragraph_1')}
+            </Typography>
+            <Typography sx={{ mb: '1rem' }}>
+              {t('my_page.my_profile.orcid.helper_text_modal.detailed_paragraph_2')}
+            </Typography>
 
             <Link
               sx={{

--- a/src/pages/project/project_wizard/EmptyProjectForm.tsx
+++ b/src/pages/project/project_wizard/EmptyProjectForm.tsx
@@ -43,18 +43,20 @@ export const EmptyProjectForm = ({ newProject, setNewProject, setShowProjectForm
           data-testid={dataTestId.newProjectPage.titleInput}
           variant="filled"
           onChange={(event) => setTitle(event.target.value)}
-          InputProps={{
-            endAdornment: titleSearch.isPending ? (
-              <CircularProgress size={20} />
-            ) : titleSearch.duplicateProject ? (
-              <ErrorIcon color="warning" />
-            ) : debouncedTitle && !titleSearch.duplicateProject ? (
-              <CheckCircleIcon color="success" />
-            ) : undefined,
-          }}
           fullWidth
           placeholder={t('project.form.write_project_title')}
           label={t('common.title')}
+          slotProps={{
+            input: {
+              endAdornment: titleSearch.isPending ? (
+                <CircularProgress size={20} />
+              ) : titleSearch.duplicateProject ? (
+                <ErrorIcon color="warning" />
+              ) : debouncedTitle && !titleSearch.duplicateProject ? (
+                <CheckCircleIcon color="success" />
+              ) : undefined,
+            },
+          }}
         />
         {titleSearch.duplicateProject && (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>

--- a/src/pages/project/project_wizard/ProjectDescriptionForm.tsx
+++ b/src/pages/project/project_wizard/ProjectDescriptionForm.tsx
@@ -36,18 +36,20 @@ export const ProjectDescriptionForm = ({ thisIsRekProject }: ProjectDescriptionF
                 data-testid={dataTestId.projectWizard.descriptionPanel.titleField}
                 label={t('common.title')}
                 disabled={thisIsRekProject}
-                InputProps={{
-                  endAdornment: duplicateProjectSearch.isPending ? (
-                    <CircularProgress size={20} />
-                  ) : duplicateProjectSearch.duplicateProject ? (
-                    <ErrorIcon color="warning" />
-                  ) : undefined,
-                }}
                 required
                 variant="filled"
                 fullWidth
                 error={touched && !!error}
                 helperText={<ErrorMessage name={field.name} />}
+                slotProps={{
+                  input: {
+                    endAdornment: duplicateProjectSearch.isPending ? (
+                      <CircularProgress size={20} />
+                    ) : duplicateProjectSearch.duplicateProject ? (
+                      <ErrorIcon color="warning" />
+                    ) : undefined,
+                  },
+                }}
               />
             )}
           </Field>

--- a/src/pages/projects/ProjectAddAffiliationModal.tsx
+++ b/src/pages/projects/ProjectAddAffiliationModal.tsx
@@ -60,7 +60,7 @@ export const ProjectAddAffiliationModal = ({
       dataTestId="affiliation-modal">
       <Trans
         i18nKey="project.affiliation_modal.add_new_affiliation_helper_text"
-        components={[<Typography paragraph key="1" />]}
+        components={[<Typography sx={{ mb: '1rem' }} key="1" />]}
       />
       {authorName && <AuthorName authorName={authorName} description={t('project.project_participant')} />}
       <SelectInstitutionForm saveAffiliation={onAddAffiliation} onCancel={toggleAffiliationModal} />

--- a/src/pages/projects/ProjectEditAffiliationModal.tsx
+++ b/src/pages/projects/ProjectEditAffiliationModal.tsx
@@ -75,7 +75,7 @@ export const ProjectEditAffiliationModal = ({
       headingText={t('project.affiliation_modal.edit_affiliation')}>
       <Trans
         i18nKey="project.affiliation_modal.add_new_affiliation_helper_text"
-        components={[<Typography key="1" paragraph />]}
+        components={[<Typography key="1" sx={{ mb: '1rem' }} />]}
       />
       {authorName && <AuthorName authorName={authorName} description={t('project.project_participant')} />}
       {institutionQuery.isPending ? (

--- a/src/pages/projects/ProjectSummary.tsx
+++ b/src/pages/projects/ProjectSummary.tsx
@@ -21,7 +21,7 @@ export const ProjectSummary = ({ academicSummary, popularScienceSummary }: Proje
       {academicSummaryString && (
         <>
           <Typography variant="h3">{t('project.scientific_summary')}</Typography>
-          <Typography paragraph>{academicSummaryString}</Typography>
+          <Typography sx={{ mb: '1rem' }}>{academicSummaryString}</Typography>
         </>
       )}
       {popularScienceSummaryString && (

--- a/src/pages/public_registration/PublicPublicationContext.tsx
+++ b/src/pages/public_registration/PublicPublicationContext.tsx
@@ -391,15 +391,17 @@ const PublicExhibitionBasicDialogContent = ({ exhibitionBasic }: { exhibitionBas
       <Typography variant="h3" gutterBottom>
         {t('common.type')}
       </Typography>
-      <Typography paragraph>{t(`registration.resource_type.artistic.output_type.${exhibitionBasic.type}`)}</Typography>
+      <Typography sx={{ mb: '1rem' }}>
+        {t(`registration.resource_type.artistic.output_type.${exhibitionBasic.type}`)}
+      </Typography>
       <Typography variant="h3" gutterBottom>
         {t('registration.resource_type.exhibition_production.institution_name')}
       </Typography>
-      <Typography paragraph>{exhibitionBasic.organization.name || '-'}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{exhibitionBasic.organization.name || '-'}</Typography>
       <Typography variant="h3" gutterBottom>
         {t('common.place')}
       </Typography>
-      <Typography paragraph>{exhibitionBasic.place?.name || '-'}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{exhibitionBasic.place?.name || '-'}</Typography>
       <Typography variant="h3" gutterBottom>
         {t('common.date')}
       </Typography>
@@ -413,7 +415,7 @@ const PublicVenueDialogContent = ({ venue }: { venue: Venue }) => {
   return (
     <DialogContent>
       <Typography variant="h3">{t('common.place')}</Typography>
-      <Typography paragraph>{venue.place?.name ?? ''}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{venue.place?.name ?? ''}</Typography>
       <Typography variant="h3">{t('common.date')}</Typography>
       <Typography>{getPeriodString(venue.date?.from, venue.date?.to)}</Typography>
     </DialogContent>
@@ -425,9 +427,9 @@ const PublicCompetitionDialogContent = ({ competition }: { competition: Competit
   return (
     <DialogContent>
       <Typography variant="h3">{t('registration.resource_type.artistic.competition_name')}</Typography>
-      <Typography paragraph>{competition.name}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{competition.name}</Typography>
       <Typography variant="h3">{t('registration.resource_type.artistic.competition_rank')}</Typography>
-      <Typography paragraph>{competition.description}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{competition.description}</Typography>
       <Typography variant="h3">{t('common.date')}</Typography>
       <Typography>{toDateString(competition.date.value)}</Typography>
     </DialogContent>
@@ -439,15 +441,15 @@ const PublicAwardDialogContent = ({ award }: { award: Award }) => {
   return (
     <DialogContent>
       <Typography variant="h3">{t('registration.resource_type.artistic.competition_name')}</Typography>
-      <Typography paragraph>{award.name}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{award.name}</Typography>
       <Typography variant="h3">{t('registration.resource_type.artistic.award_organizer')}</Typography>
-      <Typography paragraph>{award.organizer}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{award.organizer}</Typography>
       <Typography variant="h3">{t('common.year')}</Typography>
       <Typography>{new Date(award.date.value).getFullYear()}</Typography>
       <Typography variant="h3">{t('registration.resource_type.artistic.award_ranking')}</Typography>
-      <Typography paragraph>{award.ranking}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{award.ranking}</Typography>
       <Typography variant="h3">{t('registration.resource_type.artistic.award_other_type')}</Typography>
-      <Typography paragraph>{award.otherInformation}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{award.otherInformation}</Typography>
     </DialogContent>
   );
 };
@@ -457,13 +459,13 @@ const PublicMentionDialogContent = ({ mention }: { mention: MentionInPublication
   return (
     <DialogContent>
       <Typography variant="h3">{t('registration.resource_type.journal_book_medium')}</Typography>
-      <Typography paragraph>{mention.title}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{mention.title}</Typography>
       <Typography variant="h3">{t('registration.resource_type.issue')}</Typography>
-      <Typography paragraph>{mention.issue}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{mention.issue}</Typography>
       <Typography variant="h3">{t('common.date')}</Typography>
       <Typography>{toDateString(mention.date.value)}</Typography>
       <Typography variant="h3">{t('registration.resource_type.other_publisher_isbn_etc')}</Typography>
-      <Typography paragraph>{mention.otherInformation}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{mention.otherInformation}</Typography>
     </DialogContent>
   );
 };
@@ -473,13 +475,13 @@ const PublicExhibitionDialogContent = ({ exhibition }: { exhibition: Exhibition 
   return (
     <DialogContent>
       <Typography variant="h3">{t('registration.resource_type.artistic.exhibition_title')}</Typography>
-      <Typography paragraph>{exhibition.name}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{exhibition.name}</Typography>
       <Typography variant="h3">{t('common.place')}</Typography>
-      <Typography paragraph>{exhibition.place?.name ?? ''}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{exhibition.place?.name ?? ''}</Typography>
       <Typography variant="h3">{t('registration.resource_type.organizer')}</Typography>
       <Typography>{exhibition.organizer}</Typography>
       <Typography variant="h3">{t('common.other')}</Typography>
-      <Typography paragraph>{exhibition.otherInformation}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{exhibition.otherInformation}</Typography>
     </DialogContent>
   );
 };
@@ -489,9 +491,11 @@ const PublicBroadcastDialogContent = ({ broadcast }: { broadcast: Broadcast }) =
   return (
     <DialogContent>
       <Typography variant="h3">{t('common.type')}</Typography>
-      <Typography paragraph>{t(`registration.resource_type.artistic.output_type.${broadcast.type}`)}</Typography>
+      <Typography sx={{ mb: '1rem' }}>
+        {t(`registration.resource_type.artistic.output_type.${broadcast.type}`)}
+      </Typography>
       <Typography variant="h3">{t('common.publisher')}</Typography>
-      <Typography paragraph>{broadcast.publisher.name}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{broadcast.publisher.name}</Typography>
       <Typography variant="h3">{t('common.date')}</Typography>
       <Typography>{toDateString(broadcast.date.value)}</Typography>
     </DialogContent>
@@ -503,9 +507,11 @@ const PublicCinematicReleaseDialogContent = ({ cinematicRelease }: { cinematicRe
   return (
     <DialogContent>
       <Typography variant="h3">{t('common.type')}</Typography>
-      <Typography paragraph>{t(`registration.resource_type.artistic.output_type.${cinematicRelease.type}`)}</Typography>
+      <Typography sx={{ mb: '1rem' }}>
+        {t(`registration.resource_type.artistic.output_type.${cinematicRelease.type}`)}
+      </Typography>
       <Typography variant="h3">{t('common.place')}</Typography>
-      <Typography paragraph>{cinematicRelease.place.name}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{cinematicRelease.place.name}</Typography>
       <Typography variant="h3">{t('registration.resource_type.artistic.premiere_date')}</Typography>
       <Typography>{toDateString(cinematicRelease.date.value)}</Typography>
     </DialogContent>
@@ -517,15 +523,15 @@ const PublicOtherReleaseDialogContent = ({ otherRelease }: { otherRelease: Other
   return (
     <DialogContent>
       <Typography variant="h3">{t('registration.resource_type.artistic.other_release_description')}</Typography>
-      <Typography paragraph>
+      <Typography sx={{ mb: '1rem' }}>
         {t(`registration.resource_type.artistic.output_type.${otherRelease.type}`)}: {otherRelease.description}
       </Typography>
       <Typography variant="h3">{t('common.place')}</Typography>
-      <Typography paragraph>{otherRelease.place.name}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{otherRelease.place.name}</Typography>
       {otherRelease.publisher.name && (
         <>
           <Typography variant="h3">{t('registration.resource_type.artistic.other_announcement_organizer')}</Typography>
-          <Typography paragraph>{otherRelease.publisher.name}</Typography>
+          <Typography sx={{ mb: '1rem' }}>{otherRelease.publisher.name}</Typography>
         </>
       )}
       <Typography variant="h3">{t('registration.resource_type.artistic.premiere_date')}</Typography>
@@ -541,17 +547,17 @@ const PublicMusicScoreDialogContent = ({ musicScore }: { musicScore: MusicScore 
   return (
     <DialogContent>
       <Typography variant="h3">{t('common.type')}</Typography>
-      <Typography paragraph>{t(`registration.resource_type.artistic.output_type.${type}`)}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{t(`registration.resource_type.artistic.output_type.${type}`)}</Typography>
       <Typography variant="h3">{t('registration.resource_type.artistic.music_score_ensemble')}</Typography>
-      <Typography paragraph>{ensemble}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{ensemble}</Typography>
       <Typography variant="h3">{t('registration.resource_type.artistic.music_score_movements')}</Typography>
-      <Typography paragraph>{movements}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{movements}</Typography>
       <Typography variant="h3">{t('registration.resource_type.artistic.extent')}</Typography>
-      <Typography paragraph>{extent}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{extent}</Typography>
       <Typography variant="h3">{t('common.publisher')}</Typography>
-      <Typography paragraph>{publisher.name}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{publisher.name}</Typography>
       <Typography variant="h3">{t('registration.resource_type.artistic.music_score_ismn')}</Typography>
-      <Typography paragraph>{ismn?.formatted ?? ismn?.value ?? '-'}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{ismn?.formatted ?? ismn?.value ?? '-'}</Typography>
     </DialogContent>
   );
 };
@@ -567,9 +573,9 @@ const PublicAudioVisualPublicationDialogContent = ({
   return (
     <DialogContent>
       <Typography variant="h3">{t('common.type')}</Typography>
-      <Typography paragraph>{t(`registration.resource_type.artistic.output_type.${type}`)}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{t(`registration.resource_type.artistic.output_type.${type}`)}</Typography>
       <Typography variant="h3">{t('registration.resource_type.artistic.media_type')}</Typography>
-      <Typography paragraph>
+      <Typography sx={{ mb: '1rem' }}>
         {mediaType.type
           ? mediaType.type !== 'MusicMediaOther'
             ? t(`registration.resource_type.artistic.music_media_type.${mediaType.type}`)
@@ -577,11 +583,11 @@ const PublicAudioVisualPublicationDialogContent = ({
           : ''}
       </Typography>
       <Typography variant="h3">{t('common.publisher')}</Typography>
-      <Typography paragraph>{publisher.name}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{publisher.name}</Typography>
       <Typography variant="h3">{t('registration.resource_type.artistic.catalogue_number')}</Typography>
-      <Typography paragraph>{catalogueNumber ? catalogueNumber : '-'}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{catalogueNumber ? catalogueNumber : '-'}</Typography>
       <Typography variant="h3">{t('registration.resource_type.artistic.music_score_isrc')}</Typography>
-      <Typography paragraph>{isrc?.value ? hyphenateIsrc(isrc?.value) : '-'}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{isrc?.value ? hyphenateIsrc(isrc?.value) : '-'}</Typography>
       <Typography variant="h3" id="tracks-heading">
         {t('registration.resource_type.artistic.content_track')}
       </Typography>
@@ -620,29 +626,29 @@ const PublicConcertDialogContent = ({ concert }: { concert: Concert }) => {
   return (
     <DialogContent>
       <Typography variant="h3">{t('common.type')}</Typography>
-      <Typography paragraph>{t(`registration.resource_type.artistic.output_type.${type}`)}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{t(`registration.resource_type.artistic.output_type.${type}`)}</Typography>
 
       <Typography variant="h3">{t('common.place')}</Typography>
-      <Typography paragraph>{place.name}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{place.name}</Typography>
 
       <Typography variant="h3">{t('registration.resource_type.artistic.concert_part_of_series')}</Typography>
-      <Typography paragraph>{concertSeries ? t('common.yes') : t('common.no')} </Typography>
+      <Typography sx={{ mb: '1rem' }}>{concertSeries ? t('common.yes') : t('common.no')} </Typography>
       {concertSeries && (
         <>
           <Typography variant="h3">{t('common.description')} </Typography>
-          <Typography paragraph>{concertSeries}</Typography>
+          <Typography sx={{ mb: '1rem' }}>{concertSeries}</Typography>
         </>
       )}
 
       <Typography variant="h3">{t('common.date')}</Typography>
       {time.type === 'Instant' ? (
-        <Typography paragraph>{toDateString(time.value)}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{toDateString(time.value)}</Typography>
       ) : (
-        <Typography paragraph>{getPeriodString(time.from, time.to)}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{getPeriodString(time.from, time.to)}</Typography>
       )}
 
       <Typography variant="h3">{t('registration.resource_type.artistic.extent_in_minutes')}</Typography>
-      <Typography paragraph>{extent}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{extent}</Typography>
 
       <Typography variant="h3" id="program-heading">
         {t('registration.resource_type.artistic.program')}
@@ -679,16 +685,16 @@ const PublicOtherPerformanceDialogContent = ({ otherPerformance }: { otherPerfor
   return (
     <DialogContent>
       <Typography variant="h3">{t('common.type')}</Typography>
-      <Typography paragraph>{t(`registration.resource_type.artistic.output_type.${type}`)}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{t(`registration.resource_type.artistic.output_type.${type}`)}</Typography>
 
       <Typography variant="h3">{t('registration.resource_type.artistic.performance_type')}</Typography>
-      <Typography paragraph>{performanceType}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{performanceType}</Typography>
 
       <Typography variant="h3">{t('common.place')}</Typography>
-      <Typography paragraph>{place?.name}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{place?.name}</Typography>
 
       <Typography variant="h3">{t('registration.resource_type.artistic.extent_in_minutes')}</Typography>
-      <Typography paragraph>{extent}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{extent}</Typography>
 
       <Typography variant="h3" id="works-heading">
         {t('registration.resource_type.artistic.musical_works')}
@@ -727,15 +733,15 @@ const PublicLiteraryArtsMonographDialogContent = ({
   return (
     <DialogContent>
       <Typography variant="h3">{t('common.type')}</Typography>
-      <Typography paragraph>
+      <Typography sx={{ mb: '1rem' }}>
         {t(`registration.resource_type.artistic.output_type.${literaryArtsMonograph.type}`)}
       </Typography>
       <Typography variant="h3">{t('registration.resource_type.artistic.publisher')}</Typography>
-      <Typography paragraph>{literaryArtsMonograph.publisher.name}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{literaryArtsMonograph.publisher.name}</Typography>
       <Typography variant="h3">{t('common.year')}</Typography>
-      <Typography paragraph>{literaryArtsMonograph.publicationDate.year}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{literaryArtsMonograph.publicationDate.year}</Typography>
       <Typography variant="h3">{t('registration.resource_type.isbn')}</Typography>
-      <Typography paragraph>
+      <Typography sx={{ mb: '1rem' }}>
         {literaryArtsMonograph.isbnList
           .filter((isbn) => isbn)
           .map((isbn) => hyphenate(isbn))
@@ -752,17 +758,19 @@ const PublicLiteraryArtsWebPublicationDialogContent = ({ webPublication }: { web
   return (
     <DialogContent>
       <Typography variant="h3">{t('common.type')}</Typography>
-      <Typography paragraph>{t(`registration.resource_type.artistic.output_type.${webPublication.type}`)}</Typography>
+      <Typography sx={{ mb: '1rem' }}>
+        {t(`registration.resource_type.artistic.output_type.${webPublication.type}`)}
+      </Typography>
       <Typography variant="h3">{t('registration.resource_type.artistic.web_link')}</Typography>
-      <Typography paragraph>
+      <Typography sx={{ mb: '1rem' }}>
         <Link href={webPublication.id} target="_blank" rel="noopener noreferrer">
           {webPublication.id}
         </Link>
       </Typography>
       <Typography variant="h3">{t('registration.resource_type.artistic.publisher')}</Typography>
-      <Typography paragraph>{webPublication.publisher.name}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{webPublication.publisher.name}</Typography>
       <Typography variant="h3">{t('common.year')}</Typography>
-      <Typography paragraph>{webPublication.publicationDate.year}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{webPublication.publicationDate.year}</Typography>
     </DialogContent>
   );
 };
@@ -772,9 +780,11 @@ const PublicLiteraryArtsPerformanceDialogContent = ({ performance }: { performan
   return (
     <DialogContent>
       <Typography variant="h3">{t('common.type')}</Typography>
-      <Typography paragraph>{t(`registration.resource_type.artistic.output_type.${performance.type}`)}</Typography>
+      <Typography sx={{ mb: '1rem' }}>
+        {t(`registration.resource_type.artistic.output_type.${performance.type}`)}
+      </Typography>
       <Typography variant="h3">{t('registration.resource_type.type_work')}</Typography>
-      <Typography paragraph>
+      <Typography sx={{ mb: '1rem' }}>
         {performance.subtype.type
           ? performance.subtype.type === LiteraryArtsPerformanceSubtype.Other
             ? performance.subtype.description
@@ -782,9 +792,9 @@ const PublicLiteraryArtsPerformanceDialogContent = ({ performance }: { performan
           : '-'}
       </Typography>
       <Typography variant="h3">{t('common.place')}</Typography>
-      <Typography paragraph>{performance.place.name}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{performance.place.name}</Typography>
       <Typography variant="h3">{t('common.date')}</Typography>
-      <Typography paragraph>
+      <Typography sx={{ mb: '1rem' }}>
         {toDateString(
           new Date(
             +performance.publicationDate.year,
@@ -802,9 +812,11 @@ const PublicLiteraryArtsAudioVisualDialogContent = ({ audioVisual }: { audioVisu
   return (
     <DialogContent>
       <Typography variant="h3">{t('common.type')}</Typography>
-      <Typography paragraph>{t(`registration.resource_type.artistic.output_type.${audioVisual.type}`)}</Typography>
+      <Typography sx={{ mb: '1rem' }}>
+        {t(`registration.resource_type.artistic.output_type.${audioVisual.type}`)}
+      </Typography>
       <Typography variant="h3">{t('registration.resource_type.type_work')}</Typography>
-      <Typography paragraph>
+      <Typography sx={{ mb: '1rem' }}>
         {audioVisual.subtype.type
           ? audioVisual.subtype.type === LiteraryArtsAudioVisualSubtype.Other
             ? audioVisual.subtype.description
@@ -812,18 +824,18 @@ const PublicLiteraryArtsAudioVisualDialogContent = ({ audioVisual }: { audioVisu
           : '-'}
       </Typography>
       <Typography variant="h3">{t('registration.resource_type.artistic.publisher')}</Typography>
-      <Typography paragraph>{audioVisual.publisher.name}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{audioVisual.publisher.name}</Typography>
       <Typography variant="h3">{t('common.year')}</Typography>
-      <Typography paragraph>{audioVisual.publicationDate.year ?? '-'}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{audioVisual.publicationDate.year ?? '-'}</Typography>
       <Typography variant="h3">{t('registration.resource_type.isbn')}</Typography>
-      <Typography paragraph>
+      <Typography sx={{ mb: '1rem' }}>
         {audioVisual.isbnList
           .filter((isbn) => isbn)
           .map((isbn) => hyphenate(isbn))
           .join(', ')}
       </Typography>
       <Typography variant="h3">{t('registration.resource_type.artistic.extent_in_minutes')}</Typography>
-      <Typography paragraph>{audioVisual.extent ?? '-'}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{audioVisual.extent ?? '-'}</Typography>
     </DialogContent>
   );
 };

--- a/src/pages/public_registration/PublicSummaryContent.tsx
+++ b/src/pages/public_registration/PublicSummaryContent.tsx
@@ -10,7 +10,7 @@ export const PublicSummaryContent = ({ registration }: PublicRegistrationContent
   return !entityDescription ? null : (
     <>
       {entityDescription.abstract && (
-        <Typography style={{ whiteSpace: 'pre-line', overflowWrap: 'anywhere' }} paragraph>
+        <Typography style={{ whiteSpace: 'pre-line', overflowWrap: 'anywhere' }} sx={{ mb: '1rem' }}>
           {entityDescription.abstract}
         </Typography>
       )}
@@ -19,7 +19,7 @@ export const PublicSummaryContent = ({ registration }: PublicRegistrationContent
           <Typography variant="h3" color="primary" gutterBottom>
             {t('registration.description.alternative_abstract')}
           </Typography>
-          <Typography style={{ whiteSpace: 'pre-line', overflowWrap: 'anywhere' }} paragraph>
+          <Typography style={{ whiteSpace: 'pre-line', overflowWrap: 'anywhere' }} sx={{ mb: '1rem' }}>
             {entityDescription.alternativeAbstracts.und}
           </Typography>
         </>
@@ -29,7 +29,7 @@ export const PublicSummaryContent = ({ registration }: PublicRegistrationContent
           <Typography variant="h3" color="primary" gutterBottom>
             {t('registration.description.description_of_content')}
           </Typography>
-          <Typography style={{ whiteSpace: 'pre-line', overflowWrap: 'anywhere' }} paragraph>
+          <Typography style={{ whiteSpace: 'pre-line', overflowWrap: 'anywhere' }} sx={{ mb: '1rem' }}>
             {entityDescription.description}
           </Typography>
         </>

--- a/src/pages/public_registration/action_accordions/DoiRequestAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/DoiRequestAccordion.tsx
@@ -226,7 +226,7 @@ export const DoiRequestAccordion = ({
           <Trans
             t={t}
             i18nKey="registration.public_page.tasks_panel.has_reserved_doi"
-            components={[<Typography paragraph key="1" />]}
+            components={[<Typography sx={{ mb: '1rem' }} key="1" />]}
           />
         )}
 
@@ -253,8 +253,8 @@ export const DoiRequestAccordion = ({
                   i18nKey="registration.public_page.tasks_panel.request_doi_description"
                   values={{ buttonText: t('registration.public_page.request_doi') }}
                   components={[
-                    <Typography paragraph key="1" />,
-                    <Typography paragraph key="2">
+                    <Typography sx={{ mb: '1rem' }} key="1" />,
+                    <Typography sx={{ mb: '1rem' }} key="2">
                       {doiLink}
                     </Typography>,
                   ]}
@@ -270,8 +270,8 @@ export const DoiRequestAccordion = ({
                   i18nKey="registration.public_page.tasks_panel.draft_doi_description"
                   values={{ buttonText: t('registration.public_page.reserve_doi') }}
                   components={[
-                    <Typography paragraph key="1" />,
-                    <Typography paragraph key="2">
+                    <Typography sx={{ mb: '1rem' }} key="1" />,
+                    <Typography sx={{ mb: '1rem' }} key="2">
                       {doiLink}
                     </Typography>,
                   ]}
@@ -297,7 +297,10 @@ export const DoiRequestAccordion = ({
                   <Trans
                     t={t}
                     i18nKey="registration.public_page.tasks_panel.reserve_doi_confirmation"
-                    components={[<Typography paragraph key="1" />, <Typography paragraph key="2" fontWeight={700} />]}
+                    components={[
+                      <Typography sx={{ mb: '1rem' }} key="1" />,
+                      <Typography sx={{ mb: '1rem' }} key="2" fontWeight={700} />,
+                    ]}
                   />
                 </ConfirmDialog>
               </>
@@ -313,7 +316,7 @@ export const DoiRequestAccordion = ({
           <Trans
             t={t}
             i18nKey="registration.public_page.request_doi_description"
-            components={[<Typography paragraph key="1" />]}
+            components={[<Typography sx={{ mb: '1rem' }} key="1" />]}
           />
           <TextField
             variant="outlined"
@@ -348,7 +351,7 @@ export const DoiRequestAccordion = ({
           <Trans
             t={t}
             i18nKey="registration.public_page.tasks_panel.no_published_files_on_registration_description"
-            components={[<Typography paragraph key="1" />]}
+            components={[<Typography sx={{ mb: '1rem' }} key="1" />]}
           />
         </ConfirmDialog>
 
@@ -379,7 +382,7 @@ export const DoiRequestAccordion = ({
               onCancel={toggleRejectDoiDialog}
               textFieldLabel={t('common.message')}
               confirmButtonLabel={t('common.reject_doi')}>
-              <Typography paragraph>
+              <Typography sx={{ mb: '1rem' }}>
                 {t('registration.public_page.tasks_panel.describe_doi_rejection_reason')}
               </Typography>
             </ConfirmMessageDialog>
@@ -430,7 +433,7 @@ export const DoiRequestAccordion = ({
                   <Typography variant="h2" gutterBottom>
                     {t('registration.public_page.request_doi')}
                   </Typography>
-                  <Typography paragraph>{t('registration.public_page.request_doi_again')}</Typography>
+                  <Typography sx={{ mb: '1rem' }}>{t('registration.public_page.request_doi_again')}</Typography>
                   {requestDoiButton}
                 </>
               )}

--- a/src/pages/public_registration/action_accordions/FindRegistration.tsx
+++ b/src/pages/public_registration/action_accordions/FindRegistration.tsx
@@ -74,10 +74,12 @@ export const FindRegistration = ({
             variant="filled"
             label={t('unpublish_actions.duplicate')}
             onChange={(event) => setSearchBeforeDebounce(event.target.value)}
-            InputProps={{
-              ...params.InputProps,
-              type: 'search',
-              startAdornment: <SearchIcon />,
+            slotProps={{
+              input: {
+                ...params.InputProps,
+                type: 'search',
+                startAdornment: <SearchIcon />,
+              },
             }}
           />
         )}

--- a/src/pages/public_registration/action_accordions/PendingPublishingTicketForCuratorSection.tsx
+++ b/src/pages/public_registration/action_accordions/PendingPublishingTicketForCuratorSection.tsx
@@ -112,7 +112,7 @@ export const PendingPublishingTicketForCuratorSection = ({
         <DialogContent>
           <Trans
             i18nKey="registration.public_page.reject_publish_request_description"
-            components={[<Typography paragraph key="1" />]}
+            components={[<Typography sx={{ mb: '1rem' }} key="1" />]}
           />
           <TextField
             data-testid={dataTestId.registrationLandingPage.tasksPanel.publishingRequestRejectionMessageTextField}

--- a/src/pages/public_registration/action_accordions/PendingPublishingTicketForCuratorSection.tsx
+++ b/src/pages/public_registration/action_accordions/PendingPublishingTicketForCuratorSection.tsx
@@ -116,17 +116,19 @@ export const PendingPublishingTicketForCuratorSection = ({
           />
           <TextField
             data-testid={dataTestId.registrationLandingPage.tasksPanel.publishingRequestRejectionMessageTextField}
-            inputProps={{ maxLength: 160 }}
             variant="filled"
             multiline
             minRows={3}
             fullWidth
             required
             label={t('registration.public_page.reason_for_rejection')}
-            FormHelperTextProps={{ sx: { textAlign: 'end' } }}
             helperText={`${rejectionReason.length}/160`}
             value={rejectionReason}
             onChange={(event) => setRejectionReason(event.target.value)}
+            slotProps={{
+              htmlInput: { maxLength: 160 },
+              formHelperText: { sx: { textAlign: 'end' } },
+            }}
           />
         </DialogContent>
         <DialogActions>

--- a/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
@@ -219,7 +219,7 @@ export const PublishingAccordion = ({
         {/* Option to reload data if status is not up to date with ticket */}
         {userCanHandlePublishingRequest && !tabErrors && hasMismatchingPublishedStatus && (
           <>
-            <Typography paragraph sx={{ mt: '1rem' }}>
+            <Typography sx={{ my: '1rem' }}>
               {isPublishedRegistration
                 ? t('registration.public_page.tasks_panel.files_will_soon_be_published')
                 : t('registration.public_page.tasks_panel.registration_will_soon_be_published')}
@@ -240,7 +240,7 @@ export const PublishingAccordion = ({
 
         {registrationIsValid && showRegistrationWithSameNameWarning && (
           <div>
-            <Typography paragraph>
+            <Typography sx={{ mb: '1rem' }}>
               {t('registration.public_page.tasks_panel.duplicate_title_description_introduction')}
             </Typography>
             <Link
@@ -258,7 +258,7 @@ export const PublishingAccordion = ({
             </Link>
             <Trans
               i18nKey="registration.public_page.tasks_panel.duplicate_title_description_details"
-              components={[<Typography paragraph key="1" />]}
+              components={[<Typography sx={{ mb: '1rem' }} key="1" />]}
             />
             <Divider sx={{ bgcolor: 'grey.400', mb: '0.5rem' }} />
           </div>
@@ -269,11 +269,11 @@ export const PublishingAccordion = ({
           <>
             {customer?.publicationWorkflow === 'RegistratorPublishesMetadataAndFiles' ? (
               <Trans i18nKey="registration.public_page.tasks_panel.publish_registration_description_workflow1">
-                <Typography paragraph />
+                <Typography sx={{ mb: '1rem' }} />
               </Trans>
             ) : customer?.publicationWorkflow === 'RegistratorPublishesMetadataOnly' ? (
               <Trans i18nKey="registration.public_page.tasks_panel.publish_registration_description_workflow2">
-                <Typography paragraph />
+                <Typography sx={{ mb: '1rem' }} />
               </Trans>
             ) : null}
           </>
@@ -293,7 +293,7 @@ export const PublishingAccordion = ({
               {t('registration.public_page.tasks_panel.publish_registration')}
             </LoadingButton>
 
-            <Typography paragraph sx={{ mt: '1rem' }}>
+            <Typography sx={{ my: '1rem' }}>
               {t('registration.public_page.tasks_panel.delete_draft_description')}
             </Typography>
           </>

--- a/src/pages/public_registration/action_accordions/PublishingAccordionLastTicketInfo.tsx
+++ b/src/pages/public_registration/action_accordions/PublishingAccordionLastTicketInfo.tsx
@@ -34,7 +34,7 @@ export const PublishingAccordionLastTicketInfo = ({
   if (publishingTicket.workflow === 'RegistratorPublishesMetadataAndFiles' && isCompletedTicket) {
     return (
       <Trans i18nKey="registration.public_page.tasks_panel.approved_publishing_request_description_for_workflow1">
-        <Typography paragraph />
+        <Typography sx={{ mb: '1rem' }} />
       </Trans>
     );
   }
@@ -49,20 +49,20 @@ export const PublishingAccordionLastTicketInfo = ({
           {canApprovePublishingRequest ? (
             registrationHasApprovedFile ? (
               <Trans i18nKey="registration.public_page.tasks_panel.approved_publishing_request_description_for_curator">
-                <Typography paragraph />
+                <Typography sx={{ mb: '1rem' }} />
               </Trans>
             ) : (
               <Trans i18nKey="registration.public_page.tasks_panel.approved_publishing_request_without_file_description_for_curator">
-                <Typography paragraph />
+                <Typography sx={{ mb: '1rem' }} />
               </Trans>
             )
           ) : registrationHasApprovedFile ? (
             <Trans i18nKey="registration.public_page.tasks_panel.approved_publishing_request_description_for_registrator">
-              <Typography paragraph />
+              <Typography sx={{ mb: '1rem' }} />
             </Trans>
           ) : (
             <Trans i18nKey="registration.public_page.tasks_panel.approved_publishing_request_without_file_description_for_registrator">
-              <Typography paragraph />
+              <Typography sx={{ mb: '1rem' }} />
             </Trans>
           )}
         </>
@@ -72,12 +72,12 @@ export const PublishingAccordionLastTicketInfo = ({
         <>
           {canApprovePublishingRequest ? (
             <Trans i18nKey="registration.public_page.tasks_panel.has_rejected_files_publishing_request">
-              <Typography paragraph />
+              <Typography sx={{ mb: '1rem' }} />
             </Trans>
           ) : (
             <>
               <Trans i18nKey="registration.public_page.tasks_panel.has_rejected_files_publishing_request_registrator">
-                <Typography paragraph />
+                <Typography sx={{ mb: '1rem' }} />
               </Trans>
               <Button
                 sx={{ bgcolor: 'white' }}
@@ -107,11 +107,11 @@ export const PublishingAccordionLastTicketInfo = ({
             />
           ) : registrationHasApprovedFile ? (
             <Trans i18nKey="registration.public_page.tasks_panel.pending_publishing_request_with_file_description_for_registrator">
-              <Typography paragraph />
+              <Typography sx={{ mb: '1rem' }} />
             </Trans>
           ) : (
             <Trans i18nKey="registration.public_page.tasks_panel.pending_publishing_request_without_file_description_for_registrator">
-              <Typography paragraph />
+              <Typography sx={{ mb: '1rem' }} />
             </Trans>
           )}
         </>

--- a/src/pages/registration/DescriptionPanel.tsx
+++ b/src/pages/registration/DescriptionPanel.tsx
@@ -52,15 +52,17 @@ export const DescriptionPanel = () => {
               }}
               fullWidth
               label={t('common.title')}
-              InputProps={{
-                endAdornment: titleSearchPending ? (
-                  <CircularProgress size={20} />
-                ) : duplicateRegistration ? (
-                  <ErrorIcon color="warning" />
-                ) : undefined,
-              }}
               error={touched && !!error}
               helperText={<ErrorMessage name={field.name} />}
+              slotProps={{
+                input: {
+                  endAdornment: titleSearchPending ? (
+                    <CircularProgress size={20} />
+                  ) : duplicateRegistration ? (
+                    <ErrorIcon color="warning" />
+                  ) : undefined,
+                },
+              }}
             />
           )}
         </Field>

--- a/src/pages/registration/FileList.tsx
+++ b/src/pages/registration/FileList.tsx
@@ -85,22 +85,22 @@ export const FileList = ({ title, files, uppy, remove, baseFieldName }: FileList
                           buttonDataTestId={dataTestId.registrationWizard.files.versionHelpButton}>
                           {registratorPublishesMetadataOnly ? (
                             <>
-                              <Typography paragraph>
+                              <Typography sx={{ mb: '1rem' }}>
                                 {t('registration.files_and_license.version_helper_text_metadata_only')}
                               </Typography>
-                              <Typography paragraph>
+                              <Typography sx={{ mb: '1rem' }}>
                                 <Trans
                                   i18nKey="registration.files_and_license.version_accepted_helper_text_metadata_only"
                                   components={[<Box key="1" component="span" sx={{ fontWeight: 'bold' }} />]}
                                 />
                               </Typography>
-                              <Typography paragraph>
+                              <Typography sx={{ mb: '1rem' }}>
                                 <Trans
                                   i18nKey="registration.files_and_license.version_published_helper_text_metadata_only"
                                   components={[<Box key="1" component="span" sx={{ fontWeight: 'bold' }} />]}
                                 />
                               </Typography>
-                              <Typography paragraph>
+                              <Typography sx={{ mb: '1rem' }}>
                                 <Trans
                                   i18nKey="registration.files_and_license.version_publishing_agreement_helper_text_metadata_only"
                                   components={[<Box key="1" component="span" sx={{ fontWeight: 'bold' }} />]}
@@ -112,32 +112,32 @@ export const FileList = ({ title, files, uppy, remove, baseFieldName }: FileList
                               <Trans
                                 i18nKey="registration.files_and_license.version_helper_text"
                                 components={[
-                                  <Typography paragraph key="1" />,
-                                  <Typography paragraph key="2">
+                                  <Typography sx={{ mb: '1rem' }} key="1" />,
+                                  <Typography sx={{ mb: '1rem' }} key="2">
                                     <Box component="span" sx={{ textDecoration: 'underline' }} />
                                   </Typography>,
                                 ]}
                               />
 
-                              <Typography paragraph>
+                              <Typography sx={{ mb: '1rem' }}>
                                 <Trans
                                   i18nKey="registration.files_and_license.version_accepted_helper_text"
                                   components={[<Box key="1" component="span" sx={{ fontWeight: 'bold' }} />]}
                                 />
                               </Typography>
-                              <Typography paragraph>
+                              <Typography sx={{ mb: '1rem' }}>
                                 <Trans
                                   i18nKey="registration.files_and_license.version_published_helper_text"
                                   components={[<Box key="1" component="span" sx={{ fontWeight: 'bold' }} />]}
                                 />
                               </Typography>
-                              <Typography paragraph>
+                              <Typography sx={{ mb: '1rem' }}>
                                 <Trans
                                   i18nKey="registration.files_and_license.version_publishing_agreement_helper_text"
                                   components={[<Box key="1" component="span" sx={{ fontWeight: 'bold' }} />]}
                                 />
                               </Typography>
-                              <Typography paragraph>
+                              <Typography sx={{ mb: '1rem' }}>
                                 <Trans
                                   i18nKey="registration.files_and_license.version_embargo_helper_text"
                                   components={[<Box key="1" component="span" sx={{ fontWeight: 'bold' }} />]}
@@ -157,7 +157,9 @@ export const FileList = ({ title, files, uppy, remove, baseFieldName }: FileList
                         modalTitle={t('registration.files_and_license.licenses')}
                         modalDataTestId={dataTestId.registrationWizard.files.licenseModal}
                         buttonDataTestId={dataTestId.registrationWizard.files.licenseHelpButton}>
-                        <Typography paragraph>{t('registration.files_and_license.file_and_license_info')}</Typography>
+                        <Typography sx={{ mb: '1rem' }}>
+                          {t('registration.files_and_license.file_and_license_info')}
+                        </Typography>
                         {licenses
                           .filter(
                             (license) =>
@@ -171,7 +173,7 @@ export const FileList = ({ title, files, uppy, remove, baseFieldName }: FileList
                                 {license.name}
                               </Typography>
                               <Box component="img" src={license.logo} alt="" sx={{ width: '8rem' }} />
-                              <Typography paragraph>{license.description}</Typography>
+                              <Typography sx={{ mb: '1rem' }}>{license.description}</Typography>
                               {license.link && (
                                 <Link href={license.link} target="blank">
                                   {license.link}

--- a/src/pages/registration/FilesAndLicensePanel.tsx
+++ b/src/pages/registration/FilesAndLicensePanel.tsx
@@ -112,7 +112,9 @@ export const FilesAndLicensePanel = ({ uppy }: FilesAndLicensePanelProps) => {
           </Typography>
           {journalIdentifier && (
             <Link href={getChannelRegisterJournalUrl(journalIdentifier)} target="_blank">
-              <Typography paragraph>{t('registration.files_and_license.find_journal_in_channel_register')}</Typography>
+              <Typography sx={{ mb: '1rem' }}>
+                {t('registration.files_and_license.find_journal_in_channel_register')}
+              </Typography>
             </Link>
           )}
           {publisherIdentifier && (
@@ -125,7 +127,9 @@ export const FilesAndLicensePanel = ({ uppy }: FilesAndLicensePanelProps) => {
 
           {seriesIdentifier && (
             <Link href={getChannelRegisterJournalUrl(seriesIdentifier)} target="_blank">
-              <Typography paragraph>{t('registration.files_and_license.find_series_in_channel_register')}</Typography>
+              <Typography sx={{ mb: '1rem' }}>
+                {t('registration.files_and_license.find_series_in_channel_register')}
+              </Typography>
             </Link>
           )}
         </Paper>
@@ -175,7 +179,7 @@ export const FilesAndLicensePanel = ({ uppy }: FilesAndLicensePanelProps) => {
                   />
                 )}
                 <Paper elevation={5} component={BackgroundDiv}>
-                  <Typography variant="h2" paragraph>
+                  <Typography variant="h2" sx={{ mb: '1rem' }}>
                     {t('common.link')}
                   </Typography>
                   {originalDoi ? (
@@ -233,7 +237,7 @@ export const FilesAndLicensePanel = ({ uppy }: FilesAndLicensePanelProps) => {
 
             {(associatedArtifacts.length === 0 || isNullAssociatedArtifact) && !originalDoi && (
               <Paper elevation={5} component={BackgroundDiv}>
-                <Typography variant="h2" paragraph>
+                <Typography variant="h2" sx={{ mb: '1rem' }}>
                   {t('registration.files_and_license.resource_is_a_reference')}
                 </Typography>
                 <Box sx={{ backgroundColor: 'white', width: '100%', p: '0.25rem 1rem' }}>

--- a/src/pages/registration/RegistrationForm.tsx
+++ b/src/pages/registration/RegistrationForm.tsx
@@ -148,7 +148,7 @@ export const RegistrationForm = ({ identifier }: RegistrationFormProps) => {
         title={t('registration.nvi_warning.registration_is_included_in_nvi')}
         onAccept={() => setHasAcceptedNviWarning(true)}
         onCancel={() => (history.length > 1 ? history.goBack() : history.push(UrlPathTemplate.Home))}>
-        <Typography paragraph>{t('registration.nvi_warning.reset_nvi_warning')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('registration.nvi_warning.reset_nvi_warning')}</Typography>
         <Typography>{t('registration.nvi_warning.continue_editing_registration')}</Typography>
       </ConfirmDialog>
     </NviCandidateContext.Provider>

--- a/src/pages/registration/RegistrationFormActions.tsx
+++ b/src/pages/registration/RegistrationFormActions.tsx
@@ -225,7 +225,7 @@ export const RegistrationFormActions = ({
           await saveRegistration(values);
         }}
         onCancel={() => setOpenNviApprovalResetDialog(false)}>
-        <Typography paragraph>{t('registration.nvi_warning.approval_override_warning')}</Typography>
+        <Typography sx={{ mb: '1rem' }}>{t('registration.nvi_warning.approval_override_warning')}</Typography>
         <Typography>{t('registration.nvi_warning.confirm_saving_registration')}</Typography>
       </ConfirmDialog>
     </>

--- a/src/pages/registration/SupportModalContent.tsx
+++ b/src/pages/registration/SupportModalContent.tsx
@@ -1,6 +1,5 @@
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import { Divider, Grid, Link as MuiLink, Skeleton, Typography } from '@mui/material';
-import { styled } from '@mui/system';
+import { Divider, Grid, Link as MuiLink, Skeleton, styled, Typography } from '@mui/material';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';

--- a/src/pages/registration/SupportModalContent.tsx
+++ b/src/pages/registration/SupportModalContent.tsx
@@ -1,14 +1,14 @@
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { Divider, Grid, Link as MuiLink, Skeleton, Typography } from '@mui/material';
+import { styled } from '@mui/system';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { createTicket, fetchRegistrationTickets } from '../../api/registrationApi';
 import { MessageForm } from '../../components/MessageForm';
 import { setNotification } from '../../redux/notificationSlice';
-import { Registration } from '../../types/registration.types';
 import { RootState } from '../../redux/store';
-import { styled } from '@mui/system';
+import { Registration } from '../../types/registration.types';
 
 interface SupportModalContentProps {
   closeModal: () => void;
@@ -113,7 +113,7 @@ export const SupportModalContent = ({ closeModal, registration }: SupportModalCo
           <Trans
             t={t}
             i18nKey="registration.support.curator_help.description"
-            components={[<Typography paragraph key="1" />]}
+            components={[<Typography sx={{ mb: '1rem' }} key="1" />]}
           />
           <MessageForm
             confirmAction={async (message) => {

--- a/src/pages/registration/contributors_tab/Contributors.tsx
+++ b/src/pages/registration/contributors_tab/Contributors.tsx
@@ -185,12 +185,14 @@ export const Contributors = ({ contributorRoles, push, replace }: ContributorsPr
           sx={{ display: 'block', mb: '1rem' }}
           label={t('common.search_by_name')}
           variant="filled"
-          InputProps={{
-            endAdornment: (
-              <InputAdornment position="end">
-                <SearchIcon />
-              </InputAdornment>
-            ),
+          slotProps={{
+            input: {
+              endAdornment: (
+                <InputAdornment position="end">
+                  <SearchIcon />
+                </InputAdornment>
+              ),
+            },
           }}
           onChange={(event) => {
             setCurrentPage(1);

--- a/src/pages/registration/contributors_tab/components/AddAffiliationModal.tsx
+++ b/src/pages/registration/contributors_tab/components/AddAffiliationModal.tsx
@@ -85,7 +85,7 @@ export const AddAffiliationModal = ({
       dataTestId="affiliation-modal">
       <Trans
         i18nKey="registration.contributors.add_new_affiliation_helper_text"
-        components={[<Typography paragraph key="1" />]}
+        components={[<Typography sx={{ mb: '1rem' }} key="1" />]}
       />
       <Box
         sx={{
@@ -99,7 +99,7 @@ export const AddAffiliationModal = ({
         </Typography>
       </Box>
       {affiliationToVerify && (
-        <Typography paragraph>
+        <Typography sx={{ mb: '1rem' }}>
           {t('registration.contributors.prefilled_affiliation')}: <b>{affiliationToVerify}</b>
         </Typography>
       )}

--- a/src/pages/registration/contributors_tab/components/EditAffiliationModal.tsx
+++ b/src/pages/registration/contributors_tab/components/EditAffiliationModal.tsx
@@ -86,7 +86,7 @@ export const EditAffiliationModal = ({
       headingText={t('registration.contributors.edit_affiliation')}>
       <Trans
         i18nKey="registration.contributors.edit_affiliation_helper_text"
-        components={[<Typography key="1" paragraph />]}
+        components={[<Typography key="1" sx={{ mb: '1rem' }} />]}
       />
       {authorName && <AuthorName authorName={authorName} />}
       {institutionQuery.isPending ? (

--- a/src/pages/registration/description_tab/RegistrationFunding.tsx
+++ b/src/pages/registration/description_tab/RegistrationFunding.tsx
@@ -35,7 +35,7 @@ export const RegistrationFunding = ({ currentFundings }: FundingsFieldProps) => 
           modalDataTestId={dataTestId.registrationWizard.description.fundingModal}>
           <Trans
             i18nKey="registration.description.funding.funding_helper_text"
-            components={[<Typography paragraph key="1" />]}
+            components={[<Typography sx={{ mb: '1rem' }} key="1" />]}
           />
         </HelperTextModal>
       </Box>

--- a/src/pages/registration/description_tab/RegistrationFunding.tsx
+++ b/src/pages/registration/description_tab/RegistrationFunding.tsx
@@ -70,7 +70,6 @@ export const RegistrationFunding = ({ currentFundings }: FundingsFieldProps) => 
                     alignItems: 'center',
                   }}>
                   <FundingSourceField fieldName={`${baseFieldName}.${SpecificFundingFieldNames.Source}`} />
-
                   {hasSelectedNfrSource &&
                     (hasSelectedNfrProject ? (
                       <>
@@ -178,15 +177,17 @@ export const RegistrationFunding = ({ currentFundings }: FundingsFieldProps) => 
                             label={t('registration.description.funding.funding_sum')}
                             fullWidth
                             variant="filled"
-                            InputProps={{
-                              startAdornment: (
-                                <InputAdornment position="start">{funding.fundingAmount?.currency}</InputAdornment>
-                              ),
-                            }}
                             sx={getTextFieldMargin(touched && !!error)}
                             error={touched && !!error}
                             helperText={touched && !!error ? error : undefined}
                             data-testid={dataTestId.registrationWizard.description.fundingSumField}
+                            slotProps={{
+                              input: {
+                                startAdornment: (
+                                  <InputAdornment position="start">{funding.fundingAmount?.currency}</InputAdornment>
+                                ),
+                              },
+                            }}
                           />
                         )}
                       </Field>

--- a/src/pages/registration/description_tab/projects_field/ProjectsField.tsx
+++ b/src/pages/registration/description_tab/projects_field/ProjectsField.tsx
@@ -53,7 +53,7 @@ export const ProjectsField = () => {
           modalDataTestId={dataTestId.registrationWizard.description.projectModal}>
           <Trans
             i18nKey="registration.description.project_helper_text"
-            components={[<Typography key="1" paragraph />]}
+            components={[<Typography key="1" sx={{ mb: '1rem' }} />]}
           />
         </HelperTextModal>
       </Box>
@@ -126,7 +126,7 @@ export const ProjectsField = () => {
                     modalDataTestId={dataTestId.registrationWizard.description.createProjectModal}>
                     <Trans
                       i18nKey="registration.description.create_project_helper_text"
-                      components={[<Typography key="1" paragraph />]}
+                      components={[<Typography key="1" sx={{ mb: '1rem' }} />]}
                     />
                   </HelperTextModal>
                 </Box>

--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -171,11 +171,9 @@ export const FilesTableRow = ({
               <TextField
                 {...field}
                 data-testid={dataTestId.registrationWizard.files.fileTypeSelect}
-                SelectProps={{ inputProps: { 'aria-label': t('registration.files_and_license.availability') } }}
                 select
                 disabled={disabled}
                 variant="filled"
-                InputProps={{ sx: { '.MuiSelect-select': { py: '0.75rem' } } }}
                 fullWidth
                 onChange={(event) => {
                   const newValue = event.target.value as FileType;
@@ -187,6 +185,10 @@ export const FilesTableRow = ({
                   } else {
                     setFieldValue(fileTypeFieldName, newValue);
                   }
+                }}
+                slotProps={{
+                  input: { sx: { '.MuiSelect-select': { py: '0.75rem' } } },
+                  select: { inputProps: { 'aria-label': t('registration.files_and_license.availability') } },
                 }}>
                 <MenuItem value={isCompletedFile ? FileType.OpenFile : FileType.PendingOpenFile}>
                   <StyledFileTypeMenuItemContent>
@@ -296,15 +298,23 @@ export const FilesTableRow = ({
                         sx={{ minWidth: '15rem' }}
                         select
                         disabled={disabled}
-                        SelectProps={{
-                          renderValue: (option) => {
-                            const selectedLicense = licenses.find((license) => equalUris(license.id, option as string));
-                            return selectedLicense ? (
-                              <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                                <img style={{ width: '5rem' }} src={selectedLicense.logo} alt={selectedLicense.name} />
-                                <span>{selectedLicense.name}</span>
-                              </Box>
-                            ) : null;
+                        slotProps={{
+                          select: {
+                            renderValue: (option) => {
+                              const selectedLicense = licenses.find((license) =>
+                                equalUris(license.id, option as string)
+                              );
+                              return selectedLicense ? (
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                                  <img
+                                    style={{ width: '5rem' }}
+                                    src={selectedLicense.logo}
+                                    alt={selectedLicense.name}
+                                  />
+                                  <span>{selectedLicense.name}</span>
+                                </Box>
+                              ) : null;
+                            },
                           },
                         }}
                         variant="filled"

--- a/src/pages/registration/new_registration/LinkRegistration.tsx
+++ b/src/pages/registration/new_registration/LinkRegistration.tsx
@@ -106,8 +106,8 @@ export const LinkRegistration = ({ expanded, onChange }: StartRegistrationAccord
                       disabled={isSubmitting}
                       {...field}
                       error={!!error && touched}
-                      InputLabelProps={{ shrink: true }}
                       placeholder={doiUrlPlaceholder}
+                      slotProps={{ inputLabel: { shrink: true } }}
                     />
                   )}
                 </Field>

--- a/src/pages/registration/resource_type_tab/SelectRegistrationTypeField.tsx
+++ b/src/pages/registration/resource_type_tab/SelectRegistrationTypeField.tsx
@@ -352,14 +352,14 @@ export const SelectRegistrationTypeField = () => {
         <Typography fontWeight={500}>
           {t('registration.resource_type.research_data.accept_dataset_terms.contains_personal_data')}
         </Typography>
-        <Typography paragraph>
+        <Typography sx={{ mb: '1rem' }}>
           {t('registration.resource_type.research_data.accept_dataset_terms.contains_personal_data_description')}
         </Typography>
 
         <Typography fontWeight={500}>
           {t('registration.resource_type.research_data.accept_dataset_terms.contains_sensitive_data')}
         </Typography>
-        <Typography paragraph>
+        <Typography sx={{ mb: '1rem' }}>
           {t('registration.resource_type.research_data.accept_dataset_terms.contains_sensitive_data_description')}
         </Typography>
 

--- a/src/pages/registration/resource_type_tab/components/DoiField.tsx
+++ b/src/pages/registration/resource_type_tab/components/DoiField.tsx
@@ -34,7 +34,6 @@ export const DoiField = ({ canEditDoi }: DoiFieldProps) => {
         flexWrap: 'wrap',
       }}>
       <TextField
-        InputProps={{ startAdornment: <LinkIcon sx={{ mr: '0.5rem' }} /> }}
         data-testid="doi-field"
         variant="filled"
         fullWidth
@@ -43,6 +42,7 @@ export const DoiField = ({ canEditDoi }: DoiFieldProps) => {
         disabled
         value={doi || referenceDoi}
         multiline
+        slotProps={{ input: { startAdornment: <LinkIcon sx={{ mr: '0.5rem' }} /> } }}
       />
 
       {referenceDoi && (

--- a/src/pages/registration/resource_type_tab/components/JournalField.tsx
+++ b/src/pages/registration/resource_type_tab/components/JournalField.tsx
@@ -193,12 +193,11 @@ export const JournalField = ({ confirmedContextType, unconfirmedContextType }: J
             slotProps={{
               listbox: {
                 component: AutocompleteListboxWithExpansion,
-
                 ...({
                   hasMoreHits: !!journalOptionsQuery.data?.totalHits && journalOptionsQuery.data.totalHits > searchSize,
                   onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
                   isLoadingMoreHits: journalOptionsQuery.isFetching && searchSize > options.length,
-                } satisfies AutocompleteListboxWithExpansionProps as any),
+                } satisfies AutocompleteListboxWithExpansionProps),
               },
             }}
           />

--- a/src/pages/registration/resource_type_tab/components/JournalField.tsx
+++ b/src/pages/registration/resource_type_tab/components/JournalField.tsx
@@ -167,14 +167,6 @@ export const JournalField = ({ confirmedContextType, unconfirmedContextType }: J
             renderOption={({ key, ...props }, option, state) => (
               <PublicationChannelOption key={option.identifier} props={props} option={option} state={state} />
             )}
-            ListboxComponent={AutocompleteListboxWithExpansion}
-            ListboxProps={
-              {
-                hasMoreHits: !!journalOptionsQuery.data?.totalHits && journalOptionsQuery.data.totalHits > searchSize,
-                onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
-                isLoadingMoreHits: journalOptionsQuery.isFetching && searchSize > options.length,
-              } satisfies AutocompleteListboxWithExpansionProps as any
-            }
             renderTags={(value, getTagProps) =>
               value.map((option, index) => (
                 <Chip
@@ -198,6 +190,17 @@ export const JournalField = ({ confirmedContextType, unconfirmedContextType }: J
                 errorMessage={meta.touched && !!meta.error ? meta.error : ''}
               />
             )}
+            slotProps={{
+              listbox: {
+                component: AutocompleteListboxWithExpansion,
+
+                ...({
+                  hasMoreHits: !!journalOptionsQuery.data?.totalHits && journalOptionsQuery.data.totalHits > searchSize,
+                  onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
+                  isLoadingMoreHits: journalOptionsQuery.isFetching && searchSize > options.length,
+                } satisfies AutocompleteListboxWithExpansionProps as any),
+              },
+            }}
           />
         )}
       </Field>

--- a/src/pages/registration/resource_type_tab/components/JournalFormDialog.tsx
+++ b/src/pages/registration/resource_type_tab/components/JournalFormDialog.tsx
@@ -145,10 +145,10 @@ export const JournalFormDialog = ({
                     {...field}
                     variant="filled"
                     label={t('registration.resource_type.print_issn')}
-                    inputProps={{ maxLength: 9 }}
                     disabled={isLoading}
                     error={touched && !!error}
                     helperText={<ErrorMessage name={field.name} />}
+                    slotProps={{ htmlInput: { maxLength: 9 } }}
                   />
                 )}
               </Field>
@@ -158,10 +158,10 @@ export const JournalFormDialog = ({
                     {...field}
                     variant="filled"
                     label={t('registration.resource_type.online_issn')}
-                    inputProps={{ maxLength: 9 }}
                     disabled={isLoading}
                     error={touched && !!error}
                     helperText={<ErrorMessage name={field.name} />}
+                    slotProps={{ htmlInput: { maxLength: 9 } }}
                   />
                 )}
               </Field>

--- a/src/pages/registration/resource_type_tab/components/JournalFormDialog.tsx
+++ b/src/pages/registration/resource_type_tab/components/JournalFormDialog.tsx
@@ -104,7 +104,7 @@ export const JournalFormDialog = ({
         }>
         <Form>
           <DialogContent>
-            <Typography paragraph>
+            <Typography sx={{ mb: '1rem' }}>
               <Trans t={t} i18nKey="registration.resource_type.search_for_channel">
                 <MuiLink href="https://portal.issn.org" target="_blank" rel="noopener noreferrer">
                   https://portal.issn.org

--- a/src/pages/registration/resource_type_tab/components/NpiDisciplineField.tsx
+++ b/src/pages/registration/resource_type_tab/components/NpiDisciplineField.tsx
@@ -55,14 +55,16 @@ export const NpiDisciplineField = ({ required }: NpiDisciplineFieldProps) => {
                 placeholder={!value ? t('registration.description.search_for_npi_discipline') : ''}
                 error={!!error && touched}
                 helperText={<ErrorMessage name={name} />}
-                InputProps={{
-                  ...params.InputProps,
-                  startAdornment: (
-                    <>
-                      {params.InputProps.startAdornment}
-                      {!value && <SearchIcon color="disabled" sx={{ marginLeft: '0.5rem' }} />}
-                    </>
-                  ),
+                slotProps={{
+                  input: {
+                    ...params.InputProps,
+                    startAdornment: (
+                      <>
+                        {params.InputProps.startAdornment}
+                        {!value && <SearchIcon color="disabled" sx={{ marginLeft: '0.5rem' }} />}
+                      </>
+                    ),
+                  },
                 }}
               />
             )}

--- a/src/pages/registration/resource_type_tab/components/PublisherField.tsx
+++ b/src/pages/registration/resource_type_tab/components/PublisherField.tsx
@@ -151,13 +151,12 @@ export const PublisherField = () => {
             slotProps={{
               listbox: {
                 component: AutocompleteListboxWithExpansion,
-
                 ...({
                   hasMoreHits:
                     !!publisherOptionsQuery.data?.totalHits && publisherOptionsQuery.data.totalHits > searchSize,
                   onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
                   isLoadingMoreHits: publisherOptionsQuery.isFetching && searchSize > options.length,
-                } satisfies AutocompleteListboxWithExpansionProps as any),
+                } satisfies AutocompleteListboxWithExpansionProps),
               },
             }}
           />

--- a/src/pages/registration/resource_type_tab/components/PublisherField.tsx
+++ b/src/pages/registration/resource_type_tab/components/PublisherField.tsx
@@ -127,15 +127,6 @@ export const PublisherField = () => {
             renderOption={({ key, ...props }, option, state) => (
               <PublicationChannelOption key={option.identifier} props={props} option={option} state={state} />
             )}
-            ListboxComponent={AutocompleteListboxWithExpansion}
-            ListboxProps={
-              {
-                hasMoreHits:
-                  !!publisherOptionsQuery.data?.totalHits && publisherOptionsQuery.data.totalHits > searchSize,
-                onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
-                isLoadingMoreHits: publisherOptionsQuery.isFetching && searchSize > options.length,
-              } satisfies AutocompleteListboxWithExpansionProps as any
-            }
             renderTags={(value, getTagProps) =>
               value.map((option, index) => (
                 <Chip
@@ -157,6 +148,18 @@ export const PublisherField = () => {
                 errorMessage={meta.touched && !!meta.error ? meta.error : ''}
               />
             )}
+            slotProps={{
+              listbox: {
+                component: AutocompleteListboxWithExpansion,
+
+                ...({
+                  hasMoreHits:
+                    !!publisherOptionsQuery.data?.totalHits && publisherOptionsQuery.data.totalHits > searchSize,
+                  onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
+                  isLoadingMoreHits: publisherOptionsQuery.isFetching && searchSize > options.length,
+                } satisfies AutocompleteListboxWithExpansionProps as any),
+              },
+            }}
           />
         )}
       </Field>

--- a/src/pages/registration/resource_type_tab/components/PublisherFormDialog.tsx
+++ b/src/pages/registration/resource_type_tab/components/PublisherFormDialog.tsx
@@ -71,7 +71,7 @@ export const PublisherFormDialog = ({ open, closeDialog, onCreatedChannel, initi
         onSubmit={async (values) => await publisherMutation.mutateAsync(values)}>
         <Form>
           <DialogContent>
-            <Typography paragraph>
+            <Typography sx={{ mb: '1rem' }}>
               <Trans t={t} i18nKey="registration.resource_type.search_for_channel">
                 <MuiLink href="https://portal.issn.org" target="_blank" rel="noopener noreferrer">
                   https://portal.issn.org

--- a/src/pages/registration/resource_type_tab/components/PublisherFormDialog.tsx
+++ b/src/pages/registration/resource_type_tab/components/PublisherFormDialog.tsx
@@ -112,10 +112,10 @@ export const PublisherFormDialog = ({ open, closeDialog, onCreatedChannel, initi
                     {...field}
                     variant="filled"
                     label={t('registration.resource_type.isbn_prefix')}
-                    inputProps={{ maxLength: 13 }}
                     disabled={publisherMutation.isPending}
                     error={touched && !!error}
                     helperText={<ErrorMessage name={field.name} />}
+                    slotProps={{ htmlInput: { maxLength: 13 } }}
                   />
                 )}
               </Field>

--- a/src/pages/registration/resource_type_tab/components/SeriesField.tsx
+++ b/src/pages/registration/resource_type_tab/components/SeriesField.tsx
@@ -124,14 +124,6 @@ export const SeriesField = () => {
             renderOption={({ key, ...props }, option, state) => (
               <PublicationChannelOption key={option.identifier} props={props} option={option} state={state} />
             )}
-            ListboxComponent={AutocompleteListboxWithExpansion}
-            ListboxProps={
-              {
-                hasMoreHits: !!seriesOptionsQuery.data?.totalHits && seriesOptionsQuery.data.totalHits > searchSize,
-                onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
-                isLoadingMoreHits: seriesOptionsQuery.isFetching && searchSize > options.length,
-              } satisfies AutocompleteListboxWithExpansionProps as any
-            }
             renderTags={(value, getTagProps) =>
               value.map((option, index) => (
                 <Chip
@@ -152,6 +144,17 @@ export const SeriesField = () => {
                 errorMessage={meta.touched && !!meta.error ? meta.error : ''}
               />
             )}
+            slotProps={{
+              listbox: {
+                component: AutocompleteListboxWithExpansion,
+
+                ...({
+                  hasMoreHits: !!seriesOptionsQuery.data?.totalHits && seriesOptionsQuery.data.totalHits > searchSize,
+                  onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
+                  isLoadingMoreHits: seriesOptionsQuery.isFetching && searchSize > options.length,
+                } satisfies AutocompleteListboxWithExpansionProps as any),
+              },
+            }}
           />
         )}
       </Field>

--- a/src/pages/registration/resource_type_tab/components/SeriesField.tsx
+++ b/src/pages/registration/resource_type_tab/components/SeriesField.tsx
@@ -147,12 +147,11 @@ export const SeriesField = () => {
             slotProps={{
               listbox: {
                 component: AutocompleteListboxWithExpansion,
-
                 ...({
                   hasMoreHits: !!seriesOptionsQuery.data?.totalHits && seriesOptionsQuery.data.totalHits > searchSize,
                   onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
                   isLoadingMoreHits: seriesOptionsQuery.isFetching && searchSize > options.length,
-                } satisfies AutocompleteListboxWithExpansionProps as any),
+                } satisfies AutocompleteListboxWithExpansionProps),
               },
             }}
           />

--- a/src/pages/registration/resource_type_tab/components/SeriesFields.tsx
+++ b/src/pages/registration/resource_type_tab/components/SeriesFields.tsx
@@ -12,7 +12,7 @@ export const SeriesFields = () => {
   return (
     <div>
       <Typography variant="h2">{t('registration.resource_type.series')}</Typography>
-      <Typography paragraph>{t('registration.resource_type.series_info')}</Typography>
+      <Typography sx={{ mb: '1rem' }}>{t('registration.resource_type.series_info')}</Typography>
 
       <InputContainerBox>
         <SeriesField />

--- a/src/pages/registration/resource_type_tab/components/isbn_and_pages/IsbnField.tsx
+++ b/src/pages/registration/resource_type_tab/components/isbn_and_pages/IsbnField.tsx
@@ -53,11 +53,9 @@ export const IsbnField = ({ fieldName }: IsbnFieldProps) => {
               label={t('registration.resource_type.isbn')}
               placeholder={isbnFormat}
               variant="filled"
-              InputProps={{
-                inputComponent: MaskIsbnInput as any,
-              }}
               error={!!meta.error && meta.touched}
               helperText={<ErrorMessage name={field.name} />}
+              slotProps={{ input: { inputComponent: MaskIsbnInput as any } }}
             />
           )}
         </Field>

--- a/src/pages/registration/resource_type_tab/sub_type_forms/DegreeForm.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/DegreeForm.tsx
@@ -32,9 +32,9 @@ export const DegreeForm = ({ subType }: DegreeFormProps) => {
               data-testid={dataTestId.registrationWizard.resourceType.courseCodeField}
               variant="filled"
               sx={{ width: 'fit-content' }}
-              inputProps={{ maxLength: 15 }}
               label={t('registration.resource_type.course_code')}
               value={field.value ?? ''}
+              slotProps={{ htmlInput: { maxLength: 15 } }}
             />
           )}
         </Field>

--- a/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/music_performance/AudioVisualPublicationModal.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/music_performance/AudioVisualPublicationModal.tsx
@@ -236,12 +236,10 @@ export const AudioVisualPublicationModal = ({
                     variant="filled"
                     fullWidth
                     label={t('registration.resource_type.artistic.music_score_isrc')}
-                    InputProps={{
-                      inputComponent: MaskIsrcInput as any,
-                    }}
                     error={touched && !!error}
                     helperText={<ErrorMessage name={field.name} />}
                     data-testid={dataTestId.registrationWizard.resourceType.scoreIsrc}
+                    slotProps={{ input: { inputComponent: MaskIsrcInput as any } }}
                   />
                 )}
               </Field>

--- a/src/pages/search/SearchTextField.tsx
+++ b/src/pages/search/SearchTextField.tsx
@@ -21,14 +21,16 @@ export const SearchTextField = ({ clearValue, dataTestId, ...props }: SearchText
         variant="outlined"
         size="small"
         aria-label={t('common.search')}
-        InputProps={{
-          startAdornment: <SearchIcon color="disabled" />,
-          endAdornment:
-            props.value && clearValue ? (
-              <IconButton onClick={clearValue} title={t('common.clear')} size="small">
-                <ClearIcon />
-              </IconButton>
-            ) : null,
+        slotProps={{
+          input: {
+            startAdornment: <SearchIcon color="disabled" />,
+            endAdornment:
+              props.value && clearValue ? (
+                <IconButton onClick={clearValue} title={t('common.clear')} size="small">
+                  <ClearIcon />
+                </IconButton>
+              ) : null,
+          },
         }}
       />
       <input type="submit" hidden />

--- a/src/pages/search/SearchTypeField.tsx
+++ b/src/pages/search/SearchTypeField.tsx
@@ -37,7 +37,7 @@ export const SearchTypeField = ({ sx = {} }: Pick<TextFieldProps, 'sx'>) => {
         },
         ...sx,
       }}
-      inputProps={{ 'aria-label': t('common.type') }}>
+      slotProps={{ htmlInput: { 'aria-label': t('common.type') } }}>
       <MenuItem
         sx={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}
         value={SearchTypeValue.Result}

--- a/src/pages/search/advanced_search/JournalFilter.tsx
+++ b/src/pages/search/advanced_search/JournalFilter.tsx
@@ -101,12 +101,11 @@ export const JournalFilter = () => {
         slotProps={{
           listbox: {
             component: AutocompleteListboxWithExpansion,
-
             ...({
               hasMoreHits: !!journalOptionsQuery.data?.totalHits && journalOptionsQuery.data.totalHits > searchSize,
               onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
               isLoadingMoreHits: journalOptionsQuery.isFetching && searchSize > options.length,
-            } satisfies AutocompleteListboxWithExpansionProps as any),
+            } satisfies AutocompleteListboxWithExpansionProps),
           },
         }}
       />

--- a/src/pages/search/advanced_search/JournalFilter.tsx
+++ b/src/pages/search/advanced_search/JournalFilter.tsx
@@ -87,14 +87,6 @@ export const JournalFilter = () => {
             hideScientificLevel
           />
         )}
-        ListboxComponent={AutocompleteListboxWithExpansion}
-        ListboxProps={
-          {
-            hasMoreHits: !!journalOptionsQuery.data?.totalHits && journalOptionsQuery.data.totalHits > searchSize,
-            onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
-            isLoadingMoreHits: journalOptionsQuery.isFetching && searchSize > options.length,
-          } satisfies AutocompleteListboxWithExpansionProps as any
-        }
         data-testid={dataTestId.startPage.advancedSearch.journalField}
         renderInput={(params) => (
           <AutocompleteTextField
@@ -106,6 +98,17 @@ export const JournalFilter = () => {
             multiline
           />
         )}
+        slotProps={{
+          listbox: {
+            component: AutocompleteListboxWithExpansion,
+
+            ...({
+              hasMoreHits: !!journalOptionsQuery.data?.totalHits && journalOptionsQuery.data.totalHits > searchSize,
+              onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
+              isLoadingMoreHits: journalOptionsQuery.isFetching && searchSize > options.length,
+            } satisfies AutocompleteListboxWithExpansionProps as any),
+          },
+        }}
       />
     </section>
   );

--- a/src/pages/search/advanced_search/OrganizationFilters.tsx
+++ b/src/pages/search/advanced_search/OrganizationFilters.tsx
@@ -142,12 +142,11 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
           slotProps={{
             listbox: {
               component: AutocompleteListboxWithExpansion,
-
               ...({
                 hasMoreHits: !!organizationSearchQuery.data?.size && organizationSearchQuery.data.size > searchSize,
                 onShowMoreHits: () => setSearchSize(searchSize + defaultOrganizationSearchSize),
                 isLoadingMoreHits: organizationSearchQuery.isFetching && searchSize > options.length,
-              } satisfies AutocompleteListboxWithExpansionProps as any),
+              } satisfies AutocompleteListboxWithExpansionProps),
             },
           }}
         />

--- a/src/pages/search/advanced_search/OrganizationFilters.tsx
+++ b/src/pages/search/advanced_search/OrganizationFilters.tsx
@@ -128,14 +128,6 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
           renderOption={({ key, ...props }, option) => (
             <OrganizationRenderOption key={option.id} props={props} option={option} />
           )}
-          ListboxComponent={AutocompleteListboxWithExpansion}
-          ListboxProps={
-            {
-              hasMoreHits: !!organizationSearchQuery.data?.size && organizationSearchQuery.data.size > searchSize,
-              onShowMoreHits: () => setSearchSize(searchSize + defaultOrganizationSearchSize),
-              isLoadingMoreHits: organizationSearchQuery.isFetching && searchSize > options.length,
-            } satisfies AutocompleteListboxWithExpansionProps as any
-          }
           renderInput={(params) => (
             <AutocompleteTextField
               {...params}
@@ -147,6 +139,17 @@ export const OrganizationFilters = ({ topLevelOrganizationId, unitId }: Organiza
               showSearchIcon
             />
           )}
+          slotProps={{
+            listbox: {
+              component: AutocompleteListboxWithExpansion,
+
+              ...({
+                hasMoreHits: !!organizationSearchQuery.data?.size && organizationSearchQuery.data.size > searchSize,
+                onShowMoreHits: () => setSearchSize(searchSize + defaultOrganizationSearchSize),
+                isLoadingMoreHits: organizationSearchQuery.isFetching && searchSize > options.length,
+              } satisfies AutocompleteListboxWithExpansionProps as any),
+            },
+          }}
         />
 
         <Chip

--- a/src/pages/search/advanced_search/PublisherFilter.tsx
+++ b/src/pages/search/advanced_search/PublisherFilter.tsx
@@ -87,14 +87,6 @@ export const PublisherFilter = () => {
             hideScientificLevel
           />
         )}
-        ListboxComponent={AutocompleteListboxWithExpansion}
-        ListboxProps={
-          {
-            hasMoreHits: !!publisherOptionsQuery.data?.totalHits && publisherOptionsQuery.data.totalHits > searchSize,
-            onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
-            isLoadingMoreHits: publisherOptionsQuery.isFetching && searchSize > options.length,
-          } satisfies AutocompleteListboxWithExpansionProps as any
-        }
         data-testid={dataTestId.startPage.advancedSearch.publisherField}
         renderInput={(params) => (
           <AutocompleteTextField
@@ -106,6 +98,17 @@ export const PublisherFilter = () => {
             multiline
           />
         )}
+        slotProps={{
+          listbox: {
+            component: AutocompleteListboxWithExpansion,
+
+            ...({
+              hasMoreHits: !!publisherOptionsQuery.data?.totalHits && publisherOptionsQuery.data.totalHits > searchSize,
+              onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
+              isLoadingMoreHits: publisherOptionsQuery.isFetching && searchSize > options.length,
+            } satisfies AutocompleteListboxWithExpansionProps as any),
+          },
+        }}
       />
     </section>
   );

--- a/src/pages/search/advanced_search/PublisherFilter.tsx
+++ b/src/pages/search/advanced_search/PublisherFilter.tsx
@@ -101,12 +101,11 @@ export const PublisherFilter = () => {
         slotProps={{
           listbox: {
             component: AutocompleteListboxWithExpansion,
-
             ...({
               hasMoreHits: !!publisherOptionsQuery.data?.totalHits && publisherOptionsQuery.data.totalHits > searchSize,
               onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
               isLoadingMoreHits: publisherOptionsQuery.isFetching && searchSize > options.length,
-            } satisfies AutocompleteListboxWithExpansionProps as any),
+            } satisfies AutocompleteListboxWithExpansionProps),
           },
         }}
       />

--- a/src/pages/search/advanced_search/SeriesFilter.tsx
+++ b/src/pages/search/advanced_search/SeriesFilter.tsx
@@ -87,14 +87,6 @@ export const SeriesFilter = () => {
             hideScientificLevel
           />
         )}
-        ListboxComponent={AutocompleteListboxWithExpansion}
-        ListboxProps={
-          {
-            hasMoreHits: !!seriesOptionsQuery.data?.totalHits && seriesOptionsQuery.data.totalHits > searchSize,
-            onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
-            isLoadingMoreHits: seriesOptionsQuery.isFetching && searchSize > options.length,
-          } satisfies AutocompleteListboxWithExpansionProps as any
-        }
         data-testid={dataTestId.startPage.advancedSearch.seriesField}
         renderInput={(params) => (
           <AutocompleteTextField
@@ -106,6 +98,17 @@ export const SeriesFilter = () => {
             multiline
           />
         )}
+        slotProps={{
+          listbox: {
+            component: AutocompleteListboxWithExpansion,
+
+            ...({
+              hasMoreHits: !!seriesOptionsQuery.data?.totalHits && seriesOptionsQuery.data.totalHits > searchSize,
+              onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
+              isLoadingMoreHits: seriesOptionsQuery.isFetching && searchSize > options.length,
+            } satisfies AutocompleteListboxWithExpansionProps as any),
+          },
+        }}
       />
     </section>
   );

--- a/src/pages/search/advanced_search/SeriesFilter.tsx
+++ b/src/pages/search/advanced_search/SeriesFilter.tsx
@@ -101,12 +101,11 @@ export const SeriesFilter = () => {
         slotProps={{
           listbox: {
             component: AutocompleteListboxWithExpansion,
-
             ...({
               hasMoreHits: !!seriesOptionsQuery.data?.totalHits && seriesOptionsQuery.data.totalHits > searchSize,
               onShowMoreHits: () => setSearchSize(searchSize + defaultChannelSearchSize),
               isLoadingMoreHits: seriesOptionsQuery.isFetching && searchSize > options.length,
-            } satisfies AutocompleteListboxWithExpansionProps as any),
+            } satisfies AutocompleteListboxWithExpansionProps),
           },
         }}
       />

--- a/src/pages/search/registration_search/RegistrationSearchBar.tsx
+++ b/src/pages/search/registration_search/RegistrationSearchBar.tsx
@@ -140,7 +140,7 @@ export const RegistrationSearchBar = ({ registrationQuery }: Pick<SearchPageProp
             {({ field }: FieldProps<string>) => (
               <SearchTextField
                 {...field}
-                inputProps={{ [dataSearchFieldAttributeName]: ResultParam.Query }}
+                slotProps={{ htmlInput: { [dataSearchFieldAttributeName]: ResultParam.Query } }}
                 placeholder={t('search.search_placeholder')}
                 clearValue={() => {
                   field.onChange({ target: { value: '', id: field.name } });

--- a/src/pages/search/registration_search/filters/AdvancedSearchRow.tsx
+++ b/src/pages/search/registration_search/filters/AdvancedSearchRow.tsx
@@ -64,9 +64,11 @@ export const AdvancedSearchRow = ({ removeFilter, baseFieldName, queryParam }: A
             variant="standard"
             size="small"
             label={t('search.search_term_label')}
-            inputProps={queryParam ? { [dataSearchFieldAttributeName]: queryParam } : undefined}
             data-testid={dataTestId.startPage.advancedSearch.advancedValueField}
             fullWidth
+            slotProps={{
+              htmlInput: queryParam ? { [dataSearchFieldAttributeName]: queryParam } : undefined,
+            }}
           />
         )}
       </Field>

--- a/src/pages/search/registration_search/filters/AdvancedSearchRow.tsx
+++ b/src/pages/search/registration_search/filters/AdvancedSearchRow.tsx
@@ -66,9 +66,7 @@ export const AdvancedSearchRow = ({ removeFilter, baseFieldName, queryParam }: A
             label={t('search.search_term_label')}
             data-testid={dataTestId.startPage.advancedSearch.advancedValueField}
             fullWidth
-            slotProps={{
-              htmlInput: queryParam ? { [dataSearchFieldAttributeName]: queryParam } : undefined,
-            }}
+            slotProps={{ htmlInput: queryParam ? { [dataSearchFieldAttributeName]: queryParam } : undefined }}
           />
         )}
       </Field>


### PR DESCRIPTION
Omskriving av deprecated MUI props: https://mui.com/material-ui/migration/upgrade-to-v6/

Brukte først MUI sin [codemod](https://mui.com/material-ui/migration/migrating-from-deprecated-apis/#migrating) for å oppdatere, og gikk så gjennom alle for å rette litt på utformingen da default er at alle fikser ble spredd over mer plass enn nødvendig som så rotete ut

Fortsatt noen tilfeller hvor vi utvider dagens `AutocompleteRenderInputParams` bl.a. som bruker deprecated props, men tenker det får være. Nå har vi hvertfall det aller meste kompatibelt med neste major versjon

`Grid` er også deprecated, til fordel for `Grid2`. Men jer har ikke jobbet særlig mye med `Grid`, så ser ikke på det i denne runden