### PR TITLE
Allow closing modal with keyboard navigation

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -38,7 +38,7 @@ export const Modal = ({
         timeout: 500,
       }}
       PaperProps={{ 'aria-labelledby': 'titleId', ...PaperProps }}>
-      <Box sx={{ display: 'flex', pt: '1rem', justifyContent: 'space-between', mx: '1rem' }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: '1rem', mx: '1rem' }}>
         <DialogTitle id="titleId" sx={{ padding: 0 }}>
           {headingText}
         </DialogTitle>
@@ -50,7 +50,7 @@ export const Modal = ({
         </IconButton>
       </Box>
 
-      <Box sx={{ p: '1rem' }}>{children}</Box>
+      <Box sx={{ m: '1rem' }}>{children}</Box>
     </Dialog>
   );
 };

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,22 +1,7 @@
 import CloseIcon from '@mui/icons-material/Close';
-import {
-  Avatar,
-  AvatarProps,
-  Backdrop,
-  Box,
-  Dialog,
-  DialogProps,
-  DialogTitle,
-  IconButton,
-  styled,
-} from '@mui/material';
+import { AvatarProps, Backdrop, Box, Dialog, DialogProps, DialogTitle, IconButton } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { dataTestId as dataTestIdObject } from '../utils/dataTestIds';
-
-const StyledSpan = styled('span')({
-  gridArea: 'text',
-  marginLeft: '1rem',
-});
 
 interface ModalProps extends Partial<DialogProps> {
   dataTestId?: string;
@@ -31,7 +16,6 @@ export const Modal = ({
   dataTestId,
   headingIcon,
   headingText,
-  headingDataTestId,
   onClose,
   open,
   PaperProps,
@@ -54,41 +38,13 @@ export const Modal = ({
         timeout: 500,
       }}
       PaperProps={{ 'aria-labelledby': 'titleId', ...PaperProps }}>
-      <Box sx={{ display: 'flex', pt: '1rem', justifyContent: 'space-between' }}>
-        <DialogTitle sx={{ gridArea: 'text', padding: 0 }}>
-          {headingIcon ? (
-            <Box
-              sx={{
-                display: 'grid',
-                gridTemplateAreas: { xs: "'text'", sm: "'avatar text'" },
-                gridTemplateColumns: { xs: '1fr', sm: '1fr 7fr' },
-                alignItems: 'center',
-              }}>
-              {headingIcon && (
-                <Avatar
-                  src={headingIcon.src}
-                  alt={headingIcon.alt}
-                  sx={{
-                    gridArea: 'avatar',
-                    ml: '1rem',
-                    display: { xs: 'none', sm: 'block' },
-                  }}
-                />
-              )}
-              <StyledSpan id="titleId" data-testid={headingDataTestId}>
-                {headingText}
-              </StyledSpan>
-            </Box>
-          ) : (
-            <StyledSpan id="titleId" data-testid={headingDataTestId}>
-              {headingText}
-            </StyledSpan>
-          )}
+      <Box sx={{ display: 'flex', pt: '1rem', justifyContent: 'space-between', mx: '1rem' }}>
+        <DialogTitle id="titleId" sx={{ padding: 0 }}>
+          {headingText}
         </DialogTitle>
         <IconButton
           title={t('common.close')}
           onClick={handleClose}
-          sx={{ gridArea: 'cross', cursor: 'pointer', mr: '1rem', justifySelf: 'end' }}
           data-testid={dataTestIdObject.confirmDialog.cancelButton}>
           <CloseIcon />
         </IconButton>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,9 +1,19 @@
 import CloseIcon from '@mui/icons-material/Close';
-import { Avatar, AvatarProps, Backdrop, Dialog, DialogProps, DialogTitle } from '@mui/material';
-import { Box, styled as muiStyled } from '@mui/system';
+import {
+  Avatar,
+  AvatarProps,
+  Backdrop,
+  Box,
+  Dialog,
+  DialogProps,
+  DialogTitle,
+  IconButton,
+  styled,
+} from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { dataTestId as dataTestIdObject } from '../utils/dataTestIds';
 
-const StyledSpan = muiStyled('span')({
+const StyledSpan = styled('span')({
   gridArea: 'text',
   marginLeft: '1rem',
 });
@@ -44,7 +54,7 @@ export const Modal = ({
         timeout: 500,
       }}
       PaperProps={{ 'aria-labelledby': 'titleId', ...PaperProps }}>
-      <Box sx={{ display: 'grid', pt: '1rem', gridTemplateAreas: "'text cross'", gridTemplateColumns: 'auto 1fr' }}>
+      <Box sx={{ display: 'flex', pt: '1rem', justifyContent: 'space-between' }}>
         <DialogTitle sx={{ gridArea: 'text', padding: 0 }}>
           {headingIcon ? (
             <Box
@@ -75,12 +85,13 @@ export const Modal = ({
             </StyledSpan>
           )}
         </DialogTitle>
-        <CloseIcon
+        <IconButton
+          title={t('common.close')}
           onClick={handleClose}
-          data-testid="close-modal"
-          titleAccess={t('common.close')}
           sx={{ gridArea: 'cross', cursor: 'pointer', mr: '1rem', justifySelf: 'end' }}
-        />
+          data-testid={dataTestIdObject.confirmDialog.cancelButton}>
+          <CloseIcon />
+        </IconButton>
       </Box>
 
       <Box sx={{ p: '1rem' }}>{children}</Box>


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48533

Kryss-ikon oppi til høyre i vår gamle Modal kan nå nås med tastaturnavigasjon. Fjernet en del gammel kode som ikke trengs lenger også.
Tror vi helst burde komme helt bort fra vår `<Modal>` til `<Dialog>` men det er en annen mer langsiktig sak

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
