### PR TITLE
NP-48126 Set fixed top margin for NVI navigation buttons

### DIFF
--- a/src/pages/messages/components/NavigationIconButton.tsx
+++ b/src/pages/messages/components/NavigationIconButton.tsx
@@ -12,8 +12,9 @@ export const NavigationIconButton = ({ navigateTo, sx, ...rest }: NavigationIcon
     component={Link}
     size="small"
     sx={{
-      display: { xs: 'none', md: 'flex' },
-      alignSelf: 'center',
+      display: { xs: 'none', md: 'inherit' },
+      mt: '20rem',
+      height: 'fit-content',
       justifySelf: navigateTo === 'previous' ? 'start' : 'end',
       border: '1px solid',
       borderColor: 'info.main',


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48126

Setter en fast plassering på navigasjonsknapper for å unngå at de hopper ned etter eventuelle filer lastes. Det kunne også føre til at pilene kom utenfor skjermen, sånn at man måtte scrolle for å se dem.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
