### PR TITLE
NP-48331 Align HRCS input

### DIFF
--- a/src/pages/registration/description_tab/vocabularies/VocabularyAutocomplete.tsx
+++ b/src/pages/registration/description_tab/vocabularies/VocabularyAutocomplete.tsx
@@ -46,6 +46,7 @@ export const VocabularyAutocomplete = ({
         }
       }}
       multiple
+      fullWidth
       renderInput={(params) => <TextField {...params} label={label} variant="filled" />}
     />
   );

--- a/src/pages/registration/description_tab/vocabularies/VocabularyFields.tsx
+++ b/src/pages/registration/description_tab/vocabularies/VocabularyFields.tsx
@@ -82,7 +82,7 @@ export const VocabularyFields = ({ defaultVocabularies, allowedVocabularies }: V
                 <Box
                   key={vocabulary}
                   data-testid={dataTestId.registrationWizard.description.vocabularyRow(vocabulary)}
-                  sx={{ display: 'flex' }}>
+                  sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' } }}>
                   <VocabularyComponent
                     selectedIds={selectedIds}
                     addValue={push}

--- a/src/pages/registration/description_tab/vocabularies/VocabularyFields.tsx
+++ b/src/pages/registration/description_tab/vocabularies/VocabularyFields.tsx
@@ -97,7 +97,7 @@ export const VocabularyFields = ({ defaultVocabularies, allowedVocabularies }: V
                   {!defaultVocabularyKeys.includes(vocabulary) && (
                     <>
                       <Button
-                        sx={{ ml: '2rem', minWidth: 'max-content' }}
+                        sx={{ ml: { xs: '0', sm: '2rem' }, minWidth: 'max-content' }}
                         color="error"
                         startIcon={<RemoveCircleIcon />}
                         onClick={() => setVocabularyToRemove(vocabulary)}>

--- a/src/pages/registration/description_tab/vocabularies/VocabularyFields.tsx
+++ b/src/pages/registration/description_tab/vocabularies/VocabularyFields.tsx
@@ -82,12 +82,7 @@ export const VocabularyFields = ({ defaultVocabularies, allowedVocabularies }: V
                 <Box
                   key={vocabulary}
                   data-testid={dataTestId.registrationWizard.description.vocabularyRow(vocabulary)}
-                  sx={{
-                    display: 'grid',
-                    gridTemplateColumns: { xs: '1fr', sm: '4fr auto' },
-                    columnGap: '2rem',
-                    rowGap: '0.5rem',
-                  }}>
+                  sx={{ display: 'flex' }}>
                   <VocabularyComponent
                     selectedIds={selectedIds}
                     addValue={push}
@@ -102,7 +97,7 @@ export const VocabularyFields = ({ defaultVocabularies, allowedVocabularies }: V
                   {!defaultVocabularyKeys.includes(vocabulary) && (
                     <>
                       <Button
-                        sx={{ height: 'fit-content', alignSelf: 'center' }}
+                        sx={{ ml: '2rem', minWidth: 'max-content' }}
                         color="error"
                         startIcon={<RemoveCircleIcon />}
                         onClick={() => setVocabularyToRemove(vocabulary)}>


### PR DESCRIPTION
# Description

Link to Jira [NP-48331:](https://sikt.atlassian.net/browse/NP-48331)

Få input-felt HRCS-aktiviteter på linje med resten av input

<img width="1444" alt="image" src="https://github.com/user-attachments/assets/849221eb-b77a-42df-a712-d5d7f07d4d38" />


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [ ] The changes are tested OK for a11y
- [ ] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
