### PR TITLE
NP-48418 Fix redirect

### DIFF
--- a/src/components/RegistrationList.tsx
+++ b/src/components/RegistrationList.tsx
@@ -98,7 +98,8 @@ export const RegistrationListItemContent = ({
   });
 
   const shouldNotRedirect =
-    window.location.pathname === UrlPathTemplate.TasksResultRegistrations &&
+    (location.pathname === UrlPathTemplate.TasksResultRegistrations ||
+      location.pathname === UrlPathTemplate.InstitutionPortfolio) &&
     registration.recordMetadata.status === RegistrationStatus.Unpublished;
 
   return (

--- a/src/components/RegistrationList.tsx
+++ b/src/components/RegistrationList.tsx
@@ -97,6 +97,10 @@ export const RegistrationListItemContent = ({
       dispatch(setNotification({ message: t('feedback.error.update_promoted_publication'), variant: 'error' })),
   });
 
+  const shouldNotRedirect =
+    window.location.pathname === UrlPathTemplate.TasksResultRegistrations &&
+    registration.recordMetadata.status === RegistrationStatus.Unpublished;
+
   return (
     <Box sx={{ display: 'flex', width: '100%', gap: '1rem' }}>
       <ListItemText disableTypography data-testid={dataTestId.startPage.searchResultItem}>
@@ -128,6 +132,7 @@ export const RegistrationListItemContent = ({
               to={{
                 pathname: getRegistrationLandingPagePath(identifier),
                 state: { previousPath: `${location.pathname}${location.search}` } satisfies PreviousPathLocationState,
+                search: shouldNotRedirect ? 'shouldNotRedirect' : '',
               }}>
               {getTitleString(registration.mainTitle)}
             </MuiLink>


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48418

Fix an issue where the user was redirected to te duplicate result when trying to navigate to an unpublished result from the TasksRegistration Page.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
