### PR TITLE
Np 48581 show loading facets

### DIFF
--- a/src/api/hooks/useSearchForPerson.ts
+++ b/src/api/hooks/useSearchForPerson.ts
@@ -15,11 +15,11 @@ interface PersonSearchOptions extends PersonSearchParams {
   placeholderData?: PlaceholderDataFunctionType;
 }
 
-export const useSearchForPerson = ({ enabled = true, placeholderData, ...searchParams }: PersonSearchOptions) => {
+export const useSearchForPerson = ({ enabled, placeholderData, ...searchParams }: PersonSearchOptions) => {
   const { t } = useTranslation();
 
   return useQuery({
-    enabled: enabled && !!searchParams.name && searchParams.name.length > 0,
+    enabled,
     queryKey: ['personSearch', searchParams],
     queryFn: () => searchForPerson(searchParams),
     meta: { errorMessage: t('feedback.error.person_search') },

--- a/src/pages/dashboard/HomePage.tsx
+++ b/src/pages/dashboard/HomePage.tsx
@@ -127,9 +127,7 @@ const HomePage = () => {
             {resultIsSelected ? (
               <RegistrationFacetsFilter registrationQuery={registrationQuery} />
             ) : personIsSeleced ? (
-              personQuery.data?.aggregations ? (
-                <PersonFacetsFilter personQuery={personQuery} />
-              ) : null
+              <PersonFacetsFilter personQuery={personQuery} />
             ) : projectIsSelected ? (
               projectQuery.data?.aggregations ? (
                 <ProjectFacetsFilter projectQuery={projectQuery} />

--- a/src/pages/dashboard/HomePage.tsx
+++ b/src/pages/dashboard/HomePage.tsx
@@ -64,9 +64,8 @@ const HomePage = () => {
     keepDataWhileLoading: true,
   });
 
-  const personSearchTerm = params.get(PersonSearchParameter.Name) ?? '.';
   const personQueryParams: PersonSearchParams = {
-    name: personSearchTerm,
+    name: params.get(PersonSearchParameter.Name),
     orderBy: params.get(PersonSearchParameter.OrderBy),
     organization: params.get(PersonSearchParameter.Organization),
     sector: params.get(PersonSearchParameter.Sector),

--- a/src/pages/dashboard/HomePage.tsx
+++ b/src/pages/dashboard/HomePage.tsx
@@ -129,9 +129,7 @@ const HomePage = () => {
             ) : personIsSeleced ? (
               <PersonFacetsFilter personQuery={personQuery} />
             ) : projectIsSelected ? (
-              projectQuery.data?.aggregations ? (
-                <ProjectFacetsFilter projectQuery={projectQuery} />
-              ) : null
+              <ProjectFacetsFilter projectQuery={projectQuery} />
             ) : null}
           </Box>
         </NavigationListAccordion>

--- a/src/pages/search/person_search/PersonFacetsFilter.tsx
+++ b/src/pages/search/person_search/PersonFacetsFilter.tsx
@@ -28,13 +28,13 @@ export const PersonFacetsFilter = ({ personQuery }: PersonFacetsFilterProps) => 
     const newSearchParams = new URLSearchParams(
       `${SearchParam.Type}=${currentSearchType}&${searchParameters.toString()}`
     );
-    newSearchParams.set(SearchParam.Page, '1');
+    newSearchParams.delete(SearchParam.Page);
     navigate({ search: newSearchParams.toString() });
   };
 
   const removeFacetFilter = (parameter: PersonSearchParameter, keyToRemove: string) => {
     const newSearchParams = removeSearchParamValue(searchParams, parameter, keyToRemove);
-    newSearchParams.set(SearchParam.Page, '1');
+    newSearchParams.delete(SearchParam.Page);
     navigate({ search: newSearchParams.toString() });
   };
 

--- a/src/pages/search/person_search/PersonFacetsFilter.tsx
+++ b/src/pages/search/person_search/PersonFacetsFilter.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router';
 import { PersonSearchParameter } from '../../../api/cristinApi';
 import { dataTestId } from '../../../utils/dataTestIds';
-import { removeSearchParamValue, SearchParam, syncParamsWithSearchFields } from '../../../utils/searchHelpers';
+import { removeSearchParamValue, syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 import { getLanguageString } from '../../../utils/translation-helpers';
 import { FacetItem } from '../FacetItem';
 import { FacetListItem } from '../FacetListItem';
@@ -30,14 +30,14 @@ export const PersonFacetsFilter = ({ personQuery }: PersonFacetsFilterProps) => 
     } else {
       syncedParams.set(param, [...currentValues, key].join(','));
     }
-    syncedParams.delete(SearchParam.Page);
+    syncedParams.delete(PersonSearchParameter.Page);
     navigate({ search: syncedParams.toString() });
   };
 
   const removeFacetFilter = (parameter: PersonSearchParameter, keyToRemove: string) => {
     const syncedParams = syncParamsWithSearchFields(searchParams);
     const newSearchParams = removeSearchParamValue(syncedParams, parameter, keyToRemove);
-    newSearchParams.delete(SearchParam.Page);
+    newSearchParams.delete(PersonSearchParameter.Page);
     navigate({ search: newSearchParams.toString() });
   };
 

--- a/src/pages/search/person_search/PersonFacetsFilter.tsx
+++ b/src/pages/search/person_search/PersonFacetsFilter.tsx
@@ -14,8 +14,8 @@ export const PersonFacetsFilter = ({ personQuery }: PersonFacetsFilterProps) => 
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
-  const organizationFacet = personQuery.data?.aggregations?.organizationFacet;
-  const sectorFacet = personQuery.data?.aggregations?.sectorFacet;
+  const organizationFacet = personQuery.data?.aggregations?.organizationFacet ?? [];
+  const sectorFacet = personQuery.data?.aggregations?.sectorFacet ?? [];
 
   const searchParams = new URLSearchParams(location.search);
   const currentSearchType = searchParams.get(SearchParam.Type);
@@ -40,8 +40,11 @@ export const PersonFacetsFilter = ({ personQuery }: PersonFacetsFilterProps) => 
 
   return (
     <>
-      {organizationFacet && organizationFacet?.length > 0 && (
-        <FacetItem title={t('common.institution')} dataTestId={dataTestId.aggregations.institutionFacets}>
+      {(personQuery.isPending || organizationFacet.length > 0) && (
+        <FacetItem
+          title={t('common.institution')}
+          dataTestId={dataTestId.aggregations.institutionFacets}
+          isPending={personQuery.isPending}>
           {organizationFacet.map((facet) => {
             const isSelected = selectedOrganizations.includes(facet.key);
             return (
@@ -63,8 +66,11 @@ export const PersonFacetsFilter = ({ personQuery }: PersonFacetsFilterProps) => 
         </FacetItem>
       )}
 
-      {sectorFacet && sectorFacet?.length > 0 && (
-        <FacetItem title={t('search.sector')} dataTestId={dataTestId.aggregations.sectorFacets}>
+      {(personQuery.isPending || sectorFacet.length > 0) && (
+        <FacetItem
+          title={t('search.sector')}
+          dataTestId={dataTestId.aggregations.sectorFacets}
+          isPending={personQuery.isPending}>
           {sectorFacet.map((facet) => {
             const isSelected = selectedSectors.includes(facet.key);
             return (

--- a/src/pages/search/project_search/ProjectFacetsFilter.tsx
+++ b/src/pages/search/project_search/ProjectFacetsFilter.tsx
@@ -15,14 +15,14 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
-  const sectorFacet = projectQuery.data?.aggregations?.sectorFacet;
-  const coordinatingFacet = projectQuery.data?.aggregations?.coordinatingFacet;
-  const healthProjectFacet = projectQuery.data?.aggregations?.healthProjectFacet;
-  const responsibleFacet = projectQuery.data?.aggregations?.responsibleFacet;
-  const participantOrgFacet = projectQuery.data?.aggregations?.participantOrgFacet;
-  const categoryFacet = projectQuery.data?.aggregations?.categoryFacet;
-  const participantFacet = projectQuery.data?.aggregations?.participantFacet;
-  const fundingSourceFacet = projectQuery.data?.aggregations?.fundingSourceFacet;
+  const sectorFacet = projectQuery.data?.aggregations?.sectorFacet ?? [];
+  const coordinatingFacet = projectQuery.data?.aggregations?.coordinatingFacet ?? [];
+  const healthProjectFacet = projectQuery.data?.aggregations?.healthProjectFacet ?? [];
+  const responsibleFacet = projectQuery.data?.aggregations?.responsibleFacet ?? [];
+  const participantOrgFacet = projectQuery.data?.aggregations?.participantOrgFacet ?? [];
+  const categoryFacet = projectQuery.data?.aggregations?.categoryFacet ?? [];
+  const participantFacet = projectQuery.data?.aggregations?.participantFacet ?? [];
+  const fundingSourceFacet = projectQuery.data?.aggregations?.fundingSourceFacet ?? [];
 
   const searchParams = new URLSearchParams(location.search);
   const currentSearchType = searchParams.get(SearchParam.Type);
@@ -56,10 +56,11 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
 
   return (
     <>
-      {coordinatingFacet && coordinatingFacet?.length > 0 && (
+      {(projectQuery.isPending || coordinatingFacet.length > 0) && (
         <FacetItem
           title={t('project.coordinating_institution')}
-          dataTestId={dataTestId.aggregations.coordinatingFacets}>
+          dataTestId={dataTestId.aggregations.coordinatingFacets}
+          isPending={projectQuery.isPending}>
           {coordinatingFacet.map((facet) => {
             const isSelected = selectedCoordinating.includes(facet.key);
             return (
@@ -81,8 +82,11 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
         </FacetItem>
       )}
 
-      {responsibleFacet && responsibleFacet?.length > 0 && (
-        <FacetItem title={t('search.responsible_institution')} dataTestId={dataTestId.aggregations.responsibleFacets}>
+      {(projectQuery.isPending || responsibleFacet.length > 0) && (
+        <FacetItem
+          title={t('search.responsible_institution')}
+          dataTestId={dataTestId.aggregations.responsibleFacets}
+          isPending={projectQuery.isPending}>
           {responsibleFacet.map((facet) => {
             const isSelected = selectedResponsible.includes(facet.key);
             return (
@@ -104,10 +108,11 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
         </FacetItem>
       )}
 
-      {participantOrgFacet && participantOrgFacet?.length > 0 && (
+      {(projectQuery.isPending || participantOrgFacet.length > 0) && (
         <FacetItem
           title={t('search.participating_institution')}
-          dataTestId={dataTestId.aggregations.participantOrgFacets}>
+          dataTestId={dataTestId.aggregations.participantOrgFacets}
+          isPending={projectQuery.isPending}>
           {participantOrgFacet.map((facet) => {
             const isSelected = selectedParticipantOrg.includes(facet.key);
             return (
@@ -129,8 +134,11 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
         </FacetItem>
       )}
 
-      {sectorFacet && sectorFacet?.length > 0 && (
-        <FacetItem title={t('search.sector')} dataTestId={dataTestId.aggregations.sectorFacets}>
+      {(projectQuery.isPending || sectorFacet.length > 0) && (
+        <FacetItem
+          title={t('search.sector')}
+          dataTestId={dataTestId.aggregations.sectorFacets}
+          isPending={projectQuery.isPending}>
           {sectorFacet.map((facet) => {
             const isSelected = selectedSectors.includes(facet.key);
             return (
@@ -152,8 +160,11 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
         </FacetItem>
       )}
 
-      {categoryFacet && categoryFacet?.length > 0 && (
-        <FacetItem title={t('common.category')} dataTestId={dataTestId.aggregations.categoryFacets}>
+      {(projectQuery.isPending || categoryFacet.length > 0) && (
+        <FacetItem
+          title={t('common.category')}
+          dataTestId={dataTestId.aggregations.categoryFacets}
+          isPending={projectQuery.isPending}>
           {categoryFacet.map((facet) => {
             const isSelected = selecetedCategories.includes(facet.key);
             return (
@@ -175,8 +186,11 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
         </FacetItem>
       )}
 
-      {healthProjectFacet && healthProjectFacet?.length > 0 && (
-        <FacetItem title={t('search.health_project_type')} dataTestId={dataTestId.aggregations.healthProjectFacets}>
+      {(projectQuery.isPending || healthProjectFacet.length > 0) && (
+        <FacetItem
+          title={t('search.health_project_type')}
+          dataTestId={dataTestId.aggregations.healthProjectFacets}
+          isPending={projectQuery.isPending}>
           {healthProjectFacet.map((facet) => {
             const isSelected = selectedHealthProject.includes(facet.key);
             return (
@@ -198,8 +212,11 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
         </FacetItem>
       )}
 
-      {participantFacet && participantFacet?.length > 0 && (
-        <FacetItem title={t('search.participant')} dataTestId={dataTestId.aggregations.participantFacets}>
+      {(projectQuery.isPending || participantFacet.length > 0) && (
+        <FacetItem
+          title={t('search.participant')}
+          dataTestId={dataTestId.aggregations.participantFacets}
+          isPending={projectQuery.isPending}>
           {participantFacet.map((facet) => {
             const isSelected = selectedParticipants.includes(facet.key);
             return (
@@ -221,8 +238,11 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
         </FacetItem>
       )}
 
-      {fundingSourceFacet && fundingSourceFacet?.length > 0 && (
-        <FacetItem title={t('common.funding')} dataTestId={dataTestId.aggregations.fundingSourceFacets}>
+      {(projectQuery.isPending || fundingSourceFacet.length > 0) && (
+        <FacetItem
+          title={t('common.funding')}
+          dataTestId={dataTestId.aggregations.fundingSourceFacets}
+          isPending={projectQuery.isPending}>
           {fundingSourceFacet.map((facet) => {
             const isSelected = selectedFundingSources.includes(facet.key);
             return (

--- a/src/pages/search/project_search/ProjectFacetsFilter.tsx
+++ b/src/pages/search/project_search/ProjectFacetsFilter.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router';
 import { ProjectSearchParameter } from '../../../api/cristinApi';
 import { dataTestId } from '../../../utils/dataTestIds';
-import { removeSearchParamValue, SearchParam } from '../../../utils/searchHelpers';
+import { removeSearchParamValue, SearchParam, syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 import { getLanguageString } from '../../../utils/translation-helpers';
 import { FacetItem } from '../FacetItem';
 import { FacetListItem } from '../FacetListItem';
@@ -25,7 +25,6 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
   const fundingSourceFacet = projectQuery.data?.aggregations?.fundingSourceFacet ?? [];
 
   const searchParams = new URLSearchParams(location.search);
-  const currentSearchType = searchParams.get(SearchParam.Type);
 
   const selectedCoordinating = searchParams.get(ProjectSearchParameter.CoordinatingFacet)?.split(',') ?? [];
   const selectedSectors = searchParams.get(ProjectSearchParameter.SectorFacet)?.split(',') ?? [];
@@ -37,19 +36,20 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
   const selectedFundingSources = searchParams.get(ProjectSearchParameter.FundingSourceFacet)?.split(',') ?? [];
 
   const addFacetFilter = (param: ProjectSearchParameter, key: string) => {
-    const currentValues = searchParams.get(param)?.split(',') ?? [];
+    const syncedParams = syncParamsWithSearchFields(searchParams);
+    const currentValues = syncedParams.get(param)?.split(',') ?? [];
     if (currentValues.length === 0) {
-      searchParams.set(param, key);
+      syncedParams.set(param, key);
     } else {
-      searchParams.set(param, [...currentValues, key].join(','));
+      syncedParams.set(param, [...currentValues, key].join(','));
     }
-    searchParams.set(SearchParam.Type, currentSearchType ?? '');
-    searchParams.delete(SearchParam.Page);
-    navigate({ search: searchParams.toString() });
+    syncedParams.delete(SearchParam.Page);
+    navigate({ search: syncedParams.toString() });
   };
 
   const removeFacetFilter = (parameter: ProjectSearchParameter, keyToRemove: string) => {
-    const newSearchParams = removeSearchParamValue(searchParams, parameter, keyToRemove);
+    const syncedParams = syncParamsWithSearchFields(searchParams);
+    const newSearchParams = removeSearchParamValue(syncedParams, parameter, keyToRemove);
     newSearchParams.delete(SearchParam.Page);
     navigate({ search: newSearchParams.toString() });
   };

--- a/src/pages/search/project_search/ProjectFacetsFilter.tsx
+++ b/src/pages/search/project_search/ProjectFacetsFilter.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router';
 import { ProjectSearchParameter } from '../../../api/cristinApi';
 import { dataTestId } from '../../../utils/dataTestIds';
-import { removeSearchParamValue, SearchParam, syncParamsWithSearchFields } from '../../../utils/searchHelpers';
+import { removeSearchParamValue, syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 import { getLanguageString } from '../../../utils/translation-helpers';
 import { FacetItem } from '../FacetItem';
 import { FacetListItem } from '../FacetListItem';
@@ -43,14 +43,14 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
     } else {
       syncedParams.set(param, [...currentValues, key].join(','));
     }
-    syncedParams.delete(SearchParam.Page);
+    syncedParams.delete(ProjectSearchParameter.Page);
     navigate({ search: syncedParams.toString() });
   };
 
   const removeFacetFilter = (parameter: ProjectSearchParameter, keyToRemove: string) => {
     const syncedParams = syncParamsWithSearchFields(searchParams);
     const newSearchParams = removeSearchParamValue(syncedParams, parameter, keyToRemove);
-    newSearchParams.delete(SearchParam.Page);
+    newSearchParams.delete(ProjectSearchParameter.Page);
     navigate({ search: newSearchParams.toString() });
   };
 

--- a/src/pages/search/project_search/ProjectFacetsFilter.tsx
+++ b/src/pages/search/project_search/ProjectFacetsFilter.tsx
@@ -44,13 +44,13 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
       searchParams.set(param, [...currentValues, key].join(','));
     }
     searchParams.set(SearchParam.Type, currentSearchType ?? '');
-    searchParams.set(SearchParam.Page, '1');
+    searchParams.delete(SearchParam.Page);
     navigate({ search: searchParams.toString() });
   };
 
   const removeFacetFilter = (parameter: ProjectSearchParameter, keyToRemove: string) => {
     const newSearchParams = removeSearchParamValue(searchParams, parameter, keyToRemove);
-    newSearchParams.set(SearchParam.Page, '1');
+    newSearchParams.delete(SearchParam.Page);
     navigate({ search: newSearchParams.toString() });
   };
 


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48581

- Fikser loading på fastetter for prosjekt og person, på samme måte som for resultat https://github.com/BIBSYSDEV/NVA-Frontend/pull/7027
- Fjerner noe gammel kode som bare ser ut til å gi feil, feks at personsøk defaulter til "." som søketerm, da det tidligere var påkrevd av APIet men ikke ser ut til å være det lenger
- Sørg for at både prosjekt- og personsøk bruker siste versjon av søketerm, med `syncParamsWithSearchFields`

Vanskelig å si helt sikkert at dette ikke påvirker noe annet negativt, men det gir mening for meg iaf 🤔 
I ettertid ser jeg at dette gjerne kunne vært delt opp i 2-3 PRs 😬 men skal gi mening å ta QA commit for commit også

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
