### PR TITLE
Np 47979 simplify file null checking

### DIFF
--- a/src/pages/public_registration/public_files/FilesLandingPageAccordion.tsx
+++ b/src/pages/public_registration/public_files/FilesLandingPageAccordion.tsx
@@ -74,16 +74,7 @@ export const FilesLandingPageAccordion = ({ registration }: PublicRegistrationCo
     totalFiles === 0 &&
     !registration.associatedArtifacts.some(associatedArtifactIsNullArtifact);
 
-  if (
-    userCanUpdateRegistration &&
-    totalFiles === 0 &&
-    registration.associatedArtifacts.some((artifact) => artifact.type === 'NullAssociatedArtifact')
-  ) {
-    return null;
-  } else if (
-    !userCanUpdateRegistration &&
-    !associatedFiles.some((file) => file.type === 'OpenFile' || file.type === 'PendingOpenFile')
-  ) {
+  if (associatedFiles.length === 0 && !showLinkToUploadNewFiles) {
     return null;
   }
 

--- a/src/pages/public_registration/public_files/FilesLandingPageAccordion.tsx
+++ b/src/pages/public_registration/public_files/FilesLandingPageAccordion.tsx
@@ -3,8 +3,10 @@ import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Box, styled, Tab, Typography } from '@mui/material';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 import { LandingPageAccordion } from '../../../components/landing_page/LandingPageAccordion';
 import { SelectableButton } from '../../../components/SelectableButton';
+import { RootState } from '../../../redux/store';
 import { RegistrationStatus, RegistrationTab } from '../../../types/registration.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import {
@@ -41,6 +43,7 @@ const StyledTabLabelContainer = styled('div')({
 
 export const FilesLandingPageAccordion = ({ registration }: PublicRegistrationContentProps) => {
   const { t } = useTranslation();
+  const customer = useSelector((store: RootState) => store.customer);
 
   const userCanUpdateRegistration = userHasAccessRight(registration, 'update');
   const [selectedTab, setSelectedTab] = useState(FileTab.OpenFiles);
@@ -72,7 +75,9 @@ export const FilesLandingPageAccordion = ({ registration }: PublicRegistrationCo
   const showLinkToUploadNewFiles =
     userCanUpdateRegistration &&
     totalFiles === 0 &&
-    !registration.associatedArtifacts.some(associatedArtifactIsNullArtifact);
+    !registration.associatedArtifacts.some(associatedArtifactIsNullArtifact) &&
+    registration.entityDescription?.reference?.publicationInstance?.type &&
+    customer?.allowFileUploadForTypes.includes(registration.entityDescription.reference.publicationInstance.type);
 
   if (associatedFiles.length === 0 && !showLinkToUploadNewFiles) {
     return null;

--- a/src/pages/public_registration/public_files/FilesLandingPageAccordion.tsx
+++ b/src/pages/public_registration/public_files/FilesLandingPageAccordion.tsx
@@ -74,9 +74,20 @@ export const FilesLandingPageAccordion = ({ registration }: PublicRegistrationCo
     totalFiles === 0 &&
     !registration.associatedArtifacts.some(associatedArtifactIsNullArtifact);
 
-  return totalFiles > 0 ||
-    (userIsRegistrationAdmin && associatedFiles.length > 0) ||
-    (userIsRegistrationAdmin && registration.associatedArtifacts.length === 0) ? (
+  if (
+    userIsRegistrationAdmin &&
+    totalFiles === 0 &&
+    registration.associatedArtifacts.some((artifact) => artifact.type === 'NullAssociatedArtifact')
+  ) {
+    return null;
+  } else if (
+    !userIsRegistrationAdmin &&
+    !associatedFiles.some((file) => file.type === 'OpenFile' || file.type === 'PendingOpenFile')
+  ) {
+    return null;
+  }
+
+  return (
     <LandingPageAccordion
       dataTestId={dataTestId.registrationLandingPage.filesAccordion}
       defaultExpanded
@@ -208,5 +219,5 @@ export const FilesLandingPageAccordion = ({ registration }: PublicRegistrationCo
         ))
       )}
     </LandingPageAccordion>
-  ) : null;
+  );
 };

--- a/src/pages/public_registration/public_files/FilesLandingPageAccordion.tsx
+++ b/src/pages/public_registration/public_files/FilesLandingPageAccordion.tsx
@@ -42,7 +42,7 @@ const StyledTabLabelContainer = styled('div')({
 export const FilesLandingPageAccordion = ({ registration }: PublicRegistrationContentProps) => {
   const { t } = useTranslation();
 
-  const userIsRegistrationAdmin = userHasAccessRight(registration, 'update');
+  const userCanUpdateRegistration = userHasAccessRight(registration, 'update');
   const [selectedTab, setSelectedTab] = useState(FileTab.OpenFiles);
 
   const associatedFiles = getAssociatedFiles(registration.associatedArtifacts);
@@ -51,7 +51,7 @@ export const FilesLandingPageAccordion = ({ registration }: PublicRegistrationCo
   const pendingInternalFiles = associatedFiles.filter((file) => file.type === 'PendingInternalFile');
   const totalPendingFiles = pendingOpenFiles.length + pendingInternalFiles.length;
 
-  const openableFilesToShow = userIsRegistrationAdmin
+  const openableFilesToShow = userCanUpdateRegistration
     ? associatedFiles.filter((file) => isOpenFile(file) || isPendingOpenFile(file))
     : associatedFiles.filter(isOpenFile);
 
@@ -70,18 +70,18 @@ export const FilesLandingPageAccordion = ({ registration }: PublicRegistrationCo
     registration.status === RegistrationStatus.PublishedMetadata;
 
   const showLinkToUploadNewFiles =
-    userIsRegistrationAdmin &&
+    userCanUpdateRegistration &&
     totalFiles === 0 &&
     !registration.associatedArtifacts.some(associatedArtifactIsNullArtifact);
 
   if (
-    userIsRegistrationAdmin &&
+    userCanUpdateRegistration &&
     totalFiles === 0 &&
     registration.associatedArtifacts.some((artifact) => artifact.type === 'NullAssociatedArtifact')
   ) {
     return null;
   } else if (
-    !userIsRegistrationAdmin &&
+    !userCanUpdateRegistration &&
     !associatedFiles.some((file) => file.type === 'OpenFile' || file.type === 'PendingOpenFile')
   ) {
     return null;


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47979

Dette er gjort:
- Løst liten feil hvor Filer-accordion noen ganger ikke ble vist ved en feil
- Forenkle sjekken for når Filer-accordion skal vises

Vanskelig å være helt sikker på at dette ikke introduserer en ny liten bug i noen tilfeller, men om det dukker opp burde det gå ganske raskt å rette opp.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
