### PR TITLE
NP-48317 Allow fetching more projects when searching

### DIFF
--- a/src/pages/registration/description_tab/projects_field/ProjectsField.tsx
+++ b/src/pages/registration/description_tab/projects_field/ProjectsField.tsx
@@ -2,9 +2,13 @@ import AddIcon from '@mui/icons-material/Add';
 import { Autocomplete, Box, Button, Divider, Typography } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { Field, FieldProps, useFormikContext } from 'formik';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { searchForProjects } from '../../../../api/cristinApi';
+import {
+  AutocompleteListboxWithExpansion,
+  AutocompleteListboxWithExpansionProps,
+} from '../../../../components/AutocompleteListboxWithExpansion';
 import { AutocompleteProjectOption } from '../../../../components/AutocompleteProjectOption';
 import { AutocompleteTextField } from '../../../../components/AutocompleteTextField';
 import { CristinProject, ResearchProject } from '../../../../types/project.types';
@@ -12,9 +16,12 @@ import { DescriptionFieldNames } from '../../../../types/publicationFieldNames';
 import { Registration } from '../../../../types/registration.types';
 import { dataTestId } from '../../../../utils/dataTestIds';
 import { useDebounce } from '../../../../utils/hooks/useDebounce';
+import { keepSimilarPreviousData } from '../../../../utils/searchHelpers';
 import { ProjectModal } from '../../../project/ProjectModal';
 import { HelperTextModal } from '../../HelperTextModal';
 import { ProjectItem } from './ProjectItem';
+
+const defaultProjectSearchSize = 10;
 
 export const ProjectsField = () => {
   const { t } = useTranslation();
@@ -23,11 +30,17 @@ export const ProjectsField = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const debouncedSearchTerm = useDebounce(searchTerm);
 
+  const [searchSize, setSearchSize] = useState(defaultProjectSearchSize);
+
+  // Reset search size when query changes
+  useEffect(() => setSearchSize(defaultProjectSearchSize), [debouncedSearchTerm]);
+
   const projectsQuery = useQuery({
     enabled: debouncedSearchTerm.length > 0,
-    queryKey: ['projects', 10, 1, debouncedSearchTerm],
-    queryFn: () => searchForProjects(10, 1, { query: debouncedSearchTerm }),
+    queryKey: ['projects', searchSize, 1, debouncedSearchTerm],
+    queryFn: () => searchForProjects(searchSize, 1, { query: debouncedSearchTerm }),
     meta: { errorMessage: t('feedback.error.project_search') },
+    placeholderData: (data, query) => keepSimilarPreviousData(data, query, debouncedSearchTerm),
   });
 
   const toggleOpenNewProject = () => setOpenNewProject(!openNewProject);
@@ -96,6 +109,16 @@ export const ProjectsField = () => {
                   value={(field.value ?? []) as any[]}
                   getOptionDisabled={(option) => field.value.some((project) => project.id === option.id)}
                   loading={projectsQuery.isFetching}
+                  slotProps={{
+                    listbox: {
+                      component: AutocompleteListboxWithExpansion,
+                      ...({
+                        hasMoreHits: !!projectsQuery.data?.size && projectsQuery.data.size > searchSize,
+                        onShowMoreHits: () => setSearchSize(searchSize + defaultProjectSearchSize),
+                        isLoadingMoreHits: projectsQuery.isFetching && searchSize > projects.length,
+                      } satisfies AutocompleteListboxWithExpansionProps),
+                    },
+                  }}
                   renderOption={({ key, ...props }, option: CristinProject, state) => (
                     <AutocompleteProjectOption
                       key={option.id}
@@ -108,9 +131,9 @@ export const ProjectsField = () => {
                     <AutocompleteTextField
                       {...params}
                       label={t('registration.description.project_association')}
-                      isLoading={projectsQuery.isFetching}
+                      isLoading={projectsQuery.isLoading}
                       placeholder={t('search.search_project_placeholder')}
-                      showSearchIcon={field.value.length === 0}
+                      showSearchIcon
                     />
                   )}
                   renderTags={() => null}


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48317

La bruker hente 10 flere treff for prosjektsøk

![bilde](https://github.com/user-attachments/assets/d429c915-4088-4804-a074-b38fc592ec16)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [ ] The changes are tested OK for a11y ("Vis flere"-knapp har en kjente [UU-problemer](https://sikt.atlassian.net/browse/NP-47207))
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
