### PR TITLE
Refresh session before refetching user attributes

### DIFF
--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -4,6 +4,14 @@ import { LocalStorageKey, USE_MOCK_DATA } from '../utils/constants';
 import { getCurrentPath } from '../utils/general-helpers';
 import { UrlPathTemplate } from '../utils/urlPaths';
 
+export const refreshSession = async () => {
+  try {
+    return await fetchAuthSession({ forceRefresh: true });
+  } catch {
+    return null;
+  }
+};
+
 export const getUserAttributes = async (): Promise<FeideUser | null> => {
   try {
     const userAttributes = (await fetchUserAttributes()) as FeideUser;

--- a/src/components/AcceptTermsDialog.tsx
+++ b/src/components/AcceptTermsDialog.tsx
@@ -4,7 +4,7 @@ import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Link, Typogr
 import { useMutation } from '@tanstack/react-query';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
-import { getUserAttributes } from '../api/authApi';
+import { getUserAttributes, refreshSession } from '../api/authApi';
 import { acceptTermsAndConditions } from '../api/roleApi';
 import { LanguageSelector } from '../layout/header/LanguageSelector';
 import { setNotification } from '../redux/notificationSlice';
@@ -25,9 +25,12 @@ export const AcceptTermsDialog = ({ newTermsUri }: AcceptTermsDialogProps) => {
     mutationFn: async () => {
       const acceptTermsResponse = await acceptTermsAndConditions(newTermsUri);
       if (acceptTermsResponse.data.termsConditionsUri) {
-        const newUserInfo = await getUserAttributes();
-        if (newUserInfo) {
-          dispatch(setUser(newUserInfo));
+        const newSession = await refreshSession();
+        if (newSession) {
+          const newUserInfo = await getUserAttributes();
+          if (newUserInfo) {
+            dispatch(setUser(newUserInfo));
+          }
         }
       }
     },


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47183

Tester ny flyt hvor vi refresher session før user attributes hentes etter at brukervilkår godkjennes. Vi har et håp om at dette skal gjøre at roller også oppdateres i user attributes. Merger dette til sandbox, til verifisering der, før det ev. går til develop om det virker som håpet.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
