### PR TITLE
NP-47984 Show text instead of input field for curator selector when on myPage

### DIFF
--- a/src/pages/public_registration/action_accordions/TicketAssignee.tsx
+++ b/src/pages/public_registration/action_accordions/TicketAssignee.tsx
@@ -75,7 +75,7 @@ const UnselectableAssignee = ({ assignee }: UnselectableAssigneeProps) => {
   const assigneeFullName = getFullName(assigneeQuery.data?.givenName, assigneeQuery.data?.familyName);
 
   return (
-    <Box sx={{ display: 'flex', gap: '0.5rem', mb: '0.5rem' }}>
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.5rem', mb: '0.5rem' }}>
       <Avatar username={assignee ?? ''} />
       <Typography>{assignee ? assigneeFullName : t('my_page.messages.pending_curator')}</Typography>
     </Box>

--- a/src/pages/public_registration/action_accordions/TicketAssignee.tsx
+++ b/src/pages/public_registration/action_accordions/TicketAssignee.tsx
@@ -1,13 +1,17 @@
+import { Box, Typography } from '@mui/material';
 import { useMutation } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
+import { useFetchUserQuery } from '../../../api/hooks/useFetchUserQuery';
 import { updateTicket } from '../../../api/registrationApi';
 import { AssigneeSelector } from '../../../components/AssigneeSelector';
+import { Avatar } from '../../../components/Avatar';
 import { setNotification } from '../../../redux/notificationSlice';
 import { RootState } from '../../../redux/store';
 import { Ticket } from '../../../types/publication_types/ticket.types';
 import { RoleName } from '../../../types/user.types';
 import { UrlPathTemplate } from '../../../utils/urlPaths';
+import { getFullName } from '../../../utils/user-helpers';
 
 interface TicketAssigneeProps {
   ticket: Ticket;
@@ -35,12 +39,10 @@ export const TicketAssignee = ({ ticket, refetchTickets }: TicketAssigneeProps) 
     onError: () => dispatch(setNotification({ message: t('feedback.error.update_ticket_assignee'), variant: 'error' })),
   });
 
-  const canSetAssignee =
-    window.location.pathname.startsWith(UrlPathTemplate.TasksDialogue) &&
-    canEditTicket &&
-    (ticket.status === 'Pending' || ticket.status === 'New');
+  const isOnTaskPage = window.location.pathname.startsWith(UrlPathTemplate.TasksDialogue);
+  const canSetAssignee = isOnTaskPage && canEditTicket && (ticket.status === 'Pending' || ticket.status === 'New');
 
-  return (
+  return isOnTaskPage ? (
     <AssigneeSelector
       assignee={ticket.assignee}
       canSetAssignee={canSetAssignee}
@@ -58,5 +60,24 @@ export const TicketAssignee = ({ ticket, refetchTickets }: TicketAssigneeProps) 
             : RoleName.SupportCurator
       }
     />
+  ) : (
+    <UnselectableAssignee assignee={ticket.assignee} />
+  );
+};
+
+interface UnselectableAssigneeProps {
+  assignee?: string;
+}
+
+const UnselectableAssignee = ({ assignee }: UnselectableAssigneeProps) => {
+  const { t } = useTranslation();
+  const assigneeQuery = useFetchUserQuery(assignee ?? '');
+  const assigneeFullName = getFullName(assigneeQuery.data?.givenName, assigneeQuery.data?.familyName);
+
+  return (
+    <Box sx={{ display: 'flex', gap: '0.5rem', mb: '0.5rem' }}>
+      <Avatar username={assignee ?? ''} />
+      <Typography>{assignee ? assigneeFullName : t('my_page.messages.pending_curator')}</Typography>
+    </Box>
   );
 };

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -765,6 +765,7 @@
       "message_deleted": "Meldingen er slettet",
       "metadata_published": "Metadata publisert",
       "no_messages": "Du har ingen meldinger",
+      "pending_curator": "Venter på kurator",
       "ticket_types": {
         "Closed": "Avvist",
         "Completed": "Ferdig",


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-47984](https://sikt.atlassian.net/browse/NP-47984)

Fjerner dropdown for kuratorvelger når man er på "min side", da man uansett ikke kan endre kurator derifra.

Før:
![image](https://github.com/user-attachments/assets/e8dd404b-3058-4efd-be82-c7189f65112a)
![image](https://github.com/user-attachments/assets/50e7eaad-7d23-4532-888a-61480bdaf604)

Etter:
![image](https://github.com/user-attachments/assets/73d7fa85-454f-4d28-a3a6-e3a8993cce33)
![image](https://github.com/user-attachments/assets/bd562c93-2ce4-4346-8766-c5b4cf1c1346)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-47984]: https://sikt.atlassian.net/browse/NP-47984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ