### PR TITLE
NP-48329 Fjerner tøm-knapp for input-felt prosjekttilknytning

### DIFF
--- a/src/pages/registration/description_tab/projects_field/ProjectsField.tsx
+++ b/src/pages/registration/description_tab/projects_field/ProjectsField.tsx
@@ -106,6 +106,7 @@ export const ProjectsField = () => {
                   }}
                   popupIcon={null}
                   multiple
+                  disableClearable
                   value={(field.value ?? []) as any[]}
                   getOptionDisabled={(option) => field.value.some((project) => project.id === option.id)}
                   loading={projectsQuery.isFetching}


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-48329](https://sikt.atlassian.net/browse/NP-48329)

Fjerner tøm-knapp for input-felt prosjekttilknytning, da denne fjerner valgte prosjekttilknytninger i listen under. Ettersom input-feltet er en modifisert `<Autocomplete multiple ...`> som ikke viser valgte elementer i input-feltet, så er det forvirrende med en tøm-knapp som manipulerer listen under.

![image](https://github.com/user-attachments/assets/ee87f46f-aa01-4a5a-88ae-411c2e343afc)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [ ] The changes are tested OK for different screen sizes
- [ ] The changes are tested OK for a11y
- [ ] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-48329]: https://sikt.atlassian.net/browse/NP-48329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ