### PR TITLE
Require file type before publishing

### DIFF
--- a/src/utils/validation/registration/associatedArtifactValidation.ts
+++ b/src/utils/validation/registration/associatedArtifactValidation.ts
@@ -34,8 +34,13 @@ const linkValidation = Yup.string()
     associatedArtifactIsLink({ type }) ? schema.url(associatedArtifactErrorMessage.linkInvalid) : schema
   );
 
+const associatedArtifactTypeValidationSchema = Yup.string().not(
+  [FileType.UpdloadedFile],
+  associatedArtifactErrorMessage.availabilityRequired
+);
+
 export const associatedArtifactValidationSchema = Yup.object({
-  type: Yup.string().not([FileType.UpdloadedFile], associatedArtifactErrorMessage.availabilityRequired),
+  type: associatedArtifactTypeValidationSchema,
   embargoDate: Yup.date()
     .nullable()
     .when(['type'], ([type], schema) =>
@@ -65,6 +70,6 @@ export const associatedArtifactValidationSchema = Yup.object({
 });
 
 export const associatedArtifactPublishValidationSchema = Yup.object({
-  type: Yup.string().not([FileType.UpdloadedFile], associatedArtifactErrorMessage.availabilityRequired),
+  type: associatedArtifactTypeValidationSchema,
   id: linkValidation,
 });

--- a/src/utils/validation/registration/associatedArtifactValidation.ts
+++ b/src/utils/validation/registration/associatedArtifactValidation.ts
@@ -65,6 +65,6 @@ export const associatedArtifactValidationSchema = Yup.object({
 });
 
 export const associatedArtifactPublishValidationSchema = Yup.object({
-  type: Yup.string(),
+  type: Yup.string().not([FileType.UpdloadedFile], associatedArtifactErrorMessage.availabilityRequired),
   id: linkValidation,
 });


### PR DESCRIPTION
# Description

Krev at bruker oppgir filtype før man kan publisere.
Dette fordi det gir noen problemer for backend ellers, bl.a. siden HiddenFile ikke krever godkjenning.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
