### PR TITLE
Np 47983 update ticket status boxes

### DIFF
--- a/src/pages/messages/components/DoiRequestMessagesColumn.tsx
+++ b/src/pages/messages/components/DoiRequestMessagesColumn.tsx
@@ -14,9 +14,10 @@ import {
 
 interface DoiRequestMessagesColumnProps {
   ticket: ExpandedTicket | Ticket;
+  showLastMessage?: boolean;
 }
 
-export const DoiRequestMessagesColumn = ({ ticket }: DoiRequestMessagesColumnProps) => {
+export const DoiRequestMessagesColumn = ({ ticket, showLastMessage }: DoiRequestMessagesColumnProps) => {
   const { t } = useTranslation();
 
   return (
@@ -29,7 +30,7 @@ export const DoiRequestMessagesColumn = ({ ticket }: DoiRequestMessagesColumnPro
               <Typography>{t('my_page.messages.doi_pending')}</Typography>
             </StyledIconAndTextWrapper>
           </StyledStatusMessageBox>
-          <LastMessageBox ticket={ticket as ExpandedTicket} />
+          {showLastMessage && <LastMessageBox ticket={ticket as ExpandedTicket} />}
         </>
       ) : ticket.status === 'Completed' ? (
         <StyledStatusMessageBox sx={{ bgcolor: 'doiRequest.main' }}>
@@ -48,7 +49,7 @@ export const DoiRequestMessagesColumn = ({ ticket }: DoiRequestMessagesColumnPro
             </StyledIconAndTextWrapper>
             {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}
           </StyledStatusMessageBox>
-          <LastMessageBox ticket={ticket as ExpandedTicket} />
+          {showLastMessage && <LastMessageBox ticket={ticket as ExpandedTicket} />}
         </>
       ) : null}
     </StyledMessagesContainer>

--- a/src/pages/messages/components/DoiRequestMessagesColumn.tsx
+++ b/src/pages/messages/components/DoiRequestMessagesColumn.tsx
@@ -20,31 +20,34 @@ export const DoiRequestMessagesColumn = ({ ticket, showLastMessage }: DoiRequest
     <StyledMessagesContainer>
       {ticket.status === 'New' || ticket.status === 'Pending' ? (
         <>
-          {showLastMessage && <LastMessageBox ticket={ticket as ExpandedTicket} />}
           <StyledStatusMessageBox sx={{ bgcolor: 'secondary.dark' }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
               <HourglassEmptyIcon fontSize="small" />
               <Typography>{t('my_page.messages.doi_pending')}</Typography>
             </Box>
           </StyledStatusMessageBox>
+          {showLastMessage && <LastMessageBox ticket={ticket as ExpandedTicket} />}
         </>
       ) : (
         <>
-          {showLastMessage && <LastMessageBox ticket={ticket as ExpandedTicket} />}
-          <StyledStatusMessageBox sx={{ bgcolor: 'doiRequest.main' }}>
-            {ticket.status === 'Completed' ? (
+          {ticket.status === 'Completed' ? (
+            <StyledStatusMessageBox sx={{ bgcolor: 'doiRequest.main' }}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
                 <CheckIcon fontSize="small" />
                 <Typography>{t('my_page.messages.doi_completed')}</Typography>
               </Box>
-            ) : ticket.status === 'Closed' ? (
+              {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}
+            </StyledStatusMessageBox>
+          ) : ticket.status === 'Closed' ? (
+            <StyledStatusMessageBox sx={{ bgcolor: 'secondary.dark' }}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
                 <BlockIcon fontSize="small" />
                 <Typography>{t('my_page.messages.doi_closed')}</Typography>
               </Box>
-            ) : null}
-            {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}
-          </StyledStatusMessageBox>
+              {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}
+            </StyledStatusMessageBox>
+          ) : null}
+          {showLastMessage && <LastMessageBox ticket={ticket as ExpandedTicket} />}
         </>
       )}
     </StyledMessagesContainer>

--- a/src/pages/messages/components/DoiRequestMessagesColumn.tsx
+++ b/src/pages/messages/components/DoiRequestMessagesColumn.tsx
@@ -14,10 +14,9 @@ import {
 
 interface DoiRequestMessagesColumnProps {
   ticket: ExpandedTicket | Ticket;
-  showLastMessage?: boolean;
 }
 
-export const DoiRequestMessagesColumn = ({ ticket, showLastMessage }: DoiRequestMessagesColumnProps) => {
+export const DoiRequestMessagesColumn = ({ ticket }: DoiRequestMessagesColumnProps) => {
   const { t } = useTranslation();
 
   return (
@@ -30,7 +29,7 @@ export const DoiRequestMessagesColumn = ({ ticket, showLastMessage }: DoiRequest
               <Typography>{t('my_page.messages.doi_pending')}</Typography>
             </StyledIconAndTextWrapper>
           </StyledStatusMessageBox>
-          {showLastMessage && <LastMessageBox ticket={ticket as ExpandedTicket} />}
+          <LastMessageBox ticket={ticket as ExpandedTicket} />
         </>
       ) : ticket.status === 'Completed' ? (
         <StyledStatusMessageBox sx={{ bgcolor: 'doiRequest.main' }}>
@@ -49,7 +48,7 @@ export const DoiRequestMessagesColumn = ({ ticket, showLastMessage }: DoiRequest
             </StyledIconAndTextWrapper>
             {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}
           </StyledStatusMessageBox>
-          {showLastMessage && <LastMessageBox ticket={ticket as ExpandedTicket} />}
+          <LastMessageBox ticket={ticket as ExpandedTicket} />
         </>
       ) : null}
     </StyledMessagesContainer>

--- a/src/pages/messages/components/DoiRequestMessagesColumn.tsx
+++ b/src/pages/messages/components/DoiRequestMessagesColumn.tsx
@@ -1,12 +1,16 @@
 import BlockIcon from '@mui/icons-material/Block';
 import CheckIcon from '@mui/icons-material/Check';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
-import { Box, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { ExpandedTicket, Ticket } from '../../../types/publication_types/ticket.types';
 import { toDateString } from '../../../utils/date-helpers';
 import { LastMessageBox } from './LastMessageBox';
-import { StyledMessagesContainer, StyledStatusMessageBox } from './PublishingRequestMessagesColumn';
+import {
+  StyledIconAndTextWrapper,
+  StyledMessagesContainer,
+  StyledStatusMessageBox,
+} from './PublishingRequestMessagesColumn';
 
 interface DoiRequestMessagesColumnProps {
   ticket: ExpandedTicket | Ticket;
@@ -21,28 +25,28 @@ export const DoiRequestMessagesColumn = ({ ticket, showLastMessage }: DoiRequest
       {ticket.status === 'New' || ticket.status === 'Pending' ? (
         <>
           <StyledStatusMessageBox sx={{ bgcolor: 'secondary.dark' }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
+            <StyledIconAndTextWrapper>
               <HourglassEmptyIcon fontSize="small" />
               <Typography>{t('my_page.messages.doi_pending')}</Typography>
-            </Box>
+            </StyledIconAndTextWrapper>
           </StyledStatusMessageBox>
           {showLastMessage && <LastMessageBox ticket={ticket as ExpandedTicket} />}
         </>
       ) : ticket.status === 'Completed' ? (
         <StyledStatusMessageBox sx={{ bgcolor: 'doiRequest.main' }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
+          <StyledIconAndTextWrapper>
             <CheckIcon fontSize="small" />
             <Typography>{t('my_page.messages.doi_completed')}</Typography>
-          </Box>
+          </StyledIconAndTextWrapper>
           {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}
         </StyledStatusMessageBox>
       ) : ticket.status === 'Closed' ? (
         <>
           <StyledStatusMessageBox sx={{ bgcolor: 'secondary.dark' }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
+            <StyledIconAndTextWrapper>
               <BlockIcon fontSize="small" />
               <Typography>{t('my_page.messages.doi_closed')}</Typography>
-            </Box>
+            </StyledIconAndTextWrapper>
             {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}
           </StyledStatusMessageBox>
           {showLastMessage && <LastMessageBox ticket={ticket as ExpandedTicket} />}

--- a/src/pages/messages/components/DoiRequestMessagesColumn.tsx
+++ b/src/pages/messages/components/DoiRequestMessagesColumn.tsx
@@ -28,28 +28,26 @@ export const DoiRequestMessagesColumn = ({ ticket, showLastMessage }: DoiRequest
           </StyledStatusMessageBox>
           {showLastMessage && <LastMessageBox ticket={ticket as ExpandedTicket} />}
         </>
-      ) : (
+      ) : ticket.status === 'Completed' ? (
+        <StyledStatusMessageBox sx={{ bgcolor: 'doiRequest.main' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
+            <CheckIcon fontSize="small" />
+            <Typography>{t('my_page.messages.doi_completed')}</Typography>
+          </Box>
+          {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}
+        </StyledStatusMessageBox>
+      ) : ticket.status === 'Closed' ? (
         <>
-          {ticket.status === 'Completed' ? (
-            <StyledStatusMessageBox sx={{ bgcolor: 'doiRequest.main' }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
-                <CheckIcon fontSize="small" />
-                <Typography>{t('my_page.messages.doi_completed')}</Typography>
-              </Box>
-              {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}
-            </StyledStatusMessageBox>
-          ) : ticket.status === 'Closed' ? (
-            <StyledStatusMessageBox sx={{ bgcolor: 'secondary.dark' }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
-                <BlockIcon fontSize="small" />
-                <Typography>{t('my_page.messages.doi_closed')}</Typography>
-              </Box>
-              {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}
-            </StyledStatusMessageBox>
-          ) : null}
+          <StyledStatusMessageBox sx={{ bgcolor: 'secondary.dark' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
+              <BlockIcon fontSize="small" />
+              <Typography>{t('my_page.messages.doi_closed')}</Typography>
+            </Box>
+            {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}
+          </StyledStatusMessageBox>
           {showLastMessage && <LastMessageBox ticket={ticket as ExpandedTicket} />}
         </>
-      )}
+      ) : null}
     </StyledMessagesContainer>
   );
 };

--- a/src/pages/messages/components/DoiRequestMessagesColumn.tsx
+++ b/src/pages/messages/components/DoiRequestMessagesColumn.tsx
@@ -1,4 +1,5 @@
-import { Typography } from '@mui/material';
+import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
+import { Box, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { ExpandedTicket, Ticket } from '../../../types/publication_types/ticket.types';
 import { toDateString } from '../../../utils/date-helpers';
@@ -19,7 +20,10 @@ export const DoiRequestMessagesColumn = ({ ticket, showLastMessage }: DoiRequest
         <>
           {showLastMessage && <LastMessageBox ticket={ticket as ExpandedTicket} />}
           <StyledStatusMessageBox sx={{ bgcolor: 'secondary.dark' }}>
-            <Typography>{t('my_page.messages.doi_pending')}</Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              <HourglassEmptyIcon fontSize="small" />
+              <Typography>{t('my_page.messages.doi_pending')}</Typography>
+            </Box>
           </StyledStatusMessageBox>
         </>
       ) : (

--- a/src/pages/messages/components/DoiRequestMessagesColumn.tsx
+++ b/src/pages/messages/components/DoiRequestMessagesColumn.tsx
@@ -1,3 +1,5 @@
+import BlockIcon from '@mui/icons-material/Block';
+import CheckIcon from '@mui/icons-material/Check';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 import { Box, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
@@ -20,7 +22,7 @@ export const DoiRequestMessagesColumn = ({ ticket, showLastMessage }: DoiRequest
         <>
           {showLastMessage && <LastMessageBox ticket={ticket as ExpandedTicket} />}
           <StyledStatusMessageBox sx={{ bgcolor: 'secondary.dark' }}>
-            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
               <HourglassEmptyIcon fontSize="small" />
               <Typography>{t('my_page.messages.doi_pending')}</Typography>
             </Box>
@@ -31,9 +33,15 @@ export const DoiRequestMessagesColumn = ({ ticket, showLastMessage }: DoiRequest
           {showLastMessage && <LastMessageBox ticket={ticket as ExpandedTicket} />}
           <StyledStatusMessageBox sx={{ bgcolor: 'doiRequest.main' }}>
             {ticket.status === 'Completed' ? (
-              <Typography>{t('my_page.messages.doi_completed')}</Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
+                <CheckIcon fontSize="small" />
+                <Typography>{t('my_page.messages.doi_completed')}</Typography>
+              </Box>
             ) : ticket.status === 'Closed' ? (
-              <Typography>{t('my_page.messages.doi_closed')}</Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
+                <BlockIcon fontSize="small" />
+                <Typography>{t('my_page.messages.doi_closed')}</Typography>
+              </Box>
             ) : null}
             {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}
           </StyledStatusMessageBox>

--- a/src/pages/messages/components/PublishingRequestMessagesColumn.tsx
+++ b/src/pages/messages/components/PublishingRequestMessagesColumn.tsx
@@ -21,6 +21,12 @@ export const StyledStatusMessageBox = styled(Box)({
   borderRadius: '4px',
 });
 
+export const StyledIconAndTextWrapper = styled(Box)({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.2rem',
+});
+
 interface PublishingRequestMessagesColumnProps {
   ticket: ExpandedPublishingTicket | PublishingTicket;
   showLastMessage?: boolean;
@@ -35,35 +41,35 @@ export const PublishingRequestMessagesColumn = ({ ticket, showLastMessage }: Pub
         <>
           {ticket.filesForApproval.length > 0 && (
             <StyledStatusMessageBox sx={{ bgcolor: 'secondary.dark' }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
+              <StyledIconAndTextWrapper>
                 <HourglassEmptyIcon fontSize="small" />
                 <Typography>
                   {t('registration.files_and_license.files_awaits_approval', { count: ticket.filesForApproval.length })}
                 </Typography>
-              </Box>
+              </StyledIconAndTextWrapper>
             </StyledStatusMessageBox>
           )}
           {showLastMessage && <LastMessageBox ticket={ticket as ExpandedPublishingTicket} />}
         </>
       ) : ticket.status === 'Completed' ? (
         <StyledStatusMessageBox sx={{ bgcolor: 'publishingRequest.main' }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
+          <StyledIconAndTextWrapper>
             <CheckIcon fontSize="small" />
             <Typography>
               {ticket.approvedFiles.length
                 ? t('my_page.messages.files_published', { count: ticket.approvedFiles.length })
                 : t('my_page.messages.metadata_published')}
             </Typography>
-          </Box>
+          </StyledIconAndTextWrapper>
           {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}
         </StyledStatusMessageBox>
       ) : ticket.status === 'Closed' ? (
         <>
           <StyledStatusMessageBox sx={{ bgcolor: 'secondary.dark' }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
+            <StyledIconAndTextWrapper>
               <BlockIcon fontSize="small" />
               <Typography>{t('my_page.messages.files_rejected', { count: ticket.filesForApproval.length })}</Typography>
-            </Box>
+            </StyledIconAndTextWrapper>
             {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}
           </StyledStatusMessageBox>
           {showLastMessage && <LastMessageBox ticket={ticket as ExpandedPublishingTicket} />}

--- a/src/pages/messages/components/PublishingRequestMessagesColumn.tsx
+++ b/src/pages/messages/components/PublishingRequestMessagesColumn.tsx
@@ -45,33 +45,30 @@ export const PublishingRequestMessagesColumn = ({ ticket, showLastMessage }: Pub
           )}
           {showLastMessage && <LastMessageBox ticket={ticket as ExpandedPublishingTicket} />}
         </>
-      ) : (
+      ) : ticket.status === 'Completed' ? (
+        <StyledStatusMessageBox sx={{ bgcolor: 'publishingRequest.main' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
+            <CheckIcon fontSize="small" />
+            <Typography>
+              {ticket.approvedFiles.length
+                ? t('my_page.messages.files_published', { count: ticket.approvedFiles.length })
+                : t('my_page.messages.metadata_published')}
+            </Typography>
+          </Box>
+          {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}
+        </StyledStatusMessageBox>
+      ) : ticket.status === 'Closed' ? (
         <>
-          <StyledStatusMessageBox sx={{ bgcolor: 'publishingRequest.main' }}>
-            {ticket.status === 'Completed' ? (
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
-                <CheckIcon fontSize="small" />
-                <Typography>
-                  {ticket.approvedFiles.length
-                    ? t('my_page.messages.files_published', { count: ticket.approvedFiles.length })
-                    : t('my_page.messages.metadata_published')}
-                </Typography>
-              </Box>
-            ) : (
-              ticket.status === 'Closed' && (
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
-                  <BlockIcon fontSize="small" />
-                  <Typography>
-                    {t('my_page.messages.files_rejected', { count: ticket.filesForApproval.length })}
-                  </Typography>
-                </Box>
-              )
-            )}
+          <StyledStatusMessageBox sx={{ bgcolor: 'secondary.dark' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
+              <BlockIcon fontSize="small" />
+              <Typography>{t('my_page.messages.files_rejected', { count: ticket.filesForApproval.length })}</Typography>
+            </Box>
             {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}
           </StyledStatusMessageBox>
           {showLastMessage && <LastMessageBox ticket={ticket as ExpandedPublishingTicket} />}
         </>
-      )}
+      ) : null}
     </StyledMessagesContainer>
   );
 };

--- a/src/pages/messages/components/PublishingRequestMessagesColumn.tsx
+++ b/src/pages/messages/components/PublishingRequestMessagesColumn.tsx
@@ -1,3 +1,4 @@
+import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 import { Box, styled, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { ExpandedPublishingTicket, PublishingTicket } from '../../../types/publication_types/ticket.types';
@@ -33,9 +34,12 @@ export const PublishingRequestMessagesColumn = ({ ticket, showLastMessage }: Pub
           {showLastMessage && <LastMessageBox ticket={ticket as ExpandedPublishingTicket} />}
           {ticket.filesForApproval.length > 0 && (
             <StyledStatusMessageBox sx={{ bgcolor: 'secondary.dark' }}>
-              <Typography>
-                {t('registration.files_and_license.files_awaits_approval', { count: ticket.filesForApproval.length })}
-              </Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                <HourglassEmptyIcon fontSize="small" />
+                <Typography>
+                  {t('registration.files_and_license.files_awaits_approval', { count: ticket.filesForApproval.length })}
+                </Typography>
+              </Box>
             </StyledStatusMessageBox>
           )}
         </>

--- a/src/pages/messages/components/PublishingRequestMessagesColumn.tsx
+++ b/src/pages/messages/components/PublishingRequestMessagesColumn.tsx
@@ -17,7 +17,7 @@ export const StyledStatusMessageBox = styled(Box)({
   display: 'grid',
   gridTemplateColumns: '1fr auto',
   gap: '0.25rem 0.5rem',
-  padding: '0.2rem 1rem',
+  padding: '0.2rem 0.5rem',
   borderRadius: '4px',
 });
 

--- a/src/pages/messages/components/PublishingRequestMessagesColumn.tsx
+++ b/src/pages/messages/components/PublishingRequestMessagesColumn.tsx
@@ -33,7 +33,6 @@ export const PublishingRequestMessagesColumn = ({ ticket, showLastMessage }: Pub
     <StyledMessagesContainer>
       {ticket.status === 'Pending' || ticket.status === 'New' ? (
         <>
-          {showLastMessage && <LastMessageBox ticket={ticket as ExpandedPublishingTicket} />}
           {ticket.filesForApproval.length > 0 && (
             <StyledStatusMessageBox sx={{ bgcolor: 'secondary.dark' }}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
@@ -44,10 +43,10 @@ export const PublishingRequestMessagesColumn = ({ ticket, showLastMessage }: Pub
               </Box>
             </StyledStatusMessageBox>
           )}
+          {showLastMessage && <LastMessageBox ticket={ticket as ExpandedPublishingTicket} />}
         </>
       ) : (
         <>
-          {showLastMessage && <LastMessageBox ticket={ticket as ExpandedPublishingTicket} />}
           <StyledStatusMessageBox sx={{ bgcolor: 'publishingRequest.main' }}>
             {ticket.status === 'Completed' ? (
               <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
@@ -70,6 +69,7 @@ export const PublishingRequestMessagesColumn = ({ ticket, showLastMessage }: Pub
             )}
             {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}
           </StyledStatusMessageBox>
+          {showLastMessage && <LastMessageBox ticket={ticket as ExpandedPublishingTicket} />}
         </>
       )}
     </StyledMessagesContainer>

--- a/src/pages/messages/components/PublishingRequestMessagesColumn.tsx
+++ b/src/pages/messages/components/PublishingRequestMessagesColumn.tsx
@@ -29,10 +29,9 @@ export const StyledIconAndTextWrapper = styled(Box)({
 
 interface PublishingRequestMessagesColumnProps {
   ticket: ExpandedPublishingTicket | PublishingTicket;
-  showLastMessage?: boolean;
 }
 
-export const PublishingRequestMessagesColumn = ({ ticket, showLastMessage }: PublishingRequestMessagesColumnProps) => {
+export const PublishingRequestMessagesColumn = ({ ticket }: PublishingRequestMessagesColumnProps) => {
   const { t } = useTranslation();
 
   return (
@@ -49,7 +48,7 @@ export const PublishingRequestMessagesColumn = ({ ticket, showLastMessage }: Pub
               </StyledIconAndTextWrapper>
             </StyledStatusMessageBox>
           )}
-          {showLastMessage && <LastMessageBox ticket={ticket as ExpandedPublishingTicket} />}
+          <LastMessageBox ticket={ticket as ExpandedPublishingTicket} />
         </>
       ) : ticket.status === 'Completed' ? (
         <StyledStatusMessageBox sx={{ bgcolor: 'publishingRequest.main' }}>
@@ -72,7 +71,7 @@ export const PublishingRequestMessagesColumn = ({ ticket, showLastMessage }: Pub
             </StyledIconAndTextWrapper>
             {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}
           </StyledStatusMessageBox>
-          {showLastMessage && <LastMessageBox ticket={ticket as ExpandedPublishingTicket} />}
+          <LastMessageBox ticket={ticket as ExpandedPublishingTicket} />
         </>
       ) : null}
     </StyledMessagesContainer>

--- a/src/pages/messages/components/PublishingRequestMessagesColumn.tsx
+++ b/src/pages/messages/components/PublishingRequestMessagesColumn.tsx
@@ -1,3 +1,5 @@
+import BlockIcon from '@mui/icons-material/Block';
+import CheckIcon from '@mui/icons-material/Check';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 import { Box, styled, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
@@ -34,7 +36,7 @@ export const PublishingRequestMessagesColumn = ({ ticket, showLastMessage }: Pub
           {showLastMessage && <LastMessageBox ticket={ticket as ExpandedPublishingTicket} />}
           {ticket.filesForApproval.length > 0 && (
             <StyledStatusMessageBox sx={{ bgcolor: 'secondary.dark' }}>
-              <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
                 <HourglassEmptyIcon fontSize="small" />
                 <Typography>
                   {t('registration.files_and_license.files_awaits_approval', { count: ticket.filesForApproval.length })}
@@ -48,16 +50,22 @@ export const PublishingRequestMessagesColumn = ({ ticket, showLastMessage }: Pub
           {showLastMessage && <LastMessageBox ticket={ticket as ExpandedPublishingTicket} />}
           <StyledStatusMessageBox sx={{ bgcolor: 'publishingRequest.main' }}>
             {ticket.status === 'Completed' ? (
-              <Typography>
-                {ticket.approvedFiles.length
-                  ? t('my_page.messages.files_published', { count: ticket.approvedFiles.length })
-                  : t('my_page.messages.metadata_published')}
-              </Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
+                <CheckIcon fontSize="small" />
+                <Typography>
+                  {ticket.approvedFiles.length
+                    ? t('my_page.messages.files_published', { count: ticket.approvedFiles.length })
+                    : t('my_page.messages.metadata_published')}
+                </Typography>
+              </Box>
             ) : (
               ticket.status === 'Closed' && (
-                <Typography>
-                  {t('my_page.messages.files_rejected', { count: ticket.filesForApproval.length })}
-                </Typography>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.2rem' }}>
+                  <BlockIcon fontSize="small" />
+                  <Typography>
+                    {t('my_page.messages.files_rejected', { count: ticket.filesForApproval.length })}
+                  </Typography>
+                </Box>
               )
             )}
             {ticket.modifiedDate && <Typography>{toDateString(ticket.modifiedDate)}</Typography>}

--- a/src/pages/messages/components/SupportMessagesColumn.tsx
+++ b/src/pages/messages/components/SupportMessagesColumn.tsx
@@ -1,8 +1,13 @@
+import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 import { Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { ExpandedTicket } from '../../../types/publication_types/ticket.types';
 import { LastMessageBox } from './LastMessageBox';
-import { StyledMessagesContainer, StyledStatusMessageBox } from './PublishingRequestMessagesColumn';
+import {
+  StyledIconAndTextWrapper,
+  StyledMessagesContainer,
+  StyledStatusMessageBox,
+} from './PublishingRequestMessagesColumn';
 
 interface SupportMessagesColumnProps {
   ticket: ExpandedTicket;
@@ -15,10 +20,13 @@ export const SupportMessagesColumn = ({ ticket }: SupportMessagesColumnProps) =>
     <StyledMessagesContainer>
       {ticket.status === 'New' || ticket.status === 'Pending' ? (
         <>
-          <LastMessageBox ticket={ticket} />
           <StyledStatusMessageBox sx={{ bgcolor: 'secondary.dark' }}>
-            <Typography>{t('my_page.messages.general_support_pending')}</Typography>
+            <StyledIconAndTextWrapper>
+              <HourglassEmptyIcon fontSize="small" />
+              <Typography>{t('my_page.messages.general_support_pending')}</Typography>
+            </StyledIconAndTextWrapper>
           </StyledStatusMessageBox>
+          <LastMessageBox ticket={ticket} />
         </>
       ) : (
         <LastMessageBox ticket={ticket} />

--- a/src/pages/messages/components/TicketListItem.tsx
+++ b/src/pages/messages/components/TicketListItem.tsx
@@ -105,7 +105,7 @@ export const TicketListItem = ({ ticket }: TicketListItemProps) => {
           {ticket.type === 'PublishingRequest' ? (
             <PublishingRequestMessagesColumn ticket={ticket as ExpandedPublishingTicket} />
           ) : ticket.type === 'DoiRequest' ? (
-            <DoiRequestMessagesColumn ticket={ticket} />
+            <DoiRequestMessagesColumn ticket={ticket} showLastMessage />
           ) : ticket.type === 'GeneralSupportCase' ? (
             <SupportMessagesColumn ticket={ticket} />
           ) : (

--- a/src/pages/messages/components/TicketListItem.tsx
+++ b/src/pages/messages/components/TicketListItem.tsx
@@ -105,7 +105,7 @@ export const TicketListItem = ({ ticket }: TicketListItemProps) => {
           {ticket.type === 'PublishingRequest' ? (
             <PublishingRequestMessagesColumn ticket={ticket as ExpandedPublishingTicket} />
           ) : ticket.type === 'DoiRequest' ? (
-            <DoiRequestMessagesColumn ticket={ticket} showLastMessage />
+            <DoiRequestMessagesColumn ticket={ticket} />
           ) : ticket.type === 'GeneralSupportCase' ? (
             <SupportMessagesColumn ticket={ticket} />
           ) : (

--- a/src/pages/messages/components/TicketListItem.tsx
+++ b/src/pages/messages/components/TicketListItem.tsx
@@ -103,7 +103,7 @@ export const TicketListItem = ({ ticket }: TicketListItemProps) => {
           }}>
           <RegistrationListItemContent registration={convertToRegistrationSearchItem(registrationCopy)} ticketView />
           {ticket.type === 'PublishingRequest' ? (
-            <PublishingRequestMessagesColumn ticket={ticket as ExpandedPublishingTicket} showLastMessage />
+            <PublishingRequestMessagesColumn ticket={ticket as ExpandedPublishingTicket} />
           ) : ticket.type === 'DoiRequest' ? (
             <DoiRequestMessagesColumn ticket={ticket} showLastMessage />
           ) : ticket.type === 'GeneralSupportCase' ? (

--- a/src/pages/public_registration/PublishingLogPreview.tsx
+++ b/src/pages/public_registration/PublishingLogPreview.tsx
@@ -22,7 +22,7 @@ export const PublishingLogPreview = ({ registration, tickets }: PublishingLogPre
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', mb: '0.5rem' }}>
       {logEntries.map(({ Icon, text, date, bgcolor }, index) => (
-        <StyledStatusMessageBox key={index} sx={{ px: '0.5rem', display: 'flex', alignItems: 'center', bgcolor }}>
+        <StyledStatusMessageBox key={index} sx={{ display: 'flex', alignItems: 'center', bgcolor }}>
           <Icon fontSize="small" />
           <Typography>{text}</Typography>
           {date && <Typography sx={{ ml: 'auto' }}>{toDateString(date)}</Typography>}


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-47983

- Synliggjør hva som er gjort/skal gjøres før eventuelle meldinger vises
- Legg til ikon for å vise status tydeligere
- Ikke vis meldinger på tickets som er `Completed`

Før:
![bilde](https://github.com/user-attachments/assets/eef77920-a449-47d4-a9a0-3655a7ed9725)

Etter:
![bilde](https://github.com/user-attachments/assets/97a57f19-6080-4979-a93f-76def9d66e1a)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
