### PR TITLE
Avoid file table offset bug

### DIFF
--- a/src/pages/registration/FileList.tsx
+++ b/src/pages/registration/FileList.tsx
@@ -11,6 +11,7 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
+import { visuallyHidden } from '@mui/utils';
 import Uppy from '@uppy/core';
 import { useFormikContext } from 'formik';
 import { Trans, useTranslation } from 'react-i18next';
@@ -184,7 +185,9 @@ export const FileList = ({ title, files, uppy, remove, baseFieldName }: FileList
                       </HelperTextModal>
                     </Box>
                   </StyledTableCell>
-                  <TableCell />
+                  <TableCell>
+                    <span style={visuallyHidden}>{t('common.actions')}</span>
+                  </TableCell>
                 </>
               )}
             </TableRow>

--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -224,8 +224,8 @@ export const FilesTableRow = ({
         </VerticalAlignedTableCell>
         {showAllColumns && (
           <>
-            <VerticalAlignedTableCell>
-              {isOpenableFile && showFileVersion && (
+            {isOpenableFile && showFileVersion && (
+              <VerticalAlignedTableCell>
                 <Field name={publisherVersionFieldName}>
                   {({ field, meta: { error, touched } }: FieldProps<FileVersion | null>) => (
                     <FormControl data-testid={dataTestId.registrationWizard.files.version} required disabled={disabled}>
@@ -278,8 +278,8 @@ export const FilesTableRow = ({
                     </FormControl>
                   )}
                 </Field>
-              )}
-            </VerticalAlignedTableCell>
+              </VerticalAlignedTableCell>
+            )}
             <VerticalAlignedTableCell>
               {isOpenableFile && (
                 <>


### PR DESCRIPTION
# Description

Løs feil for offset i filtabell om man laster opp fil uten å ha valgt kategori.

La også til en skjult heading i kolonne lengst til venstre, for å fjerne en a11y error.

Før:
![bilde](https://github.com/user-attachments/assets/86a292b1-aa01-4c3d-8f18-25294a797aac)

Etter:
![bilde](https://github.com/user-attachments/assets/8aa51502-9a13-4d5b-803f-71a4d7710072)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
