### PR TITLE
NP-48316 Search for parent by query instead of title

### DIFF
--- a/src/pages/registration/resource_type_tab/components/SearchContainerField.tsx
+++ b/src/pages/registration/resource_type_tab/components/SearchContainerField.tsx
@@ -25,6 +25,7 @@ import { useDebounce } from '../../../../utils/hooks/useDebounce';
 import { useFetchResource } from '../../../../utils/hooks/useFetchResource';
 import { stringIncludesMathJax, typesetMathJax } from '../../../../utils/mathJaxHelpers';
 import { convertToRegistrationSearchItem, getTitleString } from '../../../../utils/registration-helpers';
+import { isValidIsbn } from '../../../../utils/searchHelpers';
 import { LockedNviFieldDescription } from '../../LockedNviFieldDescription';
 
 interface SearchContainerFieldProps {
@@ -51,10 +52,12 @@ export const SearchContainerField = ({
   const [query, setQuery] = useState('');
   const debouncedQuery = useDebounce(query);
 
+  const formattedDebouncedQuery = isValidIsbn(debouncedQuery) ? debouncedQuery.replaceAll('-', '') : debouncedQuery;
+
   const containerOptionsQuery = useQuery({
     enabled: debouncedQuery === query,
-    queryKey: ['container', debouncedQuery, searchSubtypes],
-    queryFn: () => fetchResults({ title: debouncedQuery, categoryShould: searchSubtypes, results: 25 }),
+    queryKey: ['container', formattedDebouncedQuery, searchSubtypes],
+    queryFn: () => fetchResults({ query: formattedDebouncedQuery, categoryShould: searchSubtypes, results: 25 }),
     meta: { errorMessage: t('feedback.error.search') },
   });
 


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48316

Legg til støtte for å sæke med ISBN når man skal ha parant til et kapittel. Formaterer ISBN til å være uten bindestreker når API-kallet gjøres.
Åpner nå opp for å søke etter enda flere ting også, ved å bruke query param i stedet for title.

![bilde](https://github.com/user-attachments/assets/79cda63b-8732-46a4-9519-1cca80d78673)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
