### PR TITLE
NP-46405 Use icon instead of Badge in new tasks filter button

### DIFF
--- a/src/components/DialoguesWithoutCuratorButton.tsx
+++ b/src/components/DialoguesWithoutCuratorButton.tsx
@@ -1,7 +1,7 @@
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import NotificationsActiveIcon from '@mui/icons-material/NotificationsActiveOutlined';
-import { Badge, Button } from '@mui/material';
+import { Button } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -58,7 +58,16 @@ export const DialoguesWithoutCuratorButton = () => {
       startIcon={newStatusIsSelected ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
       endIcon={
         unassignedNotificationsCount > 0 ? (
-          <Badge badgeContent={<NotificationsActiveIcon fontSize="small" />} sx={{ ml: '1rem' }} />
+          <NotificationsActiveIcon
+            sx={{
+              width: '1.5rem',
+              height: '1.5rem',
+              bgcolor: 'info.main',
+              color: 'white',
+              borderRadius: '50%',
+              padding: '3px',
+            }}
+          />
         ) : undefined
       }
       onClick={toggleDialoguesWithoutCurators}


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-46405

Bruk bare ikon i stedet for ikon wrappet i Badge for filterknapp.

Før:
![bilde](https://github.com/user-attachments/assets/5186b88d-1c91-4abd-8ca6-bb3e78ddca7c)

Etter:
![bilde](https://github.com/user-attachments/assets/0f4a0931-7230-48b2-a70f-b5ceaa20830d)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
