### PR TITLE
NP-48494 Ensure correct number of cells in files table

### DIFF
--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -255,60 +255,65 @@ export const FilesTableRow = ({
         </VerticalAlignedTableCell>
         {showAllColumns && (
           <>
-            {isOpenableFile && showFileVersion && (
+            {showFileVersion && (
               <VerticalAlignedTableCell>
-                <Field name={publisherVersionFieldName}>
-                  {({ field, meta: { error, touched } }: FieldProps<FileVersion | null>) => (
-                    <FormControl data-testid={dataTestId.registrationWizard.files.version} required disabled={disabled}>
-                      <RadioGroup
-                        {...field}
-                        row
-                        sx={{ flexWrap: 'nowrap' }}
-                        onChange={(event) => {
-                          const fileVersion = event.target.value as FileVersion;
-                          setFieldValue(field.name, fileVersion);
+                {isOpenableFile && (
+                  <Field name={publisherVersionFieldName}>
+                    {({ field, meta: { error, touched } }: FieldProps<FileVersion | null>) => (
+                      <FormControl
+                        data-testid={dataTestId.registrationWizard.files.version}
+                        required
+                        disabled={disabled}>
+                        <RadioGroup
+                          {...field}
+                          row
+                          sx={{ flexWrap: 'nowrap' }}
+                          onChange={(event) => {
+                            const fileVersion = event.target.value as FileVersion;
+                            setFieldValue(field.name, fileVersion);
 
-                          if (showRrs) {
-                            if (fileVersion === FileVersion.Published) {
-                              const nullRrsValue: FileRrs = {
-                                type: 'NullRightsRetentionStrategy',
-                                configuredType: rrsStrategy,
-                              };
-                              setFieldValue(rrsFieldName, nullRrsValue);
-                              setFieldValue(licenseFieldName, null);
-                            } else if (isCustomerRrs || isOverridableRrs) {
-                              const customerRrsValue: FileRrs = {
-                                type: 'CustomerRightsRetentionStrategy',
-                                configuredType: rrsStrategy,
-                              };
-                              setFieldValue(rrsFieldName, customerRrsValue);
-                              setFieldValue(licenseFieldName, LicenseUri.CC_BY_4);
+                            if (showRrs) {
+                              if (fileVersion === FileVersion.Published) {
+                                const nullRrsValue: FileRrs = {
+                                  type: 'NullRightsRetentionStrategy',
+                                  configuredType: rrsStrategy,
+                                };
+                                setFieldValue(rrsFieldName, nullRrsValue);
+                                setFieldValue(licenseFieldName, null);
+                              } else if (isCustomerRrs || isOverridableRrs) {
+                                const customerRrsValue: FileRrs = {
+                                  type: 'CustomerRightsRetentionStrategy',
+                                  configuredType: rrsStrategy,
+                                };
+                                setFieldValue(rrsFieldName, customerRrsValue);
+                                setFieldValue(licenseFieldName, LicenseUri.CC_BY_4);
+                              }
                             }
-                          }
-                        }}>
-                        <FormControlLabel
-                          value={FileVersion.Accepted}
-                          control={<Radio />}
-                          label={
-                            <Typography variant="caption" sx={{ lineHeight: '1.1rem' }}>
-                              {t('registration.files_and_license.accepted_version')}
-                            </Typography>
-                          }
-                        />
-                        <FormControlLabel
-                          value={FileVersion.Published}
-                          control={<Radio />}
-                          label={
-                            <Typography variant="caption" sx={{ lineHeight: '1.1rem' }}>
-                              {t('registration.files_and_license.published_version')}
-                            </Typography>
-                          }
-                        />
-                      </RadioGroup>
-                      {error && touched && <FormHelperText error>{error}</FormHelperText>}
-                    </FormControl>
-                  )}
-                </Field>
+                          }}>
+                          <FormControlLabel
+                            value={FileVersion.Accepted}
+                            control={<Radio />}
+                            label={
+                              <Typography variant="caption" sx={{ lineHeight: '1.1rem' }}>
+                                {t('registration.files_and_license.accepted_version')}
+                              </Typography>
+                            }
+                          />
+                          <FormControlLabel
+                            value={FileVersion.Published}
+                            control={<Radio />}
+                            label={
+                              <Typography variant="caption" sx={{ lineHeight: '1.1rem' }}>
+                                {t('registration.files_and_license.published_version')}
+                              </Typography>
+                            }
+                          />
+                        </RadioGroup>
+                        {error && touched && <FormHelperText error>{error}</FormHelperText>}
+                      </FormControl>
+                    )}
+                  </Field>
+                )}
               </VerticalAlignedTableCell>
             )}
             <VerticalAlignedTableCell>


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48494

Sørg for at filter-tabellen alltid viser riktig antall celler. Ellers blir det synlige mangler i borders, og enda synligere når bruker ikke kan gjøre endringer på filer fordi de er disabled.

Det er en del logikk og sjekking her som gjør alt ganske tunglest, men ser ikke noen enklere løsning som ikke er å skrive om alt. Gjør det også vanskelig å se om det introduserer et nytt problem :( 
Kunstig stor diff pga indenteringsendring, men det som er gjort er i praksis bare å flytte sjekken for `showFileVersion` ett hakk opp. Enklere å reviewe sånne ting i "split" view enn "unified" jeg bruker til vanlig IMO.

Før:
![bilde](https://github.com/user-attachments/assets/314b35b5-fe22-48f1-94de-3a2a022ddc14)

Etter:
![bilde](https://github.com/user-attachments/assets/f9f3ded8-2403-49c1-a5f5-439ea3ce7436)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
