### PR TITLE
NP-48639 Show refresh option for rejected files

### DIFF
--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -325,10 +325,6 @@
     "yes": "Ja"
   },
   "disciplines": {
-    "0001": "Humaniora",
-    "0002": "Samfunnsvitenskap",
-    "0003": "Medisin og helsefag",
-    "0004": "Realfag og teknologi",
     "1003": "Arkeologi og konservering",
     "1005": "Asiatiske og afrikanske studier",
     "1007": "Engelsk",
@@ -400,7 +396,11 @@
     "1162": "Konstruksjonsfag",
     "1166": "Filosofi",
     "1168": "Historie og idéhistorie",
-    "1170": "Kunst, design og arkitektur"
+    "1170": "Kunst, design og arkitektur",
+    "0001": "Humaniora",
+    "0002": "Samfunnsvitenskap",
+    "0003": "Medisin og helsefag",
+    "0004": "Realfag og teknologi"
   },
   "editor": {
     "categories_with_files": "Kategorier med filopplasting",
@@ -1589,6 +1589,7 @@
         "duplicate_title_description_introduction": "Denne registreringen har samme tittel, år og kategori som følgende publikasjon:",
         "edit_publishing_request_description": "For å endre på synligheten til en eller flere filer, trykk på \"$t(registration.edit_registration)\" og velg annen status i nedtrekksmenyen under overskriften \"$t(registration.files_and_license.availability)\" til filen det gjelder.",
         "files_will_soon_be_published": "Fil(er) vil være tilgjengelig for andre om kort tid. Vent litt før du oppdaterer siden på nytt for å se status.",
+        "files_will_soon_be_rejected": "Fil(er) vil bli markert som avvist. Vent litt før du oppdaterer siden på nytt for å se oppdatert status.",
         "fix_validation_errors_before_republishing": "Du må rette opp alle valideringsfeil før du kan republisere.",
         "has_rejected_files_publishing_request": "<0>Filene er ikke slettet, men skjult fra visningen av resultatet.</0><0>Du får en ny oppgave dersom registrator ønsker ny vurdering av avvist fil eller å få godkjent en nyopplastet fil.</0><0>For å slette filer permanent, rediger registrering og fjern filen.</0><0>Ønsker du å avpublisere hele resultatet, åpne flere valg nederst i denne menyen.</0>",
         "has_rejected_files_publishing_request_registrator": "<0>Kurator har avvist fil(er), og de er fjernet fra presentasjonssiden til resultatet. Du finner begrunnelse for avvisningen under meldingsfeltet i denne menyen.</0><0>Ønsker du å slette en eller flere filer, trykk på \"$t(registration.edit_registration)\" og fjern filene der.</0><0>Er du uenig i avvisningen, endre status for filen(e) under \"$t(registration.files_and_license.availability)\" fra \"Avvist\" til ny status. Filen blir da sendt til kurator for ny godkjenning. Legg gjerne inn en begrunnelse til kurator i meldingsfeltet.</0>",


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48639

Vis oppdatert info når publiseringskurator avviser fil(er) da ticket og resultat som regel ikke er i synk med en gang. Viser nå i stedete en "Last på nytt"-knapp som vi har for godkjenning fra før

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
