### PR TITLE
Hide misleading text for files at other institutions

### DIFF
--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -406,7 +406,7 @@ export const FilesTableRow = ({
                       </TextField>
                     )}
                   </Field>
-                  {showRrs && (
+                  {showRrs && canEditFile && (
                     <>
                       {fileHasCustomerRrs && (
                         <Typography>


### PR DESCRIPTION
# Description

Quick-fix for å unngå et tilfelle med villedende tekst.
Burde gjøres mer for å fikse dette skikkelig, som nevnt her: https://sikt-no.slack.com/archives/CPHGQRNAJ/p1740578666052169

Før:
![bilde](https://github.com/user-attachments/assets/1d6a2d3c-2dc7-4b8d-98b4-6a42b5908efb)

Etter:
![bilde](https://github.com/user-attachments/assets/c3b447e6-bb43-4b9b-80ac-80debb543059)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
