### PR TITLE
NP-48141 Show only institution instead of date for NVI comments

### DIFF
--- a/src/pages/messages/components/MessageItemOrganization.tsx
+++ b/src/pages/messages/components/MessageItemOrganization.tsx
@@ -1,7 +1,7 @@
-import { Skeleton, Tooltip } from '@mui/material';
+import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
+import { Box, Skeleton, Tooltip, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useFetchOrganization } from '../../../api/hooks/useFetchOrganization';
-import { StyledTruncatableTypography } from '../../../components/styled/Wrappers';
 import { getLanguageString } from '../../../utils/translation-helpers';
 
 interface MessageItemOrganizationProps {
@@ -11,19 +11,24 @@ interface MessageItemOrganizationProps {
 export const MessageItemOrganization = ({ organizationId }: MessageItemOrganizationProps) => {
   const { t } = useTranslation();
   const organizationQuery = useFetchOrganization(organizationId);
+
+  const acronym = organizationQuery.data?.acronym;
   const organizationName = getLanguageString(organizationQuery.data?.labels);
 
   return (
     <Tooltip title={organizationName}>
-      <StyledTruncatableTypography sx={{ gridColumn: '1/-1' }}>
-        {organizationQuery.isPending ? (
-          <Skeleton sx={{ width: '80%' }} />
-        ) : organizationName ? (
-          organizationName
-        ) : (
-          <i>{t('common.unknown')}</i>
-        )}
-      </StyledTruncatableTypography>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: '0.1rem' }}>
+        <AccountBalanceIcon fontSize="small" />
+        <Typography>
+          {organizationQuery.isPending ? (
+            <Skeleton sx={{ width: '2rem' }} />
+          ) : acronym ? (
+            acronym
+          ) : (
+            <i>{t('common.unknown')}</i>
+          )}
+        </Typography>
+      </Box>
     </Tooltip>
   );
 };

--- a/src/pages/messages/components/MessageList.tsx
+++ b/src/pages/messages/components/MessageList.tsx
@@ -93,7 +93,7 @@ export const MessageItem = ({
         display: 'flex',
         flexDirection: 'column',
       }}>
-      <Box sx={{ display: 'grid', gridTemplateColumns: '1fr auto auto', alignItems: 'center' }}>
+      <Box sx={{ display: 'grid', gridTemplateColumns: '1fr auto auto', alignItems: 'center', gap: '0.3rem' }}>
         <Tooltip title={senderName ? senderName : t('common.unknown')}>
           <StyledTruncatableTypography
             data-testid={dataTestId.registrationLandingPage.tasksPanel.messageSender}
@@ -107,12 +107,14 @@ export const MessageItem = ({
             )}
           </StyledTruncatableTypography>
         </Tooltip>
-        <Typography data-testid={dataTestId.registrationLandingPage.tasksPanel.messageTimestamp}>
-          {toDateString(date)}
-        </Typography>
+        {showOrganization ? (
+          <MessageItemOrganization organizationId={senderQuery.data?.institutionCristinId ?? ''} />
+        ) : (
+          <Typography data-testid={dataTestId.registrationLandingPage.tasksPanel.messageTimestamp}>
+            {toDateString(date)}
+          </Typography>
+        )}
         {menuElement}
-
-        {showOrganization && <MessageItemOrganization organizationId={senderQuery.data?.institutionCristinId ?? ''} />}
       </Box>
 
       <Divider sx={{ mb: '0.5rem', bgcolor: 'primary.main' }} />


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48141

Vis bare institusjon (ikke dato) for NVI-merknader.

Før:
![bilde](https://github.com/user-attachments/assets/b61677ac-ba81-484c-a29d-da239fb4d2c3)

Etter:
![bilde](https://github.com/user-attachments/assets/fc22640c-2d08-48c3-a871-de5d4bab836e)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
