### PR TITLE
NP-48399 Add unpublish checkbox

### DIFF
--- a/src/pages/public_registration/action_accordions/UnpublishRegistration.tsx
+++ b/src/pages/public_registration/action_accordions/UnpublishRegistration.tsx
@@ -1,5 +1,5 @@
 import { LoadingButton } from '@mui/lab';
-import { Box, Button, DialogActions, TextField, Typography } from '@mui/material';
+import { Box, Button, Checkbox, DialogActions, FormControlLabel, TextField, Typography } from '@mui/material';
 import { ErrorMessage, Field, FieldProps, Form, Formik } from 'formik';
 import { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
@@ -27,6 +27,8 @@ export const UnpublishRegistration = ({ registration }: UnpublishRegistrationPro
   const [selectedDuplicate, setSelectedDuplicate] = useState<RegistrationSearchItem>();
 
   const userCanUnpublish = userHasAccessRight(registration, 'unpublish');
+
+  const [confirmedUnpublish, setConfirmedUnpublish] = useState(false);
 
   const unpublishValidationSchema = Yup.object().shape({
     comment: Yup.string()
@@ -116,12 +118,18 @@ export const UnpublishRegistration = ({ registration }: UnpublishRegistrationPro
                 selectedRegistration={selectedDuplicate}
                 filteredRegistrationIdentifier={registration.identifier}
               />
+              <FormControlLabel
+                sx={{ my: '1rem' }}
+                control={<Checkbox onChange={() => setConfirmedUnpublish(!confirmedUnpublish)} />}
+                label={t('unpublish_actions.confirm_unpublish')}
+              />
               <DialogActions>
                 <Button data-testid={dataTestId.confirmDialog.cancelButton} onClick={toggleUnpublishModal}>
                   {t('common.cancel')}
                 </Button>
                 <LoadingButton
                   loading={updateRegistrationStatusMutation.isPending}
+                  disabled={!confirmedUnpublish}
                   type="submit"
                   data-testid={dataTestId.confirmDialog.acceptButton}
                   variant="outlined">

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -2129,6 +2129,7 @@
     "your_tasks": "Oppgaver du behandler: {{count}}"
   },
   "unpublish_actions": {
+    "confirm_unpublish": "Jeg bekrefter at informasjonen stemmer, og at resultatet skal avpubliseres.",
     "duplicate": "Duplikat",
     "search_duplicate_facets": "Søk med DOI, handle eller tittel",
     "search_for_duplicate": "Søk etter forskningsresultat",


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48399

If a user hits “Enter/return” in any of the input-fields in the unpublish modal, the result wil be prematurely unpublished.

To fix this, add a checkbox that asks the user to confirm that the information is correct before the “unpublish” button is enabled.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [ ] The changes are working as expected
- [ ] The changes are tested OK for different screen sizes
- [ ] The changes are tested OK for a11y
- [ ] Interactive elements have data-testids
- [ ] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
