### PR TITLE
NP-48165 Change support ticket autocomplete

### DIFF
--- a/src/pages/public_registration/action_accordions/SupportAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/SupportAccordion.tsx
@@ -14,6 +14,7 @@ import { Registration, RegistrationStatus } from '../../../types/registration.ty
 import { isErrorStatus, isSuccessStatus } from '../../../utils/constants';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { getTabErrors, validateRegistrationForm } from '../../../utils/formik-helpers/formik-helpers';
+import { getIdentifierFromId } from '../../../utils/general-helpers';
 import { userHasAccessRight } from '../../../utils/registration-helpers';
 import { UrlPathTemplate } from '../../../utils/urlPaths';
 import { TicketMessageList } from '../../messages/components/MessageList';
@@ -30,6 +31,8 @@ export const SupportAccordion = ({ registration, supportTicket, addMessage, refe
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const user = useSelector((store: RootState) => store.user);
+  const userCristinIdentifier = user && getIdentifierFromId(user.nvaUsername);
+  const userIsTicketOwner = supportTicket?.owner === userCristinIdentifier;
 
   const ticketMutation = useMutation({
     mutationFn: supportTicket
@@ -115,7 +118,7 @@ export const SupportAccordion = ({ registration, supportTicket, addMessage, refe
             if (message) {
               if (supportTicket) {
                 await addMessage(supportTicket.id, message);
-                if (userCanCompleteTicket) {
+                if (userCanCompleteTicket && !userIsTicketOwner) {
                   await updateTicket(supportTicket.id, { status: 'Completed' });
                 }
               } else {

--- a/src/pages/public_registration/action_accordions/SupportAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/SupportAccordion.tsx
@@ -14,7 +14,6 @@ import { Registration, RegistrationStatus } from '../../../types/registration.ty
 import { isErrorStatus, isSuccessStatus } from '../../../utils/constants';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { getTabErrors, validateRegistrationForm } from '../../../utils/formik-helpers/formik-helpers';
-import { getIdentifierFromId } from '../../../utils/general-helpers';
 import { userHasAccessRight } from '../../../utils/registration-helpers';
 import { UrlPathTemplate } from '../../../utils/urlPaths';
 import { TicketMessageList } from '../../messages/components/MessageList';
@@ -31,8 +30,9 @@ export const SupportAccordion = ({ registration, supportTicket, addMessage, refe
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const user = useSelector((store: RootState) => store.user);
-  const userCristinIdentifier = user && getIdentifierFromId(user.nvaUsername);
-  const userIsTicketOwner = supportTicket?.owner === userCristinIdentifier;
+  const userIsTicketOwner = user && supportTicket?.owner === user.nvaUsername;
+
+  console.log(user?.nvaUsername);
 
   const ticketMutation = useMutation({
     mutationFn: supportTicket

--- a/src/pages/public_registration/action_accordions/SupportAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/SupportAccordion.tsx
@@ -32,8 +32,6 @@ export const SupportAccordion = ({ registration, supportTicket, addMessage, refe
   const user = useSelector((store: RootState) => store.user);
   const userIsTicketOwner = user && supportTicket?.owner === user.nvaUsername;
 
-  console.log(user?.nvaUsername);
-
   const ticketMutation = useMutation({
     mutationFn: supportTicket
       ? (newTicketData: UpdateTicketData) => updateTicket(supportTicket.id, newTicketData)


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48165

Fixed an unwanted side-effect where a support-curator would autimatically approve their own ticket of they sent two consecutive messages.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
