### PR TITLE
Np 48634 allow removing multiple roles

### DIFF
--- a/src/pages/basic_data/app_admin/AddAdminDialog.tsx
+++ b/src/pages/basic_data/app_admin/AddAdminDialog.tsx
@@ -18,7 +18,7 @@ import { StartDateField } from '../fields/StartDateField';
 
 interface AddAdminDialogProps extends Pick<DialogProps, 'open'> {
   toggleOpen: () => void;
-  refetchInstitutionUsers: () => void;
+  refetchUsers: () => Promise<unknown>;
   cristinInstitutionId: string;
 }
 
@@ -29,12 +29,7 @@ export interface AddAdminFormData {
 
 const addAdminInitialValues: AddAdminFormData = { startDate: '', position: '' };
 
-export const AddAdminDialog = ({
-  open,
-  toggleOpen,
-  refetchInstitutionUsers,
-  cristinInstitutionId,
-}: AddAdminDialogProps) => {
+export const AddAdminDialog = ({ open, toggleOpen, refetchUsers, cristinInstitutionId }: AddAdminDialogProps) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const location = useLocation();
@@ -74,10 +69,10 @@ export const AddAdminDialog = ({
       if (isErrorStatus(createNvaUserResponse.status)) {
         dispatch(setNotification({ message: t('feedback.error.create_user'), variant: 'error' }));
       } else if (isSuccessStatus(createNvaUserResponse.status)) {
+        await refetchUsers();
         dispatch(setNotification({ message: t('feedback.success.admin_added'), variant: 'success' }));
         closeDialog();
         resetForm();
-        refetchInstitutionUsers();
       }
     }
   };

--- a/src/pages/basic_data/app_admin/CustomerInstitutionAdminsForm.tsx
+++ b/src/pages/basic_data/app_admin/CustomerInstitutionAdminsForm.tsx
@@ -1,12 +1,12 @@
 import AddIcon from '@mui/icons-material/Add';
 import { Button, Typography } from '@mui/material';
+import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { fetchUsersByCustomer } from '../../../api/roleApi';
 import { RoleName } from '../../../types/user.types';
 import { AddAdminDialog } from './AddAdminDialog';
 import { UserList } from './UserList';
-import { useQuery } from '@tanstack/react-query';
-import { fetchUsersByCustomer } from '../../../api/roleApi';
 
 interface CustomerInstitutionAdminsFormProps {
   cristinInstitutionId: string;
@@ -50,7 +50,7 @@ export const CustomerInstitutionAdminsForm = ({
         open={openAddAdminModal}
         toggleOpen={toggleOpenAddAdminModal}
         cristinInstitutionId={cristinInstitutionId}
-        refetchInstitutionUsers={adminsQuery.refetch}
+        refetchUsers={adminsQuery.refetch}
       />
     </>
   );

--- a/src/pages/basic_data/app_admin/UserList.tsx
+++ b/src/pages/basic_data/app_admin/UserList.tsx
@@ -1,54 +1,41 @@
 import CancelIcon from '@mui/icons-material/Cancel';
 import { IconButton, List, ListItem, ListItemAvatar, ListItemText, Typography } from '@mui/material';
+import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { updateUser } from '../../../api/roleApi';
 import { ConfirmDialog } from '../../../components/ConfirmDialog';
+import { ProfilePicture } from '../../../components/ProfilePicture';
 import { setNotification } from '../../../redux/notificationSlice';
 import { InstitutionUser, RoleName } from '../../../types/user.types';
-import { isErrorStatus, isSuccessStatus } from '../../../utils/constants';
-import { ProfilePicture } from '../../../components/ProfilePicture';
 
 interface UserListProps {
   userList: InstitutionUser[];
-  refetchUsers?: () => void;
-  showScope?: boolean;
+  refetchUsers: () => void;
 }
 
 export const UserList = ({ userList, refetchUsers }: UserListProps) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
-  const [updatedRoleForUsers, setUpdatedRoleForUsers] = useState<string[]>([]);
-  const [removeRoleForUser, setRemoveRoleForUser] = useState('');
 
-  const roleToRemove = RoleName.InstitutionAdmin;
+  const [userToUpdate, setUserToUpdate] = useState<InstitutionUser | null>(null);
 
-  const handleRemoveRoleFromUser = async () => {
-    if (removeRoleForUser) {
-      setUpdatedRoleForUsers((state) => [...state, removeRoleForUser]);
-
-      const existingUser = userList.find((user) => user.username === removeRoleForUser);
-      if (!existingUser) {
-        return;
-      }
-      const newUser: InstitutionUser = {
+  const removeAdminRole = useMutation({
+    mutationFn: async (existingUser: InstitutionUser) => {
+      const updatedUser: InstitutionUser = {
         ...existingUser,
-        roles: existingUser.roles.filter((role) => role.rolename !== roleToRemove),
+        roles: existingUser.roles.filter((role) => role.rolename !== RoleName.InstitutionAdmin),
       };
-      const updateUserResponse = await updateUser(removeRoleForUser, newUser);
-      if (isErrorStatus(updateUserResponse.status)) {
-        setUpdatedRoleForUsers((state) => state.filter((user) => user !== removeRoleForUser));
-        dispatch(setNotification({ message: t('feedback.error.remove_role'), variant: 'error' }));
-      } else if (isSuccessStatus(updateUserResponse.status)) {
-        dispatch(setNotification({ message: t('feedback.success.removed_role'), variant: 'success' }));
-        refetchUsers?.();
-      }
-    }
-    setRemoveRoleForUser('');
-  };
+      const updateUserResponse = await updateUser(existingUser.username, updatedUser);
+      refetchUsers(); // TODO: await this
+      setUserToUpdate(null);
+    },
+    onSuccess: () => dispatch(setNotification({ message: t('feedback.success.removed_role'), variant: 'success' })),
+    onError: () => dispatch(setNotification({ message: t('feedback.error.remove_role'), variant: 'error' })),
+  });
 
-  const isLastInstitutionAdmin = roleToRemove === RoleName.InstitutionAdmin && userList.length === 1;
+  const isLastInstitutionAdmin = userList.length === 1;
 
   const sortedList = userList.sort((a, b) =>
     `${a.givenName} ${a.familyName}`.toLocaleLowerCase() < `${b.givenName} ${b.familyName}`.toLocaleLowerCase() ? -1 : 1
@@ -73,8 +60,8 @@ export const UserList = ({ userList, refetchUsers }: UserListProps) => {
                     aria-label={t('common.remove')}
                     color="primary"
                     disabled={isLastInstitutionAdmin}
-                    data-testid={`button-remove-role-${roleToRemove}-${user.username}`}
-                    onClick={() => setRemoveRoleForUser(user.username)}>
+                    data-testid={`button-remove-role-${user.username}`}
+                    onClick={() => setUserToUpdate(user)}>
                     <CancelIcon />
                   </IconButton>
                 }>
@@ -86,17 +73,15 @@ export const UserList = ({ userList, refetchUsers }: UserListProps) => {
             ))}
           </List>
 
-          {roleToRemove && (
-            <ConfirmDialog
-              open={!!removeRoleForUser}
-              title={t('basic_data.institutions.remove_role_title')}
-              isLoading={updatedRoleForUsers.length > 0}
-              onCancel={() => setRemoveRoleForUser('')}
-              onAccept={handleRemoveRoleFromUser}
-              dialogDataTestId="confirm-remove-role-dialog">
-              {t('basic_data.institutions.remove_role_text')}
-            </ConfirmDialog>
-          )}
+          <ConfirmDialog
+            open={!!userToUpdate}
+            title={t('basic_data.institutions.remove_role_title')}
+            isLoading={removeAdminRole.isPending}
+            onCancel={() => setUserToUpdate(null)}
+            onAccept={() => userToUpdate && removeAdminRole.mutate(userToUpdate)}
+            dialogDataTestId="confirm-remove-role-dialog">
+            {t('basic_data.institutions.remove_role_text')}
+          </ConfirmDialog>
         </>
       )}
     </>

--- a/src/pages/basic_data/app_admin/UserList.tsx
+++ b/src/pages/basic_data/app_admin/UserList.tsx
@@ -12,7 +12,7 @@ import { InstitutionUser, RoleName } from '../../../types/user.types';
 
 interface UserListProps {
   userList: InstitutionUser[];
-  refetchUsers: () => void;
+  refetchUsers: () => Promise<unknown>;
 }
 
 export const UserList = ({ userList, refetchUsers }: UserListProps) => {
@@ -27,8 +27,8 @@ export const UserList = ({ userList, refetchUsers }: UserListProps) => {
         ...existingUser,
         roles: existingUser.roles.filter((role) => role.rolename !== RoleName.InstitutionAdmin),
       };
-      const updateUserResponse = await updateUser(existingUser.username, updatedUser);
-      refetchUsers(); // TODO: await this
+      await updateUser(existingUser.username, updatedUser);
+      await refetchUsers();
       setUserToUpdate(null);
     },
     onSuccess: () => dispatch(setNotification({ message: t('feedback.success.removed_role'), variant: 'success' })),

--- a/src/pages/basic_data/app_admin/UserList.tsx
+++ b/src/pages/basic_data/app_admin/UserList.tsx
@@ -35,11 +35,11 @@ export const UserList = ({ userList, refetchUsers }: UserListProps) => {
     onError: () => dispatch(setNotification({ message: t('feedback.error.remove_role'), variant: 'error' })),
   });
 
-  const isLastInstitutionAdmin = userList.length === 1;
-
-  const sortedList = userList.sort((a, b) =>
-    `${a.givenName} ${a.familyName}`.toLocaleLowerCase() < `${b.givenName} ${b.familyName}`.toLocaleLowerCase() ? -1 : 1
-  );
+  const sortedList = userList.sort((a, b) => {
+    const nameA = `${a.givenName} ${a.familyName}`.toLocaleLowerCase();
+    const nameB = `${b.givenName} ${b.familyName}`.toLocaleLowerCase();
+    return nameA.localeCompare(nameB);
+  });
 
   return (
     <>
@@ -57,9 +57,9 @@ export const UserList = ({ userList, refetchUsers }: UserListProps) => {
                 divider
                 secondaryAction={
                   <IconButton
-                    aria-label={t('common.remove')}
+                    title={t('common.remove')}
                     color="primary"
-                    disabled={isLastInstitutionAdmin}
+                    disabled={userList.length === 1}
                     data-testid={`button-remove-role-${user.username}`}
                     onClick={() => setUserToUpdate(user)}>
                     <CancelIcon />


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48634

Unngå feil i oversikten av en kundeinstitusjon for app-admin, hvor det ikke var mulig å fjerne mer enn en administrator om gangen. Når man fjernet en havned dialogen i en evig loading state, sånn at man måtte laste siden på nytt for å kunne fjerne en annen administrator.

Skrev om til å bruke `useMutation`, da det som var her var veldig gammelt. Ser også ut som dette var en generell komponent før, mens den nå bare brukes for adminstratorer på kunde, så fikk ryddet opp i litt gammel moro

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
