### PR TITLE
Fix publishing bug for workflow 2

### DIFF
--- a/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
@@ -19,7 +19,11 @@ import { PublishingTicket } from '../../../types/publication_types/ticket.types'
 import { Registration, RegistrationStatus } from '../../../types/registration.types';
 import { isErrorStatus, isSuccessStatus } from '../../../utils/constants';
 import { dataTestId } from '../../../utils/dataTestIds';
-import { getTabErrors, validateRegistrationForm } from '../../../utils/formik-helpers/formik-helpers';
+import {
+  getTabErrors,
+  isPublishableForWorkflow2,
+  validateRegistrationForm,
+} from '../../../utils/formik-helpers/formik-helpers';
 import {
   getAssociatedFiles,
   isOpenFile,
@@ -27,7 +31,6 @@ import {
   userHasAccessRight,
 } from '../../../utils/registration-helpers';
 import { getRegistrationLandingPagePath } from '../../../utils/urlPaths';
-import { registrationPublishableValidationSchema } from '../../../utils/validation/registration/registrationValidation';
 import { PublishingLogPreview } from '../PublishingLogPreview';
 import { DuplicateWarningDialog } from './DuplicateWarningDialog';
 import { MoreActionsCollapse } from './MoreActionsCollapse';
@@ -85,7 +88,7 @@ export const PublishingAccordion = ({
   const canPublishMetadata =
     isDraftRegistration &&
     ((customer?.publicationWorkflow === 'RegistratorPublishesMetadataOnly' &&
-      registrationPublishableValidationSchema.isValidSync(registration)) ||
+      isPublishableForWorkflow2(registration)) ||
       (customer?.publicationWorkflow === 'RegistratorPublishesMetadataAndFiles' && registrationIsValid));
 
   const lastPublishingRequest =


### PR DESCRIPTION
# Description

Løst en feil hvor man noen ganger ikke fikk lov til å publisere et resultat pga valideringsfeil siden kategorien ikke ble sendt med som en context-variabel til valideringen. Dette førte til problemer for enkelte kategorier.
Ett eksempel er [denne](https://dev.nva.sikt.no/registration/0193d98b7dd7-4e8e0206-8ef7-4efb-8c39-56643e1ca6ab) posten, hvor man ikke fikk lov til å publisere om bidragsyter hadde rollen "Redaktør", men fikk lov med "Forfatter".

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
