### PR TITLE
Add version for new search model for search/customer

### DIFF
--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -596,6 +596,7 @@ export const fetchCustomerResults = async (params: FetchCustomerResultsParams, s
     SearchResponse2<RegistrationSearchItem, RegistrationAggregations>
   >({
     url: `${SearchApiPath.CustomerRegistrations}?${searchParams.toString()}`,
+    headers: { accept: 'application/json; version=2024-12-01' },
     signal,
   });
 


### PR DESCRIPTION
Per i dag fungerer ikke søket om man med `status=PUBLISHED`, men om man legger med `query` får man treff. Tenker vi bare kan pushe til FE da det "fikser" litt av problemet.