### PR TITLE
Cleanup mui usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/icons-material": "^6.4.4",
         "@mui/lab": "^6.0.0-beta.27",
         "@mui/material": "^6.4.3",
+        "@mui/utils": "^6.4.3",
         "@mui/x-date-pickers": "^7.26.0",
         "@reduxjs/toolkit": "^2.5.1",
         "@tanstack/react-query": "^5.66.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@mui/icons-material": "^6.4.4",
     "@mui/lab": "^6.0.0-beta.27",
     "@mui/material": "^6.4.3",
+    "@mui/utils": "^6.4.3",
     "@mui/x-date-pickers": "^7.26.0",
     "@reduxjs/toolkit": "^2.5.1",
     "@tanstack/react-query": "^5.66.0",

--- a/src/components/StatusChip.tsx
+++ b/src/components/StatusChip.tsx
@@ -2,7 +2,6 @@ import BlockIcon from '@mui/icons-material/Block';
 import CheckIcon from '@mui/icons-material/Check';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 import { Box, Typography } from '@mui/material';
-import { StandardCSSProperties } from '@mui/system';
 import { useTranslation } from 'react-i18next';
 import { NviCandidateStatus } from '../types/nvi.types';
 import { Ticket } from '../types/publication_types/ticket.types';
@@ -52,7 +51,7 @@ export const NviStatusChip = ({ status }: NviStatusChip) => {
 interface StatusChipProps {
   text: string;
   icon: 'check' | 'block' | 'hourglass';
-  bgcolor?: StandardCSSProperties['backgroundColor'];
+  bgcolor?: string;
 }
 
 export const StatusChip = ({ text, bgcolor = 'secondary.dark', icon }: StatusChipProps) => {

--- a/src/components/styled/Wrappers.tsx
+++ b/src/components/styled/Wrappers.tsx
@@ -1,5 +1,4 @@
-import { Box, Checkbox, FormGroup, ListItem, Typography } from '@mui/material';
-import { styled } from '@mui/system';
+import { Box, Checkbox, FormGroup, ListItem, styled, Typography } from '@mui/material';
 
 export const StyledRightAlignedFooter = styled(Box)({
   display: 'flex',

--- a/src/pages/public_registration/PublicProjectsContent.tsx
+++ b/src/pages/public_registration/PublicProjectsContent.tsx
@@ -1,5 +1,4 @@
-import { Divider, Link as MuiLink, Skeleton, Typography } from '@mui/material';
-import { styled } from '@mui/system';
+import { Divider, Link as MuiLink, Skeleton, styled, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 import { useFetchProject } from '../../api/hooks/useFetchProject';

--- a/src/pages/registration/new_registration/RegistrationAccordion.tsx
+++ b/src/pages/registration/new_registration/RegistrationAccordion.tsx
@@ -1,5 +1,4 @@
-import { Accordion } from '@mui/material';
-import { styled } from '@mui/system';
+import { Accordion, styled } from '@mui/material';
 
 export const RegistrationAccordion = styled(Accordion)(({ theme }) => ({
   background: theme.palette.secondary.main,

--- a/src/pages/registration/resource_type_tab/components/SearchRelatedResultField.tsx
+++ b/src/pages/registration/resource_type_tab/components/SearchRelatedResultField.tsx
@@ -1,5 +1,4 @@
-import { Autocomplete, TextField, Typography } from '@mui/material';
-import { Box } from '@mui/system';
+import { Autocomplete, Box, TextField, Typography } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { FieldArray, FieldArrayRenderProps, useFormikContext } from 'formik';
 import { useState } from 'react';

--- a/src/pages/search/advanced_search/AdvancedSearchPage.tsx
+++ b/src/pages/search/advanced_search/AdvancedSearchPage.tsx
@@ -5,11 +5,11 @@ import {
   Divider,
   FormControlLabel,
   Grid,
+  styled,
   Theme,
   Typography,
   useMediaQuery,
 } from '@mui/material';
-import { styled } from '@mui/system';
 import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router';

--- a/src/utils/log/logFactory.ts
+++ b/src/utils/log/logFactory.ts
@@ -1,7 +1,6 @@
 import BlockIcon from '@mui/icons-material/Block';
 import CheckIcon from '@mui/icons-material/Check';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
-import { StandardCSSProperties } from '@mui/system';
 import { TFunction } from 'i18next';
 import { FileType } from '../../types/associatedArtifact.types';
 import { Log, LogEntry, LogEntryType } from '../../types/log.types';
@@ -58,7 +57,7 @@ const sortLogEntries = (a: LogEntry, b: LogEntry) => {
 interface SimpleLogItemEntry {
   text: string;
   date?: string;
-  bgcolor: StandardCSSProperties['backgroundColor'];
+  bgcolor: string;
   Icon: typeof CheckIcon;
 }
 


### PR DESCRIPTION
Fjerner "Unlisted dependencies" issues som rapporteres av `knip`.

![bilde](https://github.com/user-attachments/assets/e03d4b9c-6466-4e0a-9412-369bd976ca2a)

Litt motvillig å dra inn en ny pakke  `@mui/utils` da det vil gi enda mer PRs fra dependabot, men tenker å lage egen PR som gjør at dependabot grupperer Uppy- og MUI-pakker i samlede PRs