### PR TITLE
NP-48594 Set default organization param to viewing scope

### DIFF
--- a/src/pages/messages/TasksPage.tsx
+++ b/src/pages/messages/TasksPage.tsx
@@ -18,6 +18,7 @@ import { RootState } from '../../redux/store';
 import { PreviousSearchLocationState } from '../../types/locationState.types';
 import { ROWS_PER_PAGE_OPTIONS } from '../../utils/constants';
 import { dataTestId } from '../../utils/dataTestIds';
+import { getIdentifierFromId } from '../../utils/general-helpers';
 import { PrivateRoute } from '../../utils/routes/Routes';
 import { getTaskNotificationsParams, resetPaginationAndNavigate } from '../../utils/searchHelpers';
 import { getSubUrl, UrlPathTemplate } from '../../utils/urlPaths';
@@ -68,7 +69,11 @@ const TasksPage = () => {
     .filter(([, selected]) => selected)
     .map(([key]) => key);
 
-  const organizationIdParam = searchParams.get(TicketSearchParam.OrganizationId);
+  // TODO: This should be redundant when NP-48485 is solved
+  const defaultOrganizationParam = institutionUserQuery.data?.viewingScope.includedUnits
+    ? institutionUserQuery.data.viewingScope.includedUnits.map((unit) => getIdentifierFromId(unit)).join(',')
+    : null;
+  const organizationIdParam = searchParams.get(TicketSearchParam.OrganizationId) ?? defaultOrganizationParam;
 
   const ticketSearchParams: FetchTicketsParams = {
     aggregation: 'all',
@@ -78,7 +83,7 @@ const TasksPage = () => {
     orderBy: searchParams.get(TicketSearchParam.OrderBy) as 'createdDate' | null,
     sortOrder: searchParams.get(TicketSearchParam.SortOrder) as 'asc' | 'desc' | null,
     organizationId: organizationIdParam,
-    excludeSubUnits: !!organizationIdParam,
+    excludeSubUnits: !!organizationIdParam && organizationIdParam !== defaultOrganizationParam,
     assignee: searchParams.get(TicketSearchParam.Assignee),
     status: searchParams.get(TicketSearchParam.Status),
     type: selectedTicketTypes.join(','),


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48594

Denne skal bare merges om vi ikke rekker å implementere denne filtreringen i backend innen rimelig tid.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
