### PR TITLE
Avoid lagging counters on research profile

### DIFF
--- a/src/pages/research_profile/ResearchProfile.tsx
+++ b/src/pages/research_profile/ResearchProfile.tsx
@@ -3,7 +3,7 @@ import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import PhoneEnabledIcon from '@mui/icons-material/PhoneEnabled';
 import { Box, Chip, Divider, Grid, IconButton, List, Link as MuiLink, Typography } from '@mui/material';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -46,6 +46,12 @@ const ResearchProfile = () => {
   const [projectsPage, setProjectsPage] = useState(1);
   const [projectRowsPerPage, setProjectRowsPerPage] = useState(ROWS_PER_PAGE_OPTIONS[0]);
   const [projectSort, setProjectSort] = useState(projectSortOptions[0]);
+
+  useEffect(() => {
+    // Reset pagination when visiting a new research profile
+    setRegistrationsPage(1);
+    setProjectsPage(1);
+  }, [history.location.search]);
 
   const user = useSelector((store: RootState) => store.user);
 
@@ -121,7 +127,13 @@ const ResearchProfile = () => {
       ? `${t('my_page.my_profile.projects')} (${projectsQuery.data.size})`
       : t('my_page.my_profile.projects');
 
-  return personQuery.isPending ? (
+  const isPending =
+    personQuery.isPending ||
+    registrationsQuery.isPending ||
+    projectsQuery.isPending ||
+    promotedPublicationsQuery.isPending;
+
+  return isPending ? (
     <PageSpinner aria-label={t('my_page.research_profile')} />
   ) : !person ? (
     <NotFound />
@@ -276,7 +288,7 @@ const ResearchProfile = () => {
             </Trans>
           </Typography>
         )}
-        {registrationsQuery.isPending || promotedPublicationsQuery.isPending ? (
+        {registrationsQuery.isFetching ? (
           <ListSkeleton minWidth={100} height={100} />
         ) : registrationsQuery.data && registrationsQuery.data.totalHits > 0 ? (
           <ListPagination
@@ -325,7 +337,7 @@ const ResearchProfile = () => {
             </Trans>
           </Typography>
         )}
-        {projectsQuery.isPending ? (
+        {projectsQuery.isFetching ? (
           <ListSkeleton minWidth={100} height={100} />
         ) : projects.length > 0 ? (
           <ListPagination

--- a/src/pages/research_profile/ResearchProfile.tsx
+++ b/src/pages/research_profile/ResearchProfile.tsx
@@ -2,8 +2,8 @@ import LinkIcon from '@mui/icons-material/Link';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import PhoneEnabledIcon from '@mui/icons-material/PhoneEnabled';
 import { Box, Chip, Divider, Grid, IconButton, List, Link as MuiLink, Typography } from '@mui/material';
-import { useQuery } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -42,12 +42,10 @@ const ResearchProfile = () => {
   const [registrationsPage, setRegistrationsPage] = useState(1);
   const [registrationRowsPerPage, setRegistrationRowsPerPage] = useState(ROWS_PER_PAGE_OPTIONS[0]);
   const [registrationSort, setRegistrationSort] = useState(registrationSortOptions[0]);
-  const [totalRegistrations, setTotalRegistrations] = useState<number | null>(null);
 
   const [projectsPage, setProjectsPage] = useState(1);
   const [projectRowsPerPage, setProjectRowsPerPage] = useState(ROWS_PER_PAGE_OPTIONS[0]);
   const [projectSort, setProjectSort] = useState(projectSortOptions[0]);
-  const [totalProjects, setTotalProjects] = useState<number | null>(null);
 
   const user = useSelector((store: RootState) => store.user);
 
@@ -76,7 +74,11 @@ const ResearchProfile = () => {
     sort: registrationSort.sortOrder,
   };
 
-  const registrationsQuery = useRegistrationSearch({ enabled: !!personId, params: registrationsQueryConfig });
+  const registrationsQuery = useRegistrationSearch({
+    enabled: !!personId,
+    params: registrationsQueryConfig,
+    keepDataWhileLoading: true,
+  });
 
   const projectsQueryConfig: ProjectsSearchParams = {
     participant: personIdNumber,
@@ -88,6 +90,7 @@ const ResearchProfile = () => {
     queryKey: ['projects', projectRowsPerPage, projectsPage, projectsQueryConfig],
     queryFn: () => searchForProjects(projectRowsPerPage, projectsPage, projectsQueryConfig),
     meta: { errorMessage: t('feedback.error.project_search') },
+    placeholderData: keepPreviousData,
   });
 
   const projects = projectsQuery.data?.hits ?? [];
@@ -108,26 +111,14 @@ const ResearchProfile = () => {
   const personBackground = getLanguageString(person?.background);
   const personKeywords = person?.keywords ?? [];
 
-  useEffect(() => {
-    if (totalRegistrations === null && registrationsQuery.data) {
-      setTotalRegistrations(registrationsQuery.data.totalHits);
-    }
-  }, [totalRegistrations, registrationsQuery.data]);
-
-  useEffect(() => {
-    if (totalProjects === null && projectsQuery.data) {
-      setTotalProjects(projectsQuery.data.size);
-    }
-  }, [totalProjects, projectsQuery.data]);
-
   const registrationsHeading =
-    !!totalRegistrations && totalRegistrations > 0
-      ? `${t('my_page.my_profile.results')} (${totalRegistrations})`
+    registrationsQuery.data?.totalHits && registrationsQuery.data.totalHits > 0
+      ? `${t('my_page.my_profile.results')} (${registrationsQuery.data.totalHits})`
       : t('my_page.my_profile.results');
 
   const projectHeading =
-    !!totalProjects && totalProjects > 0
-      ? `${t('my_page.my_profile.projects')} (${totalProjects})`
+    projectsQuery.data?.size && projectsQuery.data.size > 0
+      ? `${t('my_page.my_profile.projects')} (${projectsQuery.data.size})`
       : t('my_page.my_profile.projects');
 
   return personQuery.isPending ? (
@@ -278,7 +269,7 @@ const ResearchProfile = () => {
         <Typography variant="h2" gutterBottom sx={{ mt: '2rem' }}>
           {registrationsHeading}
         </Typography>
-        {!!totalRegistrations && totalRegistrations > 0 && (
+        {registrationsQuery.data?.totalHits && (
           <Typography>
             <Trans t={t} i18nKey="my_page.my_profile.link_to_results_search">
               <MuiLink component={Link} to={`/?${ResultParam.Contributor}=${encodeURIComponent(personId)}`} />
@@ -322,7 +313,7 @@ const ResearchProfile = () => {
         <Typography variant="h2" gutterBottom sx={{ mt: '1rem' }}>
           {projectHeading}
         </Typography>
-        {!!totalProjects && totalProjects > 0 && (
+        {projectsQuery.data?.size && (
           <Typography>
             <Trans t={t} i18nKey="my_page.my_profile.link_to_projects_search">
               <MuiLink


### PR DESCRIPTION
# Description

Unngå at opptelling av antall resultat og prosjekt på forskerprofil viser verdier fra forrige person når man åpner ny forskerprofil

Åpner profil og går til side to i resultatlisten:
![bilde](https://github.com/user-attachments/assets/b59d9396-1ada-4161-ba79-c5184fcb10fb)

Velger ny person fra gjeldende visning, og den vil da få like verdier i mange felt:
![bilde](https://github.com/user-attachments/assets/01ff3532-8247-46eb-a8e0-d3df9fde2cd6)





# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [ ] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [ ] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
