### PR TITLE
Remove helmet package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "pretty-bytes": "^6.1.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-helmet-async": "^2.0.5",
         "react-i18next": "^15.4.0",
         "react-imask": "^7.6.1",
         "react-redux": "^9.2.0",
@@ -7769,15 +7768,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -10217,26 +10207,6 @@
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==",
       "license": "MIT"
     },
-    "node_modules/react-helmet-async": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-2.0.5.tgz",
-      "integrity": "sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "invariant": "^2.2.4",
-        "react-fast-compare": "^3.2.2",
-        "shallowequal": "^1.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/react-helmet-async/node_modules/react-fast-compare": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
-      "license": "MIT"
-    },
     "node_modules/react-i18next": {
       "version": "15.4.0",
       "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.4.0.tgz",
@@ -10752,12 +10722,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
       "integrity": "sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg==",
-      "license": "MIT"
-    },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
       "license": "MIT"
     },
     "node_modules/shebang-command": {
@@ -12164,21 +12128,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/yauzl": {
       "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "pretty-bytes": "^6.1.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-helmet-async": "^2.0.5",
     "react-i18next": "^15.4.0",
     "react-imask": "^7.6.1",
     "react-redux": "^9.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import { Amplify } from 'aws-amplify';
 import { Suspense, useEffect, useState } from 'react';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { createBrowserRouter, RouterProvider } from 'react-router';
@@ -18,13 +17,6 @@ import { USE_MOCK_DATA } from './utils/constants';
 import { mockUser } from './utils/testfiles/mock_feide_user';
 import { UrlPathTemplate } from './utils/urlPaths';
 
-const getLanguageTagValue = (language: string) => {
-  if (language === 'eng') {
-    return 'en';
-  }
-  return 'no';
-};
-
 if (
   (window.location.pathname === UrlPathTemplate.MyPagePersonalia ||
     window.location.pathname === UrlPathTemplate.MyPageResearchProfile) &&
@@ -38,7 +30,7 @@ if (
 const Root = () => {
   useMatomoTracking();
   const dispatch = useDispatch();
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const user = useSelector((store: RootState) => store.user);
   const [isLoadingUserAttributes, setIsLoadingUserAttributes] = useState(true);
 
@@ -74,10 +66,6 @@ const Root = () => {
 
   return (
     <>
-      <Helmet defaultTitle={t('common.page_title')} titleTemplate={`%s - ${t('common.page_title')}`}>
-        <html lang={getLanguageTagValue(i18n.language)} />
-      </Helmet>
-
       {mustAcceptTerms && <AcceptTermsDialog newTermsUri={user.currentTerms} />}
       {mustCreatePerson && <CreateCristinPersonDialog user={user} />}
       {mustSelectCustomer && <SelectCustomerInstitutionDialog allowedCustomerIds={user.allowedCustomers} />}

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,5 +1,5 @@
 import { Box, TypographyProps } from '@mui/material';
-import { Helmet } from 'react-helmet-async';
+import { DocumentHeadTitle } from '../context/DocumentHeadTitle';
 import { TruncatableTypography } from './TruncatableTypography';
 
 interface PageHeaderProps extends TypographyProps {
@@ -9,9 +9,7 @@ interface PageHeaderProps extends TypographyProps {
 
 export const PageHeader = ({ children, htmlTitle, ...props }: PageHeaderProps) => (
   <Box sx={{ width: '100%', marginBottom: '2rem' }}>
-    <Helmet>
-      <title>{htmlTitle ?? children}</title>
-    </Helmet>
+    <DocumentHeadTitle>{htmlTitle ?? children}</DocumentHeadTitle>
 
     <Box
       sx={{

--- a/src/components/StructuredSeoData.tsx
+++ b/src/components/StructuredSeoData.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { Helmet } from 'react-helmet-async';
 
 interface StructuredSeoDataProps {
   uri: string;
@@ -26,9 +25,19 @@ export const StructuredSeoData = ({ uri }: StructuredSeoDataProps) => {
     }
   }, [uri]);
 
-  return seoData ? (
-    <Helmet>
-      <script type="application/ld+json">{seoData}</script>
-    </Helmet>
-  ) : null;
+  useEffect(() => {
+    if (seoData) {
+      const scriptTag = document.createElement('script');
+      scriptTag.type = 'application/ld+json';
+      scriptTag.text = seoData;
+
+      document.head.appendChild(scriptTag);
+
+      return () => {
+        document.head.removeChild(scriptTag);
+      };
+    }
+  }, [seoData]);
+
+  return null;
 };

--- a/src/components/page_layout_components/PageHeader.tsx
+++ b/src/components/page_layout_components/PageHeader.tsx
@@ -1,6 +1,6 @@
 import { Box, BoxProps } from '@mui/material';
 import { ReactNode } from 'react';
-import { Helmet } from 'react-helmet-async';
+import { DocumentHeadTitle } from '../../context/DocumentHeadTitle';
 
 interface PageHeaderProps extends BoxProps {
   children: ReactNode;
@@ -9,11 +9,7 @@ interface PageHeaderProps extends BoxProps {
 
 export const PageHeader = ({ children, htmlTitle, sx }: PageHeaderProps) => (
   <Box sx={{ width: '100%', marginBottom: '2rem', ...sx }}>
-    {htmlTitle && (
-      <Helmet>
-        <title>{htmlTitle}</title>
-      </Helmet>
-    )}
+    {htmlTitle && <DocumentHeadTitle>{htmlTitle}</DocumentHeadTitle>}
     <Box sx={{ pb: '1rem', borderBottom: '2px solid' }}>{children}</Box>
   </Box>
 );

--- a/src/context/DocumentHeadTitle.tsx
+++ b/src/context/DocumentHeadTitle.tsx
@@ -1,0 +1,54 @@
+import { createContext, ReactNode, useContext, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface DocumentHeadTitleContextType {
+  setPageTitle: (pageTitle: string) => void;
+}
+
+export const DocumentHeadTitleContext = createContext<DocumentHeadTitleContextType | undefined>(undefined);
+
+export const TitleProvider = ({ children }: { children: ReactNode }) => {
+  const { t } = useTranslation();
+  const [pageTitle, setPageTitle] = useState('');
+
+  const appTitle = t('common.page_title');
+  const fullTitle = pageTitle ? `${pageTitle} - ${appTitle}` : appTitle;
+
+  return (
+    <DocumentHeadTitleContext.Provider value={{ setPageTitle }}>
+      <>
+        <title>{fullTitle}</title>
+        {children}
+      </>
+    </DocumentHeadTitleContext.Provider>
+  );
+};
+
+export const useDocumentHeadTitle = (pageTitle?: string) => {
+  const context = useContext(DocumentHeadTitleContext);
+  if (!context) {
+    throw new Error('useTitle must be used within a TitleProvider');
+  }
+
+  const { setPageTitle } = context;
+
+  useEffect(() => {
+    if (pageTitle) {
+      setPageTitle(pageTitle);
+      return () => setPageTitle('');
+    } else {
+      setPageTitle('');
+    }
+  }, [pageTitle, setPageTitle]);
+
+  return context;
+};
+
+interface DocumentHeadTitleProps {
+  children?: string;
+}
+
+export const DocumentHeadTitle = ({ children }: DocumentHeadTitleProps) => {
+  useDocumentHeadTitle(children);
+  return null;
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,6 @@
 import { CssBaseline, ThemeProvider } from '@mui/material';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { HelmetProvider } from 'react-helmet-async';
 import { I18nextProvider } from 'react-i18next';
 import { Provider as ReduxProvider } from 'react-redux';
 import { App } from './App';
@@ -16,6 +15,7 @@ import { USE_MOCK_DATA } from './utils/constants';
 // Fonts
 import '@fontsource/roboto/400.css';
 import '@fontsource/roboto/700.css';
+import { TitleProvider } from './context/DocumentHeadTitle';
 
 if (USE_MOCK_DATA) {
   interceptRequestsOnMock();
@@ -36,11 +36,11 @@ if (container) {
           <ReduxProvider store={store}>
             <ThemeProvider theme={mainTheme}>
               <CssBaseline />
-              <HelmetProvider>
+              <TitleProvider>
                 <QueryProvider>
                   <App />
                 </QueryProvider>
-              </HelmetProvider>
+              </TitleProvider>
             </ThemeProvider>
           </ReduxProvider>
         </I18nextProvider>

--- a/src/pages/basic_data/app_admin/NviPeriodsPage.tsx
+++ b/src/pages/basic_data/app_admin/NviPeriodsPage.tsx
@@ -1,12 +1,12 @@
 import { Box, List, Typography } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { fetchNviPeriods } from '../../../api/scientificIndexApi';
 import { ErrorBoundary } from '../../../components/ErrorBoundary';
 import { ListSkeleton } from '../../../components/ListSkeleton';
 import { SearchListItem } from '../../../components/styled/Wrappers';
+import { DocumentHeadTitle } from '../../../context/DocumentHeadTitle';
 import { NviPeriod } from '../../../types/nvi.types';
 import { toDateString } from '../../../utils/date-helpers';
 import { UpsertNviPeriodDialog } from './UpsertNviPeriodDialog';
@@ -26,9 +26,7 @@ export const NviPeriodsPage = () => {
 
   return (
     <Box component="section">
-      <Helmet>
-        <title>{t('basic_data.nvi.reporting_periods')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('basic_data.nvi.reporting_periods')}</DocumentHeadTitle>
 
       {nviPeriodsQuery.isPending ? (
         <ListSkeleton height={100} minWidth={100} />

--- a/src/pages/basic_data/app_admin/central_import/CentralImportCandidateMerge.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportCandidateMerge.tsx
@@ -3,13 +3,13 @@ import { Box, Button, Typography } from '@mui/material';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { Form, Formik, FormikProps } from 'formik';
 import { getLanguageByUri } from 'nva-language';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { Navigate, useLocation, useNavigate, useParams } from 'react-router';
 import { useFetchRegistration } from '../../../../api/hooks/useFetchRegistration';
 import { fetchImportCandidate, updateImportCandidateStatus, updateRegistration } from '../../../../api/registrationApi';
 import { PageSpinner } from '../../../../components/PageSpinner';
+import { DocumentHeadTitle } from '../../../../context/DocumentHeadTitle';
 import { setNotification } from '../../../../redux/notificationSlice';
 import { AssociatedLink } from '../../../../types/associatedArtifact.types';
 import { BasicDataLocationState, RegistrationFormLocationState } from '../../../../types/locationState.types';
@@ -126,9 +126,7 @@ export const CentralImportCandidateMerge = () => {
             gridTemplateColumns: '1fr auto 1fr',
             alignItems: 'center',
           }}>
-          <Helmet>
-            <title>{t('basic_data.central_import.central_import')}</title>
-          </Helmet>
+          <DocumentHeadTitle>{t('basic_data.central_import.central_import')}</DocumentHeadTitle>
           <Typography sx={{ gridColumn: '1/-1' }}>
             {t('basic_data.central_import.merge_candidate.merge_details_1')}
           </Typography>

--- a/src/pages/basic_data/app_admin/central_import/CentralImportDuplicationCheckPage.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportDuplicationCheckPage.tsx
@@ -1,7 +1,6 @@
 import { Box, Button, Divider, Paper, Typography } from '@mui/material';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { Link, useLocation, useParams } from 'react-router';
@@ -13,6 +12,7 @@ import { PageSpinner } from '../../../../components/PageSpinner';
 import { StyledPaperHeader } from '../../../../components/PageWithSideMenu';
 import { RegistrationListItemContent } from '../../../../components/RegistrationList';
 import { BackgroundDiv, SearchListItem } from '../../../../components/styled/Wrappers';
+import { DocumentHeadTitle } from '../../../../context/DocumentHeadTitle';
 import { setNotification } from '../../../../redux/notificationSlice';
 import { emptyDuplicateSearchFilter } from '../../../../types/duplicateSearchTypes';
 import { PreviousPathLocationState } from '../../../../types/locationState.types';
@@ -102,9 +102,7 @@ export const CentralImportDuplicationCheckPage = () => {
         gridTemplateAreas: { xs: '"actions" "main"', sm: '"main actions"' },
         gap: '1rem',
       }}>
-      <Helmet>
-        <title>{t('basic_data.central_import.central_import')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('basic_data.central_import.central_import')}</DocumentHeadTitle>
       <BackgroundDiv>
         {importCandidateSearchQuery.isPending || importCandidateQuery.isPending ? (
           <PageSpinner aria-label={t('basic_data.central_import.central_import')} />

--- a/src/pages/basic_data/app_admin/central_import/CentralImportPage.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportPage.tsx
@@ -1,6 +1,5 @@
 import { List, Typography } from '@mui/material';
 import { useEffect } from 'react';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router';
 import { ImportCandidatesSearchParam } from '../../../../api/searchApi';
@@ -9,6 +8,7 @@ import { ListPagination } from '../../../../components/ListPagination';
 import { ListSkeleton } from '../../../../components/ListSkeleton';
 import { SearchForm } from '../../../../components/SearchForm';
 import { SortSelector } from '../../../../components/SortSelector';
+import { DocumentHeadTitle } from '../../../../context/DocumentHeadTitle';
 import { useFetchImportCandidatesQuery } from '../../../../utils/hooks/useFetchImportCandidatesQuery';
 import { stringIncludesMathJax, typesetMathJax } from '../../../../utils/mathJaxHelpers';
 import { syncParamsWithSearchFields } from '../../../../utils/searchHelpers';
@@ -39,9 +39,8 @@ export const CentralImportPage = () => {
 
   return (
     <section>
-      <Helmet>
-        <title>{t('basic_data.central_import.central_import')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('basic_data.central_import.central_import')}</DocumentHeadTitle>
+
       <SearchForm sx={{ mb: '1rem' }} placeholder={t('tasks.search_placeholder')} />
 
       {importCandidateQuery.isPending ? (

--- a/src/pages/basic_data/institution_admin/AddEmployeePage.tsx
+++ b/src/pages/basic_data/institution_admin/AddEmployeePage.tsx
@@ -2,13 +2,13 @@ import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import { Box, Button, Divider, Typography } from '@mui/material';
 import { Form, Formik, FormikHelpers, FormikProps } from 'formik';
 import { useState } from 'react';
-import { Helmet } from 'react-helmet-async';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { addEmployment, createCristinPerson } from '../../../api/cristinApi';
 import { createUser } from '../../../api/roleApi';
 import { ConfirmDialog } from '../../../components/ConfirmDialog';
 import { BackgroundDiv } from '../../../components/styled/Wrappers';
+import { DocumentHeadTitle } from '../../../context/DocumentHeadTitle';
 import { setNotification } from '../../../redux/notificationSlice';
 import { RootState } from '../../../redux/store';
 import {
@@ -113,9 +113,8 @@ export const AddEmployeePage = () => {
 
   return (
     <BackgroundDiv>
-      <Helmet>
-        <title>{t('basic_data.add_employee.add_employee')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('basic_data.add_employee.add_employee')}</DocumentHeadTitle>
+
       <Typography variant="h2">{t('basic_data.add_employee.update_person_registry')}</Typography>
       <Formik
         initialValues={initialValues}

--- a/src/pages/basic_data/institution_admin/person_register/PersonRegisterPage.tsx
+++ b/src/pages/basic_data/institution_admin/person_register/PersonRegisterPage.tsx
@@ -15,13 +15,13 @@ import {
 import { visuallyHidden } from '@mui/utils';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { fetchEmployees } from '../../../../api/searchApi';
 import { ErrorBoundary } from '../../../../components/ErrorBoundary';
 import { ListPagination } from '../../../../components/ListPagination';
 import { BackgroundDiv } from '../../../../components/styled/Wrappers';
+import { DocumentHeadTitle } from '../../../../context/DocumentHeadTitle';
 import { RootState } from '../../../../redux/store';
 import { alternatingTableRowColor } from '../../../../themes/mainTheme';
 import { ROWS_PER_PAGE_OPTIONS } from '../../../../utils/constants';
@@ -57,9 +57,7 @@ export const PersonRegisterPage = () => {
 
   return (
     <BackgroundDiv>
-      <Helmet>
-        <title>{t('basic_data.person_register.person_register')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('basic_data.person_register.person_register')}</DocumentHeadTitle>
 
       <TextField
         data-testid={dataTestId.basicData.personRegisterSearchBar}

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -1,9 +1,9 @@
 import CloseIcon from '@mui/icons-material/Close';
 import { Box, Button, Collapse, IconButton, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
+import { DocumentHeadTitle } from '../../context/DocumentHeadTitle';
 import { LocalStorageKey } from '../../utils/constants';
 import { dataTestId } from '../../utils/dataTestIds';
 import { AboutContent } from '../infopages/AboutContent';
@@ -33,9 +33,8 @@ const Dashboard = () => {
         justifyItems: 'center',
         width: '100%',
       }}>
-      <Helmet>
-        <title>{t('common.start_page')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('common.start_page')}</DocumentHeadTitle>
+
       {showBanner && (
         <Box sx={{ bgcolor: 'secondary.main', p: '1rem 0.5rem', width: '100%' }}>
           <Box

--- a/src/pages/editor/CategoriesWithFiles.tsx
+++ b/src/pages/editor/CategoriesWithFiles.tsx
@@ -2,11 +2,11 @@ import { LoadingButton } from '@mui/lab';
 import { Box, Button, Typography } from '@mui/material';
 import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { updateCustomerInstitution } from '../../api/customerInstitutionsApi';
 import { CategorySelector } from '../../components/CategorySelector';
+import { DocumentHeadTitle } from '../../context/DocumentHeadTitle';
 import { setCustomer } from '../../redux/customerReducer';
 import { setNotification } from '../../redux/notificationSlice';
 import { RootState } from '../../redux/store';
@@ -20,9 +20,7 @@ export const CategoriesWithFiles = () => {
 
   return (
     <>
-      <Helmet>
-        <title>{t('editor.categories_with_files')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('editor.categories_with_files')}</DocumentHeadTitle>
       <Typography variant="h2" gutterBottom>
         {t('editor.categories_with_files')}
       </Typography>

--- a/src/pages/editor/CategoriesWithFilesOverview.tsx
+++ b/src/pages/editor/CategoriesWithFilesOverview.tsx
@@ -1,8 +1,8 @@
 import { Typography } from '@mui/material';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { CategorySelector } from '../../components/CategorySelector';
+import { DocumentHeadTitle } from '../../context/DocumentHeadTitle';
 import { RootState } from '../../redux/store';
 import { allPublicationInstanceTypes } from '../../types/publicationFieldNames';
 
@@ -18,9 +18,7 @@ export const CategoriesWithFilesOverview = () => {
 
   return (
     <>
-      <Helmet>
-        <title>{t('editor.categories_with_files')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('editor.categories_with_files')}</DocumentHeadTitle>
       <Typography variant="h2" gutterBottom>
         {t('editor.categories_with_files')}
       </Typography>

--- a/src/pages/editor/EditorDoi.tsx
+++ b/src/pages/editor/EditorDoi.tsx
@@ -1,7 +1,7 @@
 import { Box, CircularProgress, Link as MuiLink, Typography } from '@mui/material';
-import { Helmet } from 'react-helmet-async';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
+import { DocumentHeadTitle } from '../../context/DocumentHeadTitle';
 import { RootState } from '../../redux/store';
 
 export const EditorDoi = () => {
@@ -10,9 +10,7 @@ export const EditorDoi = () => {
 
   return (
     <>
-      <Helmet>
-        <title>{t('common.doi_long')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('common.doi_long')}</DocumentHeadTitle>
       <Typography id="doi-label" variant="h2" sx={{ mb: '2rem' }}>
         {t('common.doi_long')}
       </Typography>

--- a/src/pages/editor/EditorInstitution.tsx
+++ b/src/pages/editor/EditorInstitution.tsx
@@ -1,11 +1,11 @@
 import { Box, CircularProgress, Grid, Link, Typography } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
-import { Helmet } from 'react-helmet-async';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { fetchResource } from '../../api/commonApi';
 import { fetchUsersByCustomer } from '../../api/roleApi';
 import { PageSpinner } from '../../components/PageSpinner';
+import { DocumentHeadTitle } from '../../context/DocumentHeadTitle';
 import { RootState } from '../../redux/store';
 import { CustomerInstitution } from '../../types/customerInstitution.types';
 import { Organization } from '../../types/organization.types';
@@ -62,9 +62,8 @@ export const EditorInstitution = () => {
 
   return (
     <>
-      <Helmet>
-        <title>{t('editor.institution.institution_profile')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('editor.institution.institution_profile')}</DocumentHeadTitle>
+
       <Typography variant="h2" gutterBottom>
         {t('editor.institution.institution_profile')}
       </Typography>

--- a/src/pages/editor/InstitutionSupport.tsx
+++ b/src/pages/editor/InstitutionSupport.tsx
@@ -3,11 +3,11 @@ import { LoadingButton } from '@mui/lab';
 import { InputAdornment, TextField, Typography } from '@mui/material';
 import { useMutation } from '@tanstack/react-query';
 import { Field, FieldProps, Form, Formik, FormikProps } from 'formik';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { updateCustomerInstitution } from '../../api/customerInstitutionsApi';
 import { PageSpinner } from '../../components/PageSpinner';
+import { DocumentHeadTitle } from '../../context/DocumentHeadTitle';
 import { setCustomer } from '../../redux/customerReducer';
 import { setNotification } from '../../redux/notificationSlice';
 import { RootState } from '../../redux/store';
@@ -30,9 +30,8 @@ export const InstitutionSupport = () => {
 
   return (
     <>
-      <Helmet>
-        <title>{t('editor.institution.institution_support')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('editor.institution.institution_support')}</DocumentHeadTitle>
+
       {!customer ? (
         <PageSpinner />
       ) : (

--- a/src/pages/editor/OrganizationOverview.tsx
+++ b/src/pages/editor/OrganizationOverview.tsx
@@ -11,12 +11,12 @@ import {
 } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
-import { Helmet } from 'react-helmet-async';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { fetchResource } from '../../api/commonApi';
 import { ListSkeleton } from '../../components/ListSkeleton';
 import { OrganizationRenderOption } from '../../components/OrganizationRenderOption';
+import { DocumentHeadTitle } from '../../context/DocumentHeadTitle';
 import { RootState } from '../../redux/store';
 import { Organization } from '../../types/organization.types';
 import { dataTestId } from '../../utils/dataTestIds';
@@ -44,9 +44,7 @@ export const OrganizationOverview = () => {
 
   return (
     <>
-      <Helmet>
-        <title>{t('editor.organization_overview')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('editor.organization_overview')}</DocumentHeadTitle>
       <Typography variant="h1" sx={{ mb: '1rem' }}>
         {t('editor.organization_overview')}
       </Typography>

--- a/src/pages/editor/PortfolioSearchPage.tsx
+++ b/src/pages/editor/PortfolioSearchPage.tsx
@@ -1,8 +1,8 @@
 import { Typography } from '@mui/material';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useCustomerRegistrationSearch } from '../../api/hooks/useFetchCustomerRegistrationSearch';
 import { SearchForm } from '../../components/SearchForm';
+import { DocumentHeadTitle } from '../../context/DocumentHeadTitle';
 import { useRegistrationsQueryParams } from '../../utils/hooks/useRegistrationSearchParams';
 import { RegistrationSearch } from '../search/registration_search/RegistrationSearch';
 
@@ -17,9 +17,7 @@ export const PortfolioSearchPage = ({ title }: PortfolioSearchPageProps) => {
 
   return (
     <section>
-      <Helmet>
-        <title>{title}</title>
-      </Helmet>
+      <DocumentHeadTitle>{title}</DocumentHeadTitle>
       <Typography variant="h1" gutterBottom>
         {title}
       </Typography>

--- a/src/pages/editor/PublishStrategySettings.tsx
+++ b/src/pages/editor/PublishStrategySettings.tsx
@@ -2,11 +2,11 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import RemoveCircleIcon from '@mui/icons-material/RemoveCircle';
 import { Box, ButtonBase, CircularProgress, styled, Typography } from '@mui/material';
 import { useMutation } from '@tanstack/react-query';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { updateCustomerInstitution } from '../../api/customerInstitutionsApi';
 import { PageSpinner } from '../../components/PageSpinner';
+import { DocumentHeadTitle } from '../../context/DocumentHeadTitle';
 import { setCustomer } from '../../redux/customerReducer';
 import { setNotification } from '../../redux/notificationSlice';
 import { RootState } from '../../redux/store';
@@ -55,9 +55,7 @@ export const PublishStrategySettings = () => {
 
   return (
     <>
-      <Helmet>
-        <title id="publish-strategy-label">{t('editor.publish_strategy.publish_strategy')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('editor.publish_strategy.publish_strategy')}</DocumentHeadTitle>
 
       {!customer ? (
         <PageSpinner />
@@ -103,7 +101,7 @@ export const PublishStrategySettings = () => {
               </PublishStrategyButton>
               {updateRightsRetentionStrategy.isPending &&
                 customer.publicationWorkflow !== 'RegistratorPublishesMetadataAndFiles' && (
-                  <CircularProgress aria-labelledby="publish-strategy-label" />
+                  <CircularProgress aria-label={t('editor.publish_strategy.publish_strategy')} />
                 )}
             </StyledItemContainer>
 

--- a/src/pages/editor/PublishingStrategyOverview.tsx
+++ b/src/pages/editor/PublishingStrategyOverview.tsx
@@ -1,10 +1,10 @@
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import RemoveCircleIcon from '@mui/icons-material/RemoveCircle';
 import { Box, Divider, Link, styled, Typography } from '@mui/material';
-import { Helmet } from 'react-helmet-async';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { PageSpinner } from '../../components/PageSpinner';
+import { DocumentHeadTitle } from '../../context/DocumentHeadTitle';
 import { RootState } from '../../redux/store';
 import { CustomerRrsType } from '../../types/customerInstitution.types';
 
@@ -40,9 +40,7 @@ export const PublishingStrategyOverview = () => {
 
   return (
     <>
-      <Helmet>
-        <title>{t('editor.publish_strategy.publish_strategy')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('editor.publish_strategy.publish_strategy')}</DocumentHeadTitle>
 
       {!customer ? (
         <PageSpinner />

--- a/src/pages/editor/VocabularyOverview.tsx
+++ b/src/pages/editor/VocabularyOverview.tsx
@@ -1,10 +1,10 @@
 import { Card, CircularProgress, Typography } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { TFunction } from 'i18next';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { fetchVocabulary } from '../../api/customerInstitutionsApi';
+import { DocumentHeadTitle } from '../../context/DocumentHeadTitle';
 import { RootState } from '../../redux/store';
 import {
   defaultHrcsActivity,
@@ -32,9 +32,7 @@ export const VocabularyOverview = () => {
 
   return (
     <>
-      <Helmet>
-        <title id="vocabulary-label">{t('editor.vocabulary')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('editor.vocabulary')}</DocumentHeadTitle>
 
       <Typography gutterBottom fontWeight="600">
         {t('editor.vocabulary_controlled')}
@@ -42,7 +40,7 @@ export const VocabularyOverview = () => {
       <Typography>{t('editor.vocabulary_description')}</Typography>
 
       {vocabularyQuery.isPending ? (
-        <CircularProgress aria-labelledby="vocabulary-label" />
+        <CircularProgress aria-label={t('editor.vocabulary')} />
       ) : (
         vocabularyQuery.data?.vocabularies
           .filter((vocabulary) => visibleVocabularyStatuses.includes(vocabulary.status))

--- a/src/pages/editor/VocabularySettings.tsx
+++ b/src/pages/editor/VocabularySettings.tsx
@@ -1,9 +1,9 @@
 import { Box, CircularProgress, Typography } from '@mui/material';
 import { useState } from 'react';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { authenticatedApiRequest } from '../../api/apiRequest';
+import { DocumentHeadTitle } from '../../context/DocumentHeadTitle';
 import { setPartialCustomer } from '../../redux/customerReducer';
 import { setNotification } from '../../redux/notificationSlice';
 import { RootState } from '../../redux/store';
@@ -78,15 +78,13 @@ export const VocabularySettings = () => {
 
   return (
     <>
-      <Helmet>
-        <title id="vocabulary-label">{t('editor.vocabulary')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('editor.vocabulary')}</DocumentHeadTitle>
       <Typography sx={{ mb: '1rem' }} color="primary" fontWeight="600">
         {t('editor.select_vocabulary_description')}
       </Typography>
 
       {isLoadingVocabularyList ? (
-        <CircularProgress aria-labelledby="vocabulary-label" />
+        <CircularProgress aria-label={t('editor.vocabulary')} />
       ) : (
         vocabularyList && (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>

--- a/src/pages/editor/curators/OrganizationCurators.tsx
+++ b/src/pages/editor/curators/OrganizationCurators.tsx
@@ -3,7 +3,6 @@ import PersonIcon from '@mui/icons-material/Person';
 import { Autocomplete, Box, MenuItem, TextField, Typography } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { fetchResource } from '../../../api/commonApi';
@@ -11,6 +10,7 @@ import { fetchUsersByCustomer } from '../../../api/roleApi';
 import { AutocompleteTextField } from '../../../components/AutocompleteTextField';
 import { ListSkeleton } from '../../../components/ListSkeleton';
 import { OrganizationRenderOption } from '../../../components/OrganizationRenderOption';
+import { DocumentHeadTitle } from '../../../context/DocumentHeadTitle';
 import { RootState } from '../../../redux/store';
 import { Organization } from '../../../types/organization.types';
 import { dataTestId } from '../../../utils/dataTestIds';
@@ -61,9 +61,7 @@ export const OrganizationCurators = ({ heading, canEditUsers = false }: Organiza
 
   return (
     <>
-      <Helmet>
-        <title>{heading}</title>
-      </Helmet>
+      <DocumentHeadTitle>{heading}</DocumentHeadTitle>
       <Typography variant="h1" sx={{ mb: '1rem' }}>
         {heading}
       </Typography>

--- a/src/pages/messages/components/NviCandidatesList.tsx
+++ b/src/pages/messages/components/NviCandidatesList.tsx
@@ -1,5 +1,4 @@
 import { Box, List, Typography } from '@mui/material';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router';
 import { useFetchNviCandidates } from '../../../api/hooks/useFetchNviCandidates';
@@ -10,6 +9,7 @@ import { ErrorBoundary } from '../../../components/ErrorBoundary';
 import { ListPagination } from '../../../components/ListPagination';
 import { ListSkeleton } from '../../../components/ListSkeleton';
 import { SearchForm } from '../../../components/SearchForm';
+import { DocumentHeadTitle } from '../../../context/DocumentHeadTitle';
 import { NviCandidateSearchStatus } from '../../../types/nvi.types';
 import { RoleName } from '../../../types/user.types';
 import { dataTestId } from '../../../utils/dataTestIds';
@@ -34,9 +34,7 @@ export const NviCandidatesList = () => {
 
   return (
     <section>
-      <Helmet>
-        <title>{t('common.nvi')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('common.nvi')}</DocumentHeadTitle>
 
       <Box
         sx={{

--- a/src/pages/messages/components/NviCorrectionList.tsx
+++ b/src/pages/messages/components/NviCorrectionList.tsx
@@ -1,11 +1,11 @@
 import { Box, Divider, Typography } from '@mui/material';
 import { ParseKeys } from 'i18next';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
 import { useRegistrationSearch } from '../../../api/hooks/useRegistrationSearch';
 import { FetchResultsParams, ResultParam } from '../../../api/searchApi';
 import { CategorySearchFilter } from '../../../components/CategorySearchFilter';
+import { DocumentHeadTitle } from '../../../context/DocumentHeadTitle';
 import { BookType } from '../../../types/publicationFieldNames';
 import { useRegistrationsQueryParams } from '../../../utils/hooks/useRegistrationSearchParams';
 import { nviApplicableTypes } from '../../../utils/registration-helpers';
@@ -106,9 +106,7 @@ export const NviCorrectionList = () => {
 
   return (
     <section>
-      <Helmet>
-        <title>{t('tasks.correction_list')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('tasks.correction_list')}</DocumentHeadTitle>
 
       {listConfig && (
         <>

--- a/src/pages/messages/components/TicketList.tsx
+++ b/src/pages/messages/components/TicketList.tsx
@@ -1,7 +1,6 @@
 import { FormControl, Grid, InputLabel, List, MenuItem, Select, Typography } from '@mui/material';
 import { UseQueryResult } from '@tanstack/react-query';
 import { Dispatch, SetStateAction, useEffect, useMemo } from 'react';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router';
@@ -16,6 +15,7 @@ import { ListSkeleton } from '../../../components/ListSkeleton';
 import { SearchForm } from '../../../components/SearchForm';
 import { SortSelector } from '../../../components/SortSelector';
 import { TicketStatusFilter } from '../../../components/TicketStatusFilter';
+import { DocumentHeadTitle } from '../../../context/DocumentHeadTitle';
 import { RootState } from '../../../redux/store';
 import { CustomerTicketSearchResponse, ticketStatusValues } from '../../../types/publication_types/ticket.types';
 import { RoleName } from '../../../types/user.types';
@@ -76,9 +76,7 @@ export const TicketList = ({ ticketsQuery, setRowsPerPage, rowsPerPage, setPage,
 
   return (
     <section>
-      <Helmet>
-        <title>{title}</title>
-      </Helmet>
+      <DocumentHeadTitle>{title}</DocumentHeadTitle>
 
       <Grid container columns={16} spacing={2} sx={{ px: { xs: '0.5rem', md: 0 }, mb: '1rem' }}>
         <Grid item xs={16} md={5} lg={4}>

--- a/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
+++ b/src/pages/my_page/user_profile/MyFieldAndBackground.tsx
@@ -3,7 +3,6 @@ import { Autocomplete, Box, Button, Chip, TextField, Typography } from '@mui/mat
 import { keepPreviousData, useMutation, useQuery } from '@tanstack/react-query';
 import { Field, FieldProps, Form, Formik, FormikProps } from 'formik';
 import { useState } from 'react';
-import { Helmet } from 'react-helmet-async';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -17,6 +16,7 @@ import {
   AutocompleteListboxWithExpansionProps,
 } from '../../../components/AutocompleteListboxWithExpansion';
 import { AutocompleteTextField } from '../../../components/AutocompleteTextField';
+import { DocumentHeadTitle } from '../../../context/DocumentHeadTitle';
 import { setNotification } from '../../../redux/notificationSlice';
 import { RootState } from '../../../redux/store';
 import { Keywords, KeywordsOld } from '../../../types/keywords.types';
@@ -102,9 +102,7 @@ export const MyFieldAndBackground = () => {
 
   return (
     <Box sx={{ bgcolor: 'secondary.main' }}>
-      <Helmet>
-        <title>{t('my_page.my_profile.field_and_background.field_and_background')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('my_page.my_profile.field_and_background.field_and_background')}</DocumentHeadTitle>
 
       <Formik initialValues={initialValues} onSubmit={(values) => updatePerson.mutate(values)} enableReinitialize>
         {({ isSubmitting, dirty, setFieldValue, resetForm }: FormikProps<PersonBackgroundFormData>) => (

--- a/src/pages/my_page/user_profile/MyProfile.tsx
+++ b/src/pages/my_page/user_profile/MyProfile.tsx
@@ -4,12 +4,12 @@ import { Box, Button, Grid, IconButton, TextField, Tooltip, Typography } from '@
 import { useQuery } from '@tanstack/react-query';
 import { ErrorMessage, Field, FieldProps, Form, Formik, FormikProps } from 'formik';
 import { useState } from 'react';
-import { Helmet } from 'react-helmet-async';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchPerson, updateCristinPerson } from '../../../api/cristinApi';
 import { NationalIdNumberField } from '../../../components/NationalIdNumberField';
 import { PageSpinner } from '../../../components/PageSpinner';
+import { DocumentHeadTitle } from '../../../context/DocumentHeadTitle';
 import { setNotification } from '../../../redux/notificationSlice';
 import { RootState } from '../../../redux/store';
 import { FlatCristinPerson } from '../../../types/user.types';
@@ -82,9 +82,7 @@ export const MyProfile = () => {
 
   return (
     <Box sx={{ bgcolor: 'secondary.main' }}>
-      <Helmet>
-        <title>{t('my_page.my_profile.heading.personalia')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('my_page.my_profile.heading.personalia')}</DocumentHeadTitle>
 
       <Typography variant="h2" sx={{ margin: '1rem' }}>
         {t('my_page.my_profile.heading.personalia')}

--- a/src/pages/my_page/user_profile/MyProjectRegistrations.tsx
+++ b/src/pages/my_page/user_profile/MyProjectRegistrations.tsx
@@ -1,7 +1,6 @@
 import { List, Typography } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
@@ -14,6 +13,7 @@ import {
 import { ListPagination } from '../../../components/ListPagination';
 import { ListSkeleton } from '../../../components/ListSkeleton';
 import { ProjectSortSelector } from '../../../components/ProjectSortSelector';
+import { DocumentHeadTitle } from '../../../context/DocumentHeadTitle';
 import { RootState } from '../../../redux/store';
 import { ROWS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 import { getIdentifierFromId } from '../../../utils/general-helpers';
@@ -61,9 +61,7 @@ export const MyProjectRegistrations = () => {
 
   return (
     <div>
-      <Helmet>
-        <title>{t('my_page.project_registrations')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('my_page.project_registrations')}</DocumentHeadTitle>
       <Typography variant="h2" gutterBottom>
         {t('my_page.project_registrations')}
       </Typography>

--- a/src/pages/my_page/user_profile/MyProjects.tsx
+++ b/src/pages/my_page/user_profile/MyProjects.tsx
@@ -1,7 +1,6 @@
 import { List, Typography } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { ProjectsSearchParams, searchForProjects } from '../../../api/cristinApi';
@@ -9,6 +8,7 @@ import { ListPagination } from '../../../components/ListPagination';
 import { ListSkeleton } from '../../../components/ListSkeleton';
 import { projectSortOptions } from '../../../components/ProjectSortSelector';
 import { SortSelectorWithoutParams } from '../../../components/SortSelectorWithoutParams';
+import { DocumentHeadTitle } from '../../../context/DocumentHeadTitle';
 import { RootState } from '../../../redux/store';
 import { ROWS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 import { getIdentifierFromId } from '../../../utils/general-helpers';
@@ -41,9 +41,7 @@ export const MyProjects = () => {
 
   return (
     <div>
-      <Helmet>
-        <title>{t('my_page.my_profile.my_projects')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('my_page.my_profile.my_projects')}</DocumentHeadTitle>
       <Typography variant="h2" gutterBottom>
         {t('my_page.my_profile.my_projects')}
       </Typography>

--- a/src/pages/my_page/user_profile/MyResults.tsx
+++ b/src/pages/my_page/user_profile/MyResults.tsx
@@ -1,7 +1,6 @@
 import { Typography } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { fetchPromotedPublicationsById } from '../../../api/preferencesApi';
@@ -9,6 +8,7 @@ import { FetchResultsParams, fetchResults } from '../../../api/searchApi';
 import { ListPagination } from '../../../components/ListPagination';
 import { ListSkeleton } from '../../../components/ListSkeleton';
 import { SortSelectorWithoutParams } from '../../../components/SortSelectorWithoutParams';
+import { DocumentHeadTitle } from '../../../context/DocumentHeadTitle';
 import { RootState } from '../../../redux/store';
 import { ROWS_PER_PAGE_OPTIONS } from '../../../utils/constants';
 import { RegistrationSearchResults } from '../../search/registration_search/RegistrationSearchResults';
@@ -49,9 +49,7 @@ export const MyResults = () => {
 
   return (
     <div>
-      <Helmet>
-        <title>{t('my_page.my_profile.my_research_results')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('my_page.my_profile.my_research_results')}</DocumentHeadTitle>
       <Typography variant="h2" gutterBottom>
         {t('my_page.my_profile.my_research_results')}
       </Typography>

--- a/src/pages/my_page/user_profile/Terms.tsx
+++ b/src/pages/my_page/user_profile/Terms.tsx
@@ -1,17 +1,15 @@
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { Link, Typography } from '@mui/material';
-import { Helmet } from 'react-helmet-async';
 import { Trans, useTranslation } from 'react-i18next';
 import { BackgroundDiv } from '../../../components/styled/Wrappers';
+import { DocumentHeadTitle } from '../../../context/DocumentHeadTitle';
 
 export const Terms = () => {
   const { t } = useTranslation();
 
   return (
     <BackgroundDiv>
-      <Helmet>
-        <title>{t('common.terms')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('common.terms')}</DocumentHeadTitle>
       <Typography variant="h1" gutterBottom>
         {t('common.terms')}
       </Typography>

--- a/src/pages/my_page/user_profile/UserRoleAndHelp.tsx
+++ b/src/pages/my_page/user_profile/UserRoleAndHelp.tsx
@@ -1,10 +1,10 @@
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { Box, Divider, Link as MuiLink, Typography } from '@mui/material';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useFetchUserQuery } from '../../../api/hooks/useFetchUserQuery';
 import { BackgroundDiv } from '../../../components/styled/Wrappers';
+import { DocumentHeadTitle } from '../../../context/DocumentHeadTitle';
 import { RootState } from '../../../redux/store';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { hasCuratorRole } from '../../../utils/user-helpers';
@@ -20,9 +20,7 @@ export const UserRoleAndHelp = () => {
 
   return (
     <BackgroundDiv sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-      <Helmet>
-        <title>{t('my_page.my_profile.user_role_and_help.user_role_and_help')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('my_page.my_profile.user_role_and_help.user_role_and_help')}</DocumentHeadTitle>
       {nvaUser?.viewingScope && hasCuratorRole(user) && (
         <div>
           <Typography gutterBottom fontWeight="bold">

--- a/src/pages/my_registrations/MyRegistrations.tsx
+++ b/src/pages/my_registrations/MyRegistrations.tsx
@@ -1,12 +1,12 @@
 import { Box, Button, Typography } from '@mui/material';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { deleteRegistration, fetchRegistrationsByOwner } from '../../api/registrationApi';
 import { ConfirmDialog } from '../../components/ConfirmDialog';
 import { ListSkeleton } from '../../components/ListSkeleton';
+import { DocumentHeadTitle } from '../../context/DocumentHeadTitle';
 import { setNotification } from '../../redux/notificationSlice';
 import { RegistrationStatus } from '../../types/registration.types';
 import { MyRegistrationsList } from './MyRegistrationsList';
@@ -82,9 +82,7 @@ export const MyRegistrations = ({ selectedUnpublished, selectedPublished }: MyRe
 
   return (
     <>
-      <Helmet>
-        <title>{t('common.result_registrations')}</title>
-      </Helmet>
+      <DocumentHeadTitle>{t('common.result_registrations')}</DocumentHeadTitle>
       <div>
         {registrationsQuery.isPending ? (
           <ListSkeleton minWidth={100} maxWidth={100} height={100} />

--- a/src/pages/projects/ProjectLandingPage.tsx
+++ b/src/pages/projects/ProjectLandingPage.tsx
@@ -1,6 +1,5 @@
 import EditIcon from '@mui/icons-material/Edit';
 import { Box, IconButton, Paper, Tooltip } from '@mui/material';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { Link as RouterLink } from 'react-router';
@@ -8,6 +7,7 @@ import { LandingPageAccordion } from '../../components/landing_page/LandingPageA
 import { StyledPaperHeader } from '../../components/PageWithSideMenu';
 import { BackgroundDiv } from '../../components/styled/Wrappers';
 import { TruncatableTypography } from '../../components/TruncatableTypography';
+import { DocumentHeadTitle } from '../../context/DocumentHeadTitle';
 import { RootState } from '../../redux/store';
 import { CristinProject } from '../../types/project.types';
 import { dataTestId } from '../../utils/dataTestIds';
@@ -32,9 +32,7 @@ export const ProjectLandingPage = ({ project }: ProjectLandingPageProps) => {
 
   return (
     <Paper elevation={0}>
-      <Helmet>
-        <title>{project.title}</title>
-      </Helmet>
+      <DocumentHeadTitle>{project.title}</DocumentHeadTitle>
       <StyledPaperHeader sx={{ borderLeft: '1.5rem solid', borderColor: 'project.main' }}>
         <Box sx={{ display: 'flex', flexDirection: 'column' }}>
           <ProjectIconHeader projectStatus={project.status} />

--- a/src/pages/public_registration/PublicRegistrationContent.tsx
+++ b/src/pages/public_registration/PublicRegistrationContent.tsx
@@ -2,7 +2,6 @@ import EditIcon from '@mui/icons-material/Edit';
 import { Box, IconButton, Paper, Tooltip, Typography } from '@mui/material';
 import { visuallyHidden } from '@mui/utils';
 import { useQuery } from '@tanstack/react-query';
-import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { Link as RouterLink } from 'react-router';
 import { fetchResults, FetchResultsParams } from '../../api/searchApi';
@@ -12,6 +11,7 @@ import { RegistrationIconHeader } from '../../components/RegistrationIconHeader'
 import { StructuredSeoData } from '../../components/StructuredSeoData';
 import { BackgroundDiv } from '../../components/styled/Wrappers';
 import { TruncatableTypography } from '../../components/TruncatableTypography';
+import { DocumentHeadTitle } from '../../context/DocumentHeadTitle';
 import { PreviousPathLocationState } from '../../types/locationState.types';
 import { DegreeType, ResearchDataType } from '../../types/publicationFieldNames';
 import { ConfirmedDocument, Registration, RegistrationStatus, RelatedDocument } from '../../types/registration.types';
@@ -61,9 +61,8 @@ export const PublicRegistrationContent = ({ registration }: PublicRegistrationCo
   return (
     <Paper elevation={0} sx={{ gridArea: 'registration' }}>
       {registration.status === RegistrationStatus.Published && <StructuredSeoData uri={registration.id} />}
-      <Helmet>
-        <title>{mainTitle}</title>
-      </Helmet>
+
+      <DocumentHeadTitle>{mainTitle}</DocumentHeadTitle>
       <Box sx={visuallyHidden}>
         <DeletedPublicationInformation registration={registration} />
       </Box>

--- a/src/pages/research_profile/ResearchProfile.tsx
+++ b/src/pages/research_profile/ResearchProfile.tsx
@@ -4,7 +4,6 @@ import PhoneEnabledIcon from '@mui/icons-material/PhoneEnabled';
 import { Box, Chip, Divider, Grid, IconButton, List, Link as MuiLink, Typography } from '@mui/material';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
-import { Helmet } from 'react-helmet-async';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { Link, useLocation } from 'react-router';
@@ -20,6 +19,7 @@ import { ProfilePicture } from '../../components/ProfilePicture';
 import { projectSortOptions } from '../../components/ProjectSortSelector';
 import { SortSelectorWithoutParams } from '../../components/SortSelectorWithoutParams';
 import { BackgroundDiv } from '../../components/styled/Wrappers';
+import { DocumentHeadTitle } from '../../context/DocumentHeadTitle';
 import { RootState } from '../../redux/store';
 import orcidIcon from '../../resources/images/orcid_logo.svg';
 import { ROWS_PER_PAGE_OPTIONS } from '../../utils/constants';
@@ -168,9 +168,7 @@ const ResearchProfile = () => {
         {orcidUri && <img src={orcidIcon} height="20" alt="orcid" />}
       </Box>
       <BackgroundDiv>
-        <Helmet>
-          <title>{fullName}</title>
-        </Helmet>
+        <DocumentHeadTitle>{fullName}</DocumentHeadTitle>
 
         {activeAffiliations.length > 0 ? (
           <Box

--- a/src/translations/i18n.ts
+++ b/src/translations/i18n.ts
@@ -23,4 +23,15 @@ i18n.use(LanguageDetector).init({
   debug: false,
 });
 
+const getLanguageTagValue = (language: string) => {
+  if (language === 'eng') {
+    return 'en';
+  }
+  return 'no';
+};
+
+i18n.on('languageChanged', (lng) => {
+  document.documentElement.lang = getLanguageTagValue(lng);
+});
+
 export default i18n;


### PR DESCRIPTION
Dette er en del av bump av react til v19.
`react-helmet-async` støtter ikke react v19 nå, og ser litt ut som et dødt prosjekt.

I React 19 har de ny håntering av `<title>` som gjøre mye av det helmet gjør for oss i dag (men ikke alt). Har derfor prøvd å lage en egen context for å håndtere document title uten å måtte dra inn en egen pakke for dette. 

Ser ut til å virke, men må verifisere at det faktisk gjør det i alle tilfeller, OG at det ikke gir noen performance bottleneck som rammer hele appen. 
