### PR TITLE
Hide person pagination when no search

### DIFF
--- a/src/components/ContributorSearchField.tsx
+++ b/src/components/ContributorSearchField.tsx
@@ -44,7 +44,12 @@ export const ContributorSearchField = ({
   const debouncedSearchTerm = useDebounce(searchTerm);
   const [page, setPage] = useState(1);
   const [rowsPerPage, setRowsPerPage] = useState(ROWS_PER_PAGE_OPTIONS[0]);
-  const personQuery = useSearchForPerson({ name: debouncedSearchTerm, results: rowsPerPage, page });
+  const personQuery = useSearchForPerson({
+    enabled: !!debouncedSearchTerm,
+    name: debouncedSearchTerm,
+    results: rowsPerPage,
+    page,
+  });
   const userSearch = personQuery.data?.hits ?? [];
 
   return (
@@ -66,46 +71,48 @@ export const ContributorSearchField = ({
         slotProps={{ input: { startAdornment: <SearchIcon /> } }}
         sx={{ my: '1rem' }}
       />
-      <ListPagination
-        count={personQuery.data?.size ?? 0}
-        rowsPerPage={rowsPerPage}
-        page={page}
-        onPageChange={setPage}
-        onRowsPerPageChange={(newRowsPerPage) => {
-          setRowsPerPage(newRowsPerPage);
-          setPage(1);
-        }}
-        showPaginationTop>
-        {personQuery.isFetching ? (
-          <ListSkeleton arrayLength={3} minWidth={100} height={80} />
-        ) : userSearch && personQuery.data && personQuery.data.size > 0 && debouncedSearchTerm ? (
-          <TableContainer component={Paper} sx={{ my: '0.5rem' }} elevation={3}>
-            <Table size="medium">
-              <caption style={visuallyHidden}>{t('search.persons')}</caption>
-              <TableHead>
-                <TableRow>
-                  <TableCell width="20%">{t('common.person')}</TableCell>
-                  <TableCell width="45%">{t('my_page.my_profile.heading.affiliations')}</TableCell>
-                  <TableCell width="25%">{t('common.result_registrations')}</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {personQuery.data.hits.map((cristinPerson) => (
-                  <CristinPersonTableRow
-                    key={cristinPerson.id}
-                    cristinPerson={cristinPerson}
-                    setSelectedPerson={setSelectedPerson}
-                    selectedPerson={selectedPerson}
-                    selectAffiliations={selectAffiliations}
-                  />
-                ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
-        ) : (
-          debouncedSearchTerm && <Typography>{t('common.no_hits')}</Typography>
-        )}
-      </ListPagination>
+      {debouncedSearchTerm && (
+        <ListPagination
+          count={personQuery.data?.size ?? 0}
+          rowsPerPage={rowsPerPage}
+          page={page}
+          onPageChange={setPage}
+          onRowsPerPageChange={(newRowsPerPage) => {
+            setRowsPerPage(newRowsPerPage);
+            setPage(1);
+          }}
+          showPaginationTop>
+          {personQuery.isFetching ? (
+            <ListSkeleton arrayLength={3} minWidth={100} height={80} />
+          ) : userSearch && userSearch.length > 0 ? (
+            <TableContainer component={Paper} sx={{ my: '0.5rem' }} elevation={3}>
+              <Table size="medium">
+                <caption style={visuallyHidden}>{t('search.persons')}</caption>
+                <TableHead>
+                  <TableRow>
+                    <TableCell width="20%">{t('common.person')}</TableCell>
+                    <TableCell width="45%">{t('my_page.my_profile.heading.affiliations')}</TableCell>
+                    <TableCell width="25%">{t('common.result_registrations')}</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {userSearch.map((cristinPerson) => (
+                    <CristinPersonTableRow
+                      key={cristinPerson.id}
+                      cristinPerson={cristinPerson}
+                      setSelectedPerson={setSelectedPerson}
+                      selectedPerson={selectedPerson}
+                      selectAffiliations={selectAffiliations}
+                    />
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          ) : (
+            debouncedSearchTerm && <Typography>{t('common.no_hits')}</Typography>
+          )}
+        </ListPagination>
+      )}
     </>
   );
 };

--- a/src/pages/search/registration_search/filters/SearchForContributorFacetItem.tsx
+++ b/src/pages/search/registration_search/filters/SearchForContributorFacetItem.tsx
@@ -29,6 +29,7 @@ export const SearchForContributorFacetItem = ({ onSelectContributor }: SearchFor
   useEffect(() => setSearchSize(defaultPersonSearchSize), [debouncedQuery]);
 
   const personSearchQuery = useSearchForPerson({
+    enabled: !!debouncedQuery,
     name: debouncedQuery,
     results: searchSize,
     placeholderData: (data, query) => keepSimilarPreviousData(data, query, debouncedQuery),


### PR DESCRIPTION
# Description

Løser feil som ble introdusert [her](https://github.com/BIBSYSDEV/NVA-Frontend/pull/7043), hvor søket blir gjort selv om søketermen er tom. Burde trolig rulle ut til prod når dette er klart, siden det er en såpass ny bug som også ble rullet ut dit.

Før:
![bilde](https://github.com/user-attachments/assets/d6b297b0-5b75-4843-b18e-0554e3b88772)

Etter:
![bilde](https://github.com/user-attachments/assets/5ed45bf0-0bd9-4b75-9077-2cd8317f321d)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
