### PR TITLE
NP-48640 Show full organization for coordinating unit

### DIFF
--- a/src/pages/projects/ProjectGeneralInfo.tsx
+++ b/src/pages/projects/ProjectGeneralInfo.tsx
@@ -1,6 +1,7 @@
 import { Box, Chip, Link as MuiLink, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
+import { AffiliationHierarchy } from '../../components/institution/AffiliationHierarchy';
 import { StyledGeneralInfo } from '../../components/styled/Wrappers';
 import { CristinProject } from '../../types/project.types';
 import { dataTestId } from '../../utils/dataTestIds';
@@ -10,7 +11,6 @@ import { getFullName, getValueByKey } from '../../utils/user-helpers';
 import {
   fundingSourceIsNfr,
   getNfrProjectUrl,
-  getProjectCoordinatingInstitutionName,
   getProjectManagers,
   getProjectPeriod,
 } from '../registration/description_tab/projects_field/projectHelpers';
@@ -35,7 +35,9 @@ export const ProjectGeneralInfo = ({ project }: ProjectGeneralInfoProps) => {
         <Typography variant="overline" component="dt">
           {t('project.coordinating_institution')}
         </Typography>
-        <Typography component="dd">{getProjectCoordinatingInstitutionName(project) ?? '-'}</Typography>
+        <Box component="dd" sx={{ m: 0 }}>
+          <AffiliationHierarchy unitUri={project.coordinatingInstitution.id} boldTopLevel={false} />
+        </Box>
         <Typography variant="overline" component="dt">
           {t('project.project_manager')}
         </Typography>


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48640

Vis hele treet for koordinerende institusjon, ikke bare løvnode om man har valgt en bestemt enhet.

Før:
![bilde](https://github.com/user-attachments/assets/5d155a1d-cfd8-44fe-a3f6-0ef1b1c5377f)

Etter:
![bilde](https://github.com/user-attachments/assets/ff8a3701-766c-48ad-82b7-2f3ff58956e4)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
