### PR TITLE
NP-48568 Avoid searching for duplicate on each key stroke

### DIFF
--- a/src/pages/registration/DescriptionPanel.tsx
+++ b/src/pages/registration/DescriptionPanel.tsx
@@ -3,7 +3,7 @@ import ErrorIcon from '@mui/icons-material/Error';
 import { Autocomplete, Box, Button, CircularProgress, Divider, MenuItem, TextField } from '@mui/material';
 import { ErrorMessage, Field, FieldProps, useFormikContext } from 'formik';
 import { getLanguageByIso6393Code } from 'nva-language';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDuplicateRegistrationSearch } from '../../api/hooks/useDuplicateRegistrationSearch';
 import { InputContainerBox } from '../../components/styled/Wrappers';
@@ -22,10 +22,10 @@ import { DuplicateWarning } from './DuplicateWarning';
 export const DescriptionPanel = () => {
   const { t, i18n } = useTranslation();
   const { values, setFieldValue } = useFormikContext<Registration>();
-  const [title, setTitle] = useState('');
-  const debouncedTitle = useDebounce(title);
+  const debouncedTitle = useDebounce(values.entityDescription?.mainTitle ?? '');
+
   const { titleSearchPending, duplicateRegistration } = useDuplicateRegistrationSearch({
-    title: debouncedTitle || values.entityDescription?.mainTitle,
+    title: debouncedTitle,
     identifier: values.identifier,
   });
 
@@ -46,10 +46,6 @@ export const DescriptionPanel = () => {
               required
               data-testid={dataTestId.registrationWizard.description.titleField}
               variant="filled"
-              onChange={(event) => {
-                setTitle(event.target.value);
-                field.onChange(event);
-              }}
               fullWidth
               label={t('common.title')}
               error={touched && !!error}


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48568

Unngå å søke etter duplikat for hver input når tittelen er tom fra før. Se før/etter bilder for hva som skjer om jeg holder skriver "aaaaaa" fort.

Før:
![bilde](https://github.com/user-attachments/assets/8019630a-5d58-4b4e-983d-3836b984a693)

Etter:
![bilde](https://github.com/user-attachments/assets/706e3266-61a2-43e9-a076-df14a902d9e1)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
