### PR TITLE
Adjust tagline and description

### DIFF
--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -40,13 +40,14 @@ const Dashboard = () => {
         <Box sx={{ bgcolor: 'secondary.main', p: '1rem 0.5rem', width: '100%' }}>
           <Box
             sx={{
+              justifyItems: 'center',
               gridArea: 'tagline',
               display: 'grid',
               gridTemplateAreas: {
                 xs: "'text-tagline close-button' 'short-description short-description'",
-                md: "'. . text-tagline close-button' '. . short-description .'",
+                md: "'. text-tagline close-button' '. short-description .'",
               },
-              gridTemplateColumns: { xs: '1fr', md: '1fr 1fr 2.5fr 1fr' },
+              gridTemplateColumns: { xs: '1fr', md: '1fr 2.5fr 1fr' },
             }}>
             <Typography
               variant="h1"
@@ -70,21 +71,27 @@ const Dashboard = () => {
             <Typography
               variant="h3"
               variantMapping={{ h3: 'p' }}
-              sx={{ mt: '1.5rem', maxWidth: '40rem', gridArea: 'short-description', whiteSpace: 'pre-wrap' }}>
+              sx={{
+                mt: '1.5rem',
+                maxWidth: '45rem',
+                gridArea: 'short-description',
+                whiteSpace: 'pre-wrap',
+              }}>
               {t('about.short_description')}
             </Typography>
           </Box>
           <Box
             sx={{
+              justifyItems: 'center',
               gridArea: 'description',
               display: 'grid',
               gridTemplateAreas: {
                 xs: "'button' 'text-description'",
-                md: "'. . button .' '. . text-description .'",
+                md: "'. button .' '. text-description .'",
               },
-              gridTemplateColumns: { xs: '1fr', md: '1fr 1fr 2.5fr 1fr' },
+              gridTemplateColumns: { xs: '1fr', md: '1fr 2.5fr 1fr' },
             }}>
-            <Collapse in={readMore} sx={{ gridArea: 'text-description', mt: '1rem', maxWidth: '40rem' }}>
+            <Collapse in={readMore} sx={{ gridArea: 'text-description', mt: '1rem', maxWidth: '45rem' }}>
               <AboutContent />
             </Collapse>
             <Box sx={{ mt: '1rem', gridArea: 'button' }}>

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -44,7 +44,7 @@ const Dashboard = () => {
               display: 'grid',
               gridTemplateAreas: {
                 xs: "'text-tagline close-button' 'short-description short-description'",
-                md: "'. text-tagline text-tagline close-button' '. . short-description .'",
+                md: "'. . text-tagline close-button' '. . short-description .'",
               },
               gridTemplateColumns: { xs: '1fr', md: '1fr 1fr 2.5fr 1fr' },
             }}>

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -80,11 +80,11 @@ const Dashboard = () => {
               display: 'grid',
               gridTemplateAreas: {
                 xs: "'button' 'text-description'",
-                md: "'. . button .' '. text-description text-description .'",
+                md: "'. . button .' '. . text-description .'",
               },
               gridTemplateColumns: { xs: '1fr', md: '1fr 1fr 2.5fr 1fr' },
             }}>
-            <Collapse in={readMore} sx={{ gridArea: 'text-description', mt: '1rem' }}>
+            <Collapse in={readMore} sx={{ gridArea: 'text-description', mt: '1rem', maxWidth: '40rem' }}>
               <AboutContent />
             </Collapse>
             <Box sx={{ mt: '1rem', gridArea: 'button' }}>


### PR DESCRIPTION
Suggestion for centering the banner-content on start-page.

Before:
![Screenshot 2025-01-09 at 11 07 05](https://github.com/user-attachments/assets/c385e03d-0e57-4eeb-b97c-068b4bf7121b)

After:
![Screenshot 2025-01-09 at 11 06 12](https://github.com/user-attachments/assets/aca1586a-186d-480b-8524-db1e5f452e8a)
