### PR TITLE
NP-48654 Hide name and institution of log entry when empty

### DIFF
--- a/src/pages/public_registration/log/LogEntry.tsx
+++ b/src/pages/public_registration/log/LogEntry.tsx
@@ -6,7 +6,7 @@ import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
 import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutlined';
 import LocalOfferOutlinedIcon from '@mui/icons-material/LocalOfferOutlined';
 import UnpublishedOutlinedIcon from '@mui/icons-material/UnpublishedOutlined';
-import { Avatar, Box, Divider, styled, SvgIconProps, Typography } from '@mui/material';
+import { Avatar, Box, Divider, styled, SvgIconProps, Tooltip, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { LogDateItem } from '../../../components/Log/LogDateItem';
 import { FileType } from '../../../types/associatedArtifact.types';
@@ -54,15 +54,25 @@ export const LogEntry = ({ logEntry }: LogEntryProps) => {
       </StyledLogRow>
       <LogDateItem date={new Date(logEntry.timestamp)} />
 
-      {logEntry.performedBy && (
+      {(fullName || logEntry.performedBy?.onBehalfOf.shortName) && (
         <StyledLogRow>
-          <Avatar sx={{ height: '1.5rem', width: '1.5rem', fontSize: '0.7rem', bgcolor: 'primary.main' }}>
-            {getInitials(fullName)}
-          </Avatar>
-          <Typography>{fullName}</Typography>
+          {fullName && (
+            <>
+              <Avatar sx={{ height: '1.5rem', width: '1.5rem', fontSize: '0.7rem', bgcolor: 'primary.main' }}>
+                {getInitials(fullName)}
+              </Avatar>
+              <Typography>{fullName}</Typography>
+            </>
+          )}
 
-          <AccountBalanceIcon {...logIconProps} />
-          <Typography>{logEntry.performedBy.onBehalfOf.displayName}</Typography>
+          {logEntry.performedBy?.onBehalfOf.shortName && (
+            <>
+              <AccountBalanceIcon {...logIconProps} />
+              <Tooltip title={logEntry.performedBy.onBehalfOf.displayName}>
+                <Typography>{logEntry.performedBy.onBehalfOf.shortName}</Typography>
+              </Tooltip>
+            </>
+          )}
         </StyledLogRow>
       )}
 

--- a/src/types/log.types.ts
+++ b/src/types/log.types.ts
@@ -32,6 +32,7 @@ export interface LogActionItem {
 
 interface LogEntryOnBehalfOf {
   id: string;
+  shortName: string;
   displayName: string;
 }
 


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48654

Vis institusjonens kortnavn. Lager en PR med dette for å få bort feilen med at bare ikoner for person og institusjon vises uten noen tekst i noen tilfeller.
La også inn visning av kortnavn i samme slengen, selv jeg egentlig ikke tror det er noen vits i det ref [denne kommentaren](https://sikt.atlassian.net/browse/NP-48654?focusedCommentId=112526)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
