### PR TITLE
NP-48263 Use new endpoint for fetching NVI reported year

### DIFF
--- a/src/api/apiPaths.ts
+++ b/src/api/apiPaths.ts
@@ -65,4 +65,5 @@ export enum ScientificIndexApiPath {
   InstitutionApprovalReport = '/scientific-index/institution-approval-report',
   InstitutionReport = '/scientific-index/institution-report',
   Period = '/scientific-index/period',
+  Publication = '/scientific-index/publication',
 }

--- a/src/api/hooks/useFetchNviReportedStatus.ts
+++ b/src/api/hooks/useFetchNviReportedStatus.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { RegistrationStatus } from '../../types/registration.types';
+import { fetchNviReportStatusForRegistration } from '../scientificIndexApi';
+
+export const useFetchNviReportedStatus = (registrationId: string, registrationStatus: RegistrationStatus) => {
+  return useQuery({
+    enabled: !!registrationId && registrationStatus !== RegistrationStatus.Draft,
+    queryKey: ['nviReportStatus', registrationId],
+    queryFn: () => fetchNviReportStatusForRegistration(registrationId),
+    retry: false,
+    meta: { errorMessage: false },
+  });
+};

--- a/src/api/scientificIndexApi.ts
+++ b/src/api/scientificIndexApi.ts
@@ -104,7 +104,6 @@ export const fetchNviReportStatusForRegistration = async (registrationId: string
   const fetchNviReportHistoryForRegistrationResponse = await apiRequest2<ReportStatusResponse>({
     url: `${ScientificIndexApiPath.Publication}/${encodeURIComponent(registrationId)}/report-status`,
   });
-
   return fetchNviReportHistoryForRegistrationResponse.data;
 };
 

--- a/src/api/scientificIndexApi.ts
+++ b/src/api/scientificIndexApi.ts
@@ -92,6 +92,22 @@ export const fetchNviCandidateForRegistration = async (registrationId: string) =
   return fetchNviCandidateForRegistrationResponse.data;
 };
 
+interface ReportStatusResponse {
+  publicationId: string;
+  reportStatus: {
+    status: 'PENDING_REVIEW' | 'REPORTED' | 'UNDER_REVIEW' | 'NOT_REPORTED' | 'NOT_CANDIDATE';
+  };
+  period: string;
+}
+
+export const fetchNviReportStatusForRegistration = async (registrationId: string) => {
+  const fetchNviReportHistoryForRegistrationResponse = await apiRequest2<ReportStatusResponse>({
+    url: `${ScientificIndexApiPath.Publication}/${encodeURIComponent(registrationId)}/report-status`,
+  });
+
+  return fetchNviReportHistoryForRegistrationResponse.data;
+};
+
 export const fetchNviInstitutionStatus = async (year: number) => {
   const fetchNviStatusResponse = await authenticatedApiRequest2<NviInstitutionStatusResponse>({
     url: `${ScientificIndexApiPath.InstitutionReport}/${year}`,

--- a/src/api/scientificIndexApi.ts
+++ b/src/api/scientificIndexApi.ts
@@ -101,10 +101,10 @@ interface ReportStatusResponse {
 }
 
 export const fetchNviReportStatusForRegistration = async (registrationId: string) => {
-  const fetchNviReportHistoryForRegistrationResponse = await apiRequest2<ReportStatusResponse>({
+  const fetchNviReportStatusResponse = await apiRequest2<ReportStatusResponse>({
     url: `${ScientificIndexApiPath.Publication}/${encodeURIComponent(registrationId)}/report-status`,
   });
-  return fetchNviReportHistoryForRegistrationResponse.data;
+  return fetchNviReportStatusResponse.data;
 };
 
 export const fetchNviInstitutionStatus = async (year: number) => {

--- a/src/pages/public_registration/PublicGeneralContent.tsx
+++ b/src/pages/public_registration/PublicGeneralContent.tsx
@@ -1,7 +1,7 @@
 import { Link, Typography } from '@mui/material';
 import { getLanguageByUri } from 'nva-language';
 import { useTranslation } from 'react-i18next';
-import { useFetchNviCandidateQuery } from '../../api/hooks/useFetchNviCandidateQuery';
+import { useFetchNviReportedStatus } from '../../api/hooks/useFetchNviReportedStatus';
 import { StyledGeneralInfo } from '../../components/styled/Wrappers';
 import disciplines from '../../resources/disciplines.json';
 import { ArtisticPublicationInstance } from '../../types/publication_types/artisticRegistration.types';
@@ -95,7 +95,7 @@ const prioritiseIdentifiersFromCristin = (a: AdditionalIdentifier, b: Additional
 export const PublicGeneralContent = ({ registration }: PublicRegistrationContentProps) => {
   const { t, i18n } = useTranslation();
   const { entityDescription, id, status } = registration;
-  const nviCandidateQuery = useFetchNviCandidateQuery(id, status);
+  const nviReportedStatus = useFetchNviReportedStatus(id, status);
 
   const publicationContext = entityDescription?.reference?.publicationContext;
   const publicationInstance = entityDescription?.reference?.publicationInstance;
@@ -113,10 +113,13 @@ export const PublicGeneralContent = ({ registration }: PublicRegistrationContent
     (identifier) => identifier.type === 'ScopusIdentifier' || identifier.sourceName === 'Scopus'
   )?.value;
 
-  const isNviReported = nviCandidateQuery.isSuccess && nviCandidateQuery.data.status === 'Reported';
-  const reportedYear = nviCandidateQuery.data?.period.year;
+  const publicationDateString = displayDate(entityDescription?.publicationDate);
+  const nviReportedYearString =
+    nviReportedStatus.data?.reportStatus.status === 'REPORTED' && nviReportedStatus.data.period
+      ? `(${t('basic_data.nvi.nvi_reporting_year')}: ${nviReportedStatus.data.period})`
+      : '';
 
-  const dateString = `${displayDate(entityDescription?.publicationDate)}${isNviReported && reportedYear ? ` (${t('basic_data.nvi.nvi_reporting_year')}: ${reportedYear})` : ''}`;
+  const dateString = [publicationDateString, nviReportedYearString].filter(Boolean).join(' ');
   const alternativeTitles = Object.values(registration.entityDescription?.alternativeTitles ?? {});
 
   return (


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48263

Bruk nytt endepunkt for å vise året et resultat ble NVI-rapportert. 
Vi ønsker sikkert å bruke samme endepunkt i wizard også, men det avhenger av: https://github.com/BIBSYSDEV/nva-nvi/pull/416 så det blir også egen PR for frontend

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
