### PR TITLE
Np 48439 handle uploaded file

### DIFF
--- a/src/pages/registration/FilesAndLicensePanel.tsx
+++ b/src/pages/registration/FilesAndLicensePanel.tsx
@@ -49,7 +49,10 @@ export const FilesAndLicensePanel = ({ uppy }: FilesAndLicensePanelProps) => {
   );
   const pendingFiles = files.filter(
     (file) =>
-      isPendingOpenFile(file) || file.type === FileType.PendingInternalFile || file.type === FileType.RejectedFile
+      isPendingOpenFile(file) ||
+      file.type === FileType.PendingInternalFile ||
+      file.type === FileType.RejectedFile ||
+      file.type === FileType.UpdloadedFile
   );
 
   const associatedLinkIndex = associatedArtifacts.findIndex(associatedArtifactIsLink);

--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -186,7 +186,7 @@ export const FilesTableRow = ({
         </VerticalAlignedTableCell>
         <VerticalAlignedTableCell>
           <Field name={fileTypeFieldName}>
-            {({ field }: FieldProps<FileType>) => (
+            {({ field, meta: { error, touched } }: FieldProps<FileType>) => (
               <TextField
                 {...field}
                 data-testid={dataTestId.registrationWizard.files.fileTypeSelect}
@@ -205,6 +205,8 @@ export const FilesTableRow = ({
                     setFieldValue(fileTypeFieldName, newValue);
                   }
                 }}
+                error={!!error && touched}
+                helperText={<ErrorMessage name={field.name} />}
                 slotProps={{
                   input: { sx: { '.MuiSelect-select': { py: '0.75rem' } } },
                   select: { inputProps: { 'aria-label': t('registration.files_and_license.availability') } },

--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -211,6 +211,11 @@ export const FilesTableRow = ({
                   input: { sx: { '.MuiSelect-select': { py: '0.75rem' } } },
                   select: { inputProps: { 'aria-label': t('registration.files_and_license.availability') } },
                 }}>
+                {field.value === FileType.UpdloadedFile && (
+                  <MenuItem value={FileType.UpdloadedFile} disabled hidden>
+                    <i>{t('registration.files_and_license.select_availability')}</i>
+                  </MenuItem>
+                )}
                 <MenuItem value={isCompletedFile ? FileType.OpenFile : FileType.PendingOpenFile}>
                   <StyledFileTypeMenuItemContent>
                     <CheckIcon fontSize="small" />

--- a/src/pages/registration/helpers/fileHelpers.test.ts
+++ b/src/pages/registration/helpers/fileHelpers.test.ts
@@ -160,7 +160,7 @@ describe('userCanEditFile', () => {
     expect(result).toBe(true);
   });
 
-  test('returns true for a uploaded file if the user is the uploader', () => {
+  test('returns true for an uploaded file if the user is the uploader', () => {
     const file: AssociatedFile = {
       ...emptyFile,
       uploadDetails: { type: 'UserUploadDetails', uploadedBy: '123@1.0.0.0', uploadedDate: '' },

--- a/src/pages/registration/helpers/fileHelpers.test.ts
+++ b/src/pages/registration/helpers/fileHelpers.test.ts
@@ -160,6 +160,30 @@ describe('userCanEditFile', () => {
     expect(result).toBe(true);
   });
 
+  test('returns true for a uploaded file if the user is the uploader', () => {
+    const file: AssociatedFile = {
+      ...emptyFile,
+      uploadDetails: { type: 'UserUploadDetails', uploadedBy: '123@1.0.0.0', uploadedDate: '' },
+      type: FileType.UpdloadedFile,
+    };
+    const user: User = { ...emptyUser, nvaUsername: '123@1.0.0.0' };
+
+    const result = userCanEditFile(file, user, emptyRegistration);
+    expect(result).toBe(true);
+  });
+
+  test('returns false for a uploaded file if the user is not the uploader', () => {
+    const file: AssociatedFile = {
+      ...emptyFile,
+      uploadDetails: { type: 'UserUploadDetails', uploadedBy: '123@1.0.0.0', uploadedDate: '' },
+      type: FileType.UpdloadedFile,
+    };
+    const user: User = { ...emptyUser, nvaUsername: '456@1.0.0.0' };
+
+    const result = userCanEditFile(file, user, emptyRegistration);
+    expect(result).toBe(false);
+  });
+
   test('returns true for a pending file if the user is the uploader', () => {
     const file: AssociatedFile = {
       ...emptyFile,

--- a/src/pages/registration/helpers/fileHelpers.ts
+++ b/src/pages/registration/helpers/fileHelpers.ts
@@ -42,7 +42,10 @@ export const userCanEditFile = (file: AssociatedFile, user: User | null, registr
   const isPublishingCuratorForUploader = user.isPublishingCurator && userIsOnSameInstitutionAsFileUploader;
 
   const isPendingFile =
-    isPendingOpenFile(file) || file.type === FileType.PendingInternalFile || file.type === FileType.RejectedFile;
+    isPendingOpenFile(file) ||
+    file.type === FileType.PendingInternalFile ||
+    file.type === FileType.RejectedFile ||
+    file.type === FileType.UpdloadedFile;
 
   if (isPendingFile) {
     const isFileUploader =

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -328,6 +328,10 @@
     "yes": "Ja"
   },
   "disciplines": {
+    "0001": "Humaniora",
+    "0002": "Samfunnsvitenskap",
+    "0003": "Medisin og helsefag",
+    "0004": "Realfag og teknologi",
     "1003": "Arkeologi og konservering",
     "1005": "Asiatiske og afrikanske studier",
     "1007": "Engelsk",
@@ -399,11 +403,7 @@
     "1162": "Konstruksjonsfag",
     "1166": "Filosofi",
     "1168": "Historie og idéhistorie",
-    "1170": "Kunst, design og arkitektur",
-    "0001": "Humaniora",
-    "0002": "Samfunnsvitenskap",
-    "0003": "Medisin og helsefag",
-    "0004": "Realfag og teknologi"
+    "1170": "Kunst, design og arkitektur"
   },
   "editor": {
     "categories_with_files": "Kategorier med filopplasting",
@@ -722,18 +722,18 @@
       "doi_given": "DOI tildelt",
       "doi_rejected": "DOI avvist",
       "doi_requested": "Etterspurt DOI",
-      "file_archived_one": "Fil arkivert",
-      "file_archived_other": "Filer arkivert",
       "file_archived_count_one": "{{count}} fil arkivert",
       "file_archived_count_other": "{{count}} filer arkivert",
+      "file_archived_one": "Fil arkivert",
+      "file_archived_other": "Filer arkivert",
       "file_published_count_one": "{{count}} fil publisert",
       "file_published_count_other": "{{count}} filer publisert",
       "files_published_one": "Fil publisert",
       "files_published_other": "Filer publisert",
-      "files_rejected_one": "Fil avvist",
-      "files_rejected_other": "Filer avvist",
       "files_rejected_count_one": "{{count}} fil avvist",
       "files_rejected_count_other": "{{count}} filer avvist",
+      "files_rejected_one": "Fil avvist",
+      "files_rejected_other": "Filer avvist",
       "files_uploaded_one": "Fil lastet opp",
       "files_uploaded_other": "Filer lastet opp",
       "imported": "Importert",
@@ -1471,6 +1471,7 @@
       "registration_without_file": "Resultat uten fil",
       "resource_has_no_files_or_links": "Ressursen har ingen filer eller lenker å publisere",
       "resource_is_a_reference": "Ressursen er en referanse og har ingen filer eller lenker å publisere",
+      "select_availability": "Velg tilgjengelighet",
       "show_all_older_versions": "Vis alle tidligere versjoner",
       "version_accepted_helper_text": "<0>Akseptert versjon</0>: forfatters siste gjennomarbeidede versjon etter at artikkelen har vært gjennom fagfellevurdering, slik den er sendt til forlaget. Denne versjonen har ikke forlagets sidetall og grafiske stil, eller eventuelle redaksjonelle omskrivinger, som den publiserte versjonen har. Denne versjonen bør deles i NVA, helst i pdf-format, med en CC-BY-lisens.",
       "version_accepted_helper_text_metadata_only": "<0>Akseptert versjon</0>: forfatters siste gjennomarbeidede versjon etter at artikkelen har vært gjennom fagfellevurdering, slik den er sendt til forlaget. Denne versjonen har ikke forlagets sidetall og grafiske stil, eller eventuelle redaksjonelle omskrivinger, som den publiserte versjonen har. Denne versjonen bør deles i NVA, helst i pdf-format, med en CC-BY-lisens.",
@@ -1480,8 +1481,7 @@
       "version_published_helper_text": "<0>Publisert versjon</0>: Artikkelen slik den presenteres i et tidsskrift, i trykk og/eller online. Denne versjonen vil inkludere eventuelle redaksjonelle forbedringer, og forlagets grafiske profil, etter utført fagfellevurdering. Vanligvis tilgjengelig på en utgivers nettsted, i PDF-format. Lisensen er normalt bestemt av utgiveren, så det sikre valget for lisens er «Utgivers betingelser». Mange utgivere støtter derimot Open Access og tillater bruk av CC-BY-lisensen.",
       "version_published_helper_text_metadata_only": "<0>Publisert versjon</0>: Artikkelen slik den presenteres i et tidsskrift, i trykk og/eller online. Denne versjonen vil inkludere eventuelle redaksjonelle forbedringer og forlagets grafiske profil, etter utført fagfellevurdering. Vanligvis tilgjengelig på en utgivers nettsted, i PDF-format. Lisensen er normalt bestemt av utgiveren, så det sikre valget for lisens er «Utgivers betingelser». Mange utgivere støtter derimot Open Access og tillater bruk av CC-BY-lisensen.",
       "version_publishing_agreement_helper_text": "<0>Forfatteravtalen</0> er en kontrakt mellom en utgiver og en artist eller forfatter. Den spesifiserer forhold som intellektuelt eierskap, hvor og hvordan verket kan offentliggjøres, betalinger, ansvarsbeskyttelse, konfidensialitet og royalty. Dette dokumentet er til stor hjelp for kuratorer når de gjør vurderinger om lisens og publiseringsdato (embargo). Slike dokumenter vil ikke være synlig for andre.",
-      "version_publishing_agreement_helper_text_metadata_only": "<0>Forfatteravtalen</0> er en kontrakt mellom en utgiver og en artist eller forfatter. Den spesifiserer forhold som intellektuelt eierskap, hvor og hvordan verket kan offentliggjøres, betalinger, ansvarsbeskyttelse, konfidensialitet og royalty. Dette dokumentet er til stor hjelp for kuratorer når de gjør vurderinger om lisens og publiseringsdato (embargo). Slike dokumenter vil ikke være synlig for andre.",
-      "select_availability": "Velg tilgjengelighet"
+      "version_publishing_agreement_helper_text_metadata_only": "<0>Forfatteravtalen</0> er en kontrakt mellom en utgiver og en artist eller forfatter. Den spesifiserer forhold som intellektuelt eierskap, hvor og hvordan verket kan offentliggjøres, betalinger, ansvarsbeskyttelse, konfidensialitet og royalty. Dette dokumentet er til stor hjelp for kuratorer når de gjør vurderinger om lisens og publiseringsdato (embargo). Slike dokumenter vil ikke være synlig for andre."
     },
     "heading": {
       "contributors": "Bidragsytere",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -328,10 +328,6 @@
     "yes": "Ja"
   },
   "disciplines": {
-    "0001": "Humaniora",
-    "0002": "Samfunnsvitenskap",
-    "0003": "Medisin og helsefag",
-    "0004": "Realfag og teknologi",
     "1003": "Arkeologi og konservering",
     "1005": "Asiatiske og afrikanske studier",
     "1007": "Engelsk",
@@ -403,7 +399,11 @@
     "1162": "Konstruksjonsfag",
     "1166": "Filosofi",
     "1168": "Historie og idéhistorie",
-    "1170": "Kunst, design og arkitektur"
+    "1170": "Kunst, design og arkitektur",
+    "0001": "Humaniora",
+    "0002": "Samfunnsvitenskap",
+    "0003": "Medisin og helsefag",
+    "0004": "Realfag og teknologi"
   },
   "editor": {
     "categories_with_files": "Kategorier med filopplasting",
@@ -1480,7 +1480,8 @@
       "version_published_helper_text": "<0>Publisert versjon</0>: Artikkelen slik den presenteres i et tidsskrift, i trykk og/eller online. Denne versjonen vil inkludere eventuelle redaksjonelle forbedringer, og forlagets grafiske profil, etter utført fagfellevurdering. Vanligvis tilgjengelig på en utgivers nettsted, i PDF-format. Lisensen er normalt bestemt av utgiveren, så det sikre valget for lisens er «Utgivers betingelser». Mange utgivere støtter derimot Open Access og tillater bruk av CC-BY-lisensen.",
       "version_published_helper_text_metadata_only": "<0>Publisert versjon</0>: Artikkelen slik den presenteres i et tidsskrift, i trykk og/eller online. Denne versjonen vil inkludere eventuelle redaksjonelle forbedringer og forlagets grafiske profil, etter utført fagfellevurdering. Vanligvis tilgjengelig på en utgivers nettsted, i PDF-format. Lisensen er normalt bestemt av utgiveren, så det sikre valget for lisens er «Utgivers betingelser». Mange utgivere støtter derimot Open Access og tillater bruk av CC-BY-lisensen.",
       "version_publishing_agreement_helper_text": "<0>Forfatteravtalen</0> er en kontrakt mellom en utgiver og en artist eller forfatter. Den spesifiserer forhold som intellektuelt eierskap, hvor og hvordan verket kan offentliggjøres, betalinger, ansvarsbeskyttelse, konfidensialitet og royalty. Dette dokumentet er til stor hjelp for kuratorer når de gjør vurderinger om lisens og publiseringsdato (embargo). Slike dokumenter vil ikke være synlig for andre.",
-      "version_publishing_agreement_helper_text_metadata_only": "<0>Forfatteravtalen</0> er en kontrakt mellom en utgiver og en artist eller forfatter. Den spesifiserer forhold som intellektuelt eierskap, hvor og hvordan verket kan offentliggjøres, betalinger, ansvarsbeskyttelse, konfidensialitet og royalty. Dette dokumentet er til stor hjelp for kuratorer når de gjør vurderinger om lisens og publiseringsdato (embargo). Slike dokumenter vil ikke være synlig for andre."
+      "version_publishing_agreement_helper_text_metadata_only": "<0>Forfatteravtalen</0> er en kontrakt mellom en utgiver og en artist eller forfatter. Den spesifiserer forhold som intellektuelt eierskap, hvor og hvordan verket kan offentliggjøres, betalinger, ansvarsbeskyttelse, konfidensialitet og royalty. Dette dokumentet er til stor hjelp for kuratorer når de gjør vurderinger om lisens og publiseringsdato (embargo). Slike dokumenter vil ikke være synlig for andre.",
+      "select_availability": "Velg tilgjengelighet"
     },
     "heading": {
       "contributors": "Bidragsytere",

--- a/src/types/associatedArtifact.types.ts
+++ b/src/types/associatedArtifact.types.ts
@@ -23,6 +23,7 @@ export enum FileType {
   InternalFile = 'InternalFile',
   PendingInternalFile = 'PendingInternalFile',
   HiddenFile = 'HiddenFile',
+  UpdloadedFile = 'UploadedFile',
 }
 
 export interface AssociatedFile {

--- a/src/utils/formik-helpers/formik-helpers.ts
+++ b/src/utils/formik-helpers/formik-helpers.ts
@@ -451,6 +451,7 @@ const touchedFilesTabFields = (associatedArtifacts: AssociatedArtifact[]): Formi
   associatedArtifacts: associatedArtifacts.map((artifact) => {
     if (associatedArtifactIsFile(artifact)) {
       const touched: FormikTouched<AssociatedFile> = {
+        type: true,
         publisherVersion: true,
         embargoDate: true,
         license: true,

--- a/src/utils/validation/registration/associatedArtifactValidation.ts
+++ b/src/utils/validation/registration/associatedArtifactValidation.ts
@@ -1,6 +1,6 @@
 import * as Yup from 'yup';
 import i18n from '../../../translations/i18n';
-import { FileVersion } from '../../../types/associatedArtifact.types';
+import { FileType, FileVersion } from '../../../types/associatedArtifact.types';
 import {
   associatedArtifactIsFile,
   associatedArtifactIsLink,
@@ -10,6 +10,9 @@ import {
 } from '../../registration-helpers';
 
 const associatedArtifactErrorMessage = {
+  availabilityRequired: i18n.t('feedback.validation.is_required', {
+    field: i18n.t('registration.files_and_license.availability'),
+  }),
   fileVersionRequired: i18n.t('feedback.validation.is_required', {
     field: i18n.t('common.version'),
   }),
@@ -31,10 +34,12 @@ const linkValidation = Yup.string()
     associatedArtifactIsLink({ type }) ? schema.url(associatedArtifactErrorMessage.linkInvalid) : schema
   );
 
-export const associatedArtifactValidationSchema = Yup.object({
-  type: Yup.string(),
+const validFileTypes = Object.values(FileType).filter((type) => type !== FileType.UpdloadedFile);
 
-  // File validation
+export const associatedArtifactValidationSchema = Yup.object({
+  type: Yup.string()
+    .oneOf(validFileTypes, associatedArtifactErrorMessage.availabilityRequired)
+    .required(associatedArtifactErrorMessage.availabilityRequired),
   embargoDate: Yup.date()
     .nullable()
     .when(['type'], ([type], schema) =>


### PR DESCRIPTION
Bygger videre på https://github.com/BIBSYSDEV/NVA-Frontend/pull/6922

- Bruker må nå eksplisitt velge tilgjengelighet etter at fila er lastet opp (tidligere ble den automatisk satt til å være åpen fil)
- Vis feilmelding om filtypen ikke er satt til noe gyldig

Litt uheldig at vi har "Velg tilgjengelighet" her mens vi har en vanlig label i lisens. Årsaken er at label der er ulik i motsetning til tilgjengelighet, så det gir mer mening å ha egen label. Kunne ev. hatt label i stedet for denne placeholderen til Tilgjengelighet også om det er bedre.

![bilde](https://github.com/user-attachments/assets/14b50580-6c3f-49e2-897d-97fc90104428)
