### PR TITLE
NP-48656 add refresh button for files after deletion

### DIFF
--- a/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
@@ -221,7 +221,8 @@ export const PublishingAccordion = ({
         {hasPendingTicket && <Divider sx={{ my: '1rem' }} />}
 
         {/* Option to reload data if status is not up to date with ticket */}
-        {userCanHandlePublishingRequest && !tabErrors && hasMismatchingPublishedStatus && (
+        {((userCanHandlePublishingRequest && !tabErrors && hasMismatchingPublishedStatus) ||
+          isWaitingForFileDeletion) && (
           <>
             <Typography sx={{ my: '1rem' }}>
               {isPublishedRegistration

--- a/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
@@ -160,15 +160,17 @@ export const PublishingAccordion = ({
     !!lastPublishingRequest &&
     (isDraftRegistration || hasMismatchingFiles(lastPublishingRequest, publishingRequestTickets, registration));
 
-  const hasMismatchingPublishedStatus = mismatchingPublishedStatusWorkflow1 || mismatchingPublishedStatusWorkflow2;
+  const isWaitingForFileDeletion =
+    isDeletedRegistration && getAssociatedFiles(registration.associatedArtifacts).length > 0;
+
+  const hasMismatchingPublishedStatus =
+    mismatchingPublishedStatusWorkflow1 || mismatchingPublishedStatusWorkflow2 || isWaitingForFileDeletion;
 
   const showRegistrationWithSameNameWarning = duplicateRegistration && isDraftRegistration;
 
   const defaultExpanded = locationState?.selectedTicketType
     ? locationState.selectedTicketType === 'PublishingRequest'
     : isDraftRegistration || hasPendingTicket || hasMismatchingPublishedStatus || hasClosedTicket;
-
-  const isWaitingForFileDeletion = isDeletedRegistration && registration.associatedArtifacts.length > 0;
 
   return (
     <Accordion
@@ -230,14 +232,16 @@ export const PublishingAccordion = ({
                     : ''
                 : t('registration.public_page.tasks_panel.registration_will_soon_be_published')}
             </Typography>
-            <RefreshPublishingRequestButton refetchData={refetchData} isLoadingData={isLoadingData} />
+            <RefreshPublishingRequestButton refetchData={refetchData} loading={isLoadingData} />
           </>
         )}
 
-        {isDeletedRegistration && isWaitingForFileDeletion && (
+        {isWaitingForFileDeletion && (
           <>
-            <Typography gutterBottom>{t('registration.public_page.tasks_panel.files_will_soon_be_deleted')}</Typography>
-            <RefreshPublishingRequestButton refetchData={refetchData} isLoadingData={isLoadingData} />
+            <Typography sx={{ my: '1rem' }}>
+              {t('registration.public_page.tasks_panel.files_will_soon_be_deleted')}
+            </Typography>
+            <RefreshPublishingRequestButton refetchData={refetchData} loading={isLoadingData} />
           </>
         )}
 

--- a/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
@@ -301,7 +301,7 @@ export const PublishingAccordion = ({
           </>
         )}
 
-        {lastPublishingRequest && !hasMismatchingPublishedStatus && !isWaitingForFileDeletion && (
+        {lastPublishingRequest && !hasMismatchingPublishedStatus && (
           <PublishingAccordionLastTicketInfo
             publishingTicket={lastPublishingRequest}
             canCreatePublishingRequest={userCanCreatePublishingRequest}

--- a/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
@@ -230,16 +230,9 @@ export const PublishingAccordion = ({
                   : hasClosedTicket
                     ? t('registration.public_page.tasks_panel.files_will_soon_be_rejected')
                     : ''
-                : t('registration.public_page.tasks_panel.registration_will_soon_be_published')}
-            </Typography>
-            <RefreshPublishingRequestButton refetchData={refetchData} loading={isLoadingData} />
-          </>
-        )}
-
-        {isWaitingForFileDeletion && (
-          <>
-            <Typography sx={{ my: '1rem' }}>
-              {t('registration.public_page.tasks_panel.files_will_soon_be_deleted')}
+                : isWaitingForFileDeletion
+                  ? t('registration.public_page.tasks_panel.files_will_soon_be_deleted')
+                  : t('registration.public_page.tasks_panel.registration_will_soon_be_published')}
             </Typography>
             <RefreshPublishingRequestButton refetchData={refetchData} loading={isLoadingData} />
           </>

--- a/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/PublishingAccordion.tsx
@@ -1,7 +1,6 @@
 import ErrorIcon from '@mui/icons-material/Error';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import OpenInNewOutlinedIcon from '@mui/icons-material/OpenInNewOutlined';
-import RefreshIcon from '@mui/icons-material/Refresh';
 import { LoadingButton } from '@mui/lab';
 import { Accordion, AccordionDetails, AccordionSummary, Box, Divider, Tooltip, Typography } from '@mui/material';
 import { useState } from 'react';
@@ -36,6 +35,7 @@ import { PublishingLogPreview } from '../PublishingLogPreview';
 import { DuplicateWarningDialog } from './DuplicateWarningDialog';
 import { MoreActionsCollapse } from './MoreActionsCollapse';
 import { PublishingAccordionLastTicketInfo } from './PublishingAccordionLastTicketInfo';
+import { RefreshPublishingRequestButton } from './RefreshPublishingRequestButton';
 import { TicketAssignee } from './TicketAssignee';
 
 interface PublishingAccordionProps {
@@ -168,6 +168,8 @@ export const PublishingAccordion = ({
     ? locationState.selectedTicketType === 'PublishingRequest'
     : isDraftRegistration || hasPendingTicket || hasMismatchingPublishedStatus || hasClosedTicket;
 
+  const isWaitingForFileDeletion = isDeletedRegistration && registration.associatedArtifacts.length > 0;
+
   return (
     <Accordion
       data-testid={dataTestId.registrationLandingPage.tasksPanel.publishingRequestAccordion}
@@ -228,17 +230,14 @@ export const PublishingAccordion = ({
                     : ''
                 : t('registration.public_page.tasks_panel.registration_will_soon_be_published')}
             </Typography>
-            <LoadingButton
-              variant="contained"
-              color="info"
-              size="small"
-              loading={isLoadingData}
-              fullWidth
-              onClick={refetchData}
-              startIcon={<RefreshIcon />}
-              data-testid={dataTestId.registrationLandingPage.tasksPanel.refreshPublishingRequestButton}>
-              {t('registration.public_page.tasks_panel.reload')}
-            </LoadingButton>
+            <RefreshPublishingRequestButton refetchData={refetchData} isLoadingData={isLoadingData} />
+          </>
+        )}
+
+        {isDeletedRegistration && isWaitingForFileDeletion && (
+          <>
+            <Typography gutterBottom>{t('registration.public_page.tasks_panel.files_will_soon_be_deleted')}</Typography>
+            <RefreshPublishingRequestButton refetchData={refetchData} isLoadingData={isLoadingData} />
           </>
         )}
 
@@ -305,7 +304,7 @@ export const PublishingAccordion = ({
           </>
         )}
 
-        {lastPublishingRequest && !hasMismatchingPublishedStatus && (
+        {lastPublishingRequest && !hasMismatchingPublishedStatus && !isWaitingForFileDeletion && (
           <PublishingAccordionLastTicketInfo
             publishingTicket={lastPublishingRequest}
             canCreatePublishingRequest={userCanCreatePublishingRequest}

--- a/src/pages/public_registration/action_accordions/RefreshPublishingRequestButton.tsx
+++ b/src/pages/public_registration/action_accordions/RefreshPublishingRequestButton.tsx
@@ -1,24 +1,30 @@
 import RefreshIcon from '@mui/icons-material/Refresh';
-import { LoadingButton } from '@mui/lab';
-import { t } from 'i18next';
+import { ButtonProps } from '@mui/lab';
 import { dataTestId } from '../../../utils/dataTestIds';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@mui/material';
 
-interface RefreshPublishingRequestButtonProps {
+interface RefreshPublishingRequestButtonProps extends ButtonProps {
   refetchData: () => void;
-  isLoadingData: boolean;
 }
-export const RefreshPublishingRequestButton = ({ refetchData, isLoadingData }: RefreshPublishingRequestButtonProps) => {
+
+export const RefreshPublishingRequestButton = ({
+  refetchData,
+  ...buttonProps
+}: RefreshPublishingRequestButtonProps) => {
+  const { t } = useTranslation();
+
   return (
-    <LoadingButton
+    <Button
+      {...buttonProps}
       variant="contained"
       color="info"
       size="small"
-      loading={isLoadingData}
       fullWidth
       onClick={refetchData}
       startIcon={<RefreshIcon />}
       data-testid={dataTestId.registrationLandingPage.tasksPanel.refreshPublishingRequestButton}>
       {t('registration.public_page.tasks_panel.reload')}
-    </LoadingButton>
+    </Button>
   );
 };

--- a/src/pages/public_registration/action_accordions/RefreshPublishingRequestButton.tsx
+++ b/src/pages/public_registration/action_accordions/RefreshPublishingRequestButton.tsx
@@ -1,0 +1,24 @@
+import RefreshIcon from '@mui/icons-material/Refresh';
+import { LoadingButton } from '@mui/lab';
+import { t } from 'i18next';
+import { dataTestId } from '../../../utils/dataTestIds';
+
+interface RefreshPublishingRequestButtonProps {
+  refetchData: () => void;
+  isLoadingData: boolean;
+}
+export const RefreshPublishingRequestButton = ({ refetchData, isLoadingData }: RefreshPublishingRequestButtonProps) => {
+  return (
+    <LoadingButton
+      variant="contained"
+      color="info"
+      size="small"
+      loading={isLoadingData}
+      fullWidth
+      onClick={refetchData}
+      startIcon={<RefreshIcon />}
+      data-testid={dataTestId.registrationLandingPage.tasksPanel.refreshPublishingRequestButton}>
+      {t('registration.public_page.tasks_panel.reload')}
+    </LoadingButton>
+  );
+};

--- a/src/pages/public_registration/action_accordions/RefreshPublishingRequestButton.tsx
+++ b/src/pages/public_registration/action_accordions/RefreshPublishingRequestButton.tsx
@@ -1,8 +1,7 @@
 import RefreshIcon from '@mui/icons-material/Refresh';
-import { ButtonProps } from '@mui/lab';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@mui/material';
+import { Button, ButtonProps } from '@mui/material';
 
 interface RefreshPublishingRequestButtonProps extends ButtonProps {
   refetchData: () => void;

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1591,6 +1591,7 @@
         "duplicate_title_description_details": "<0>Det skal ikke opprettes duplikater i NVA. Sjekk om din registrering tilsvarer det som alt er publisert.</0><0>Om resultatet som er publisert har feil eller mangler så be registrator eller bidragsyter som er tilknyttet resultatet om å endre det.</0>",
         "duplicate_title_description_introduction": "Denne registreringen har samme tittel, år og kategori som følgende publikasjon:",
         "edit_publishing_request_description": "For å endre på synligheten til en eller flere filer, trykk på \"$t(registration.edit_registration)\" og velg annen status i nedtrekksmenyen under overskriften \"$t(registration.files_and_license.availability)\" til filen det gjelder.",
+        "files_will_soon_be_deleted": "Fil(er) vil bli slettet. Vent litt før du oppdaterer siden på nytt for å se oppdatert status.",
         "files_will_soon_be_published": "Fil(er) vil være tilgjengelig for andre om kort tid. Vent litt før du oppdaterer siden på nytt for å se status.",
         "files_will_soon_be_rejected": "Fil(er) vil bli markert som avvist. Vent litt før du oppdaterer siden på nytt for å se oppdatert status.",
         "fix_validation_errors_before_republishing": "Du må rette opp alle valideringsfeil før du kan republisere.",


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48656

Added a refresh button to `PublishingAccordion` when there is a mismatch between publication status and number of `associatedArtifacts`

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
