### PR TITLE
Fetch funding sources on demand

### DIFF
--- a/src/api/hooks/useFetchFundingSources.ts
+++ b/src/api/hooks/useFetchFundingSources.ts
@@ -2,10 +2,15 @@ import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { fetchFundingSources } from '../cristinApi';
 
-export const useFetchFundingSources = () => {
+interface FetchFundingSourcesOptions {
+  enabled?: boolean;
+}
+
+export const useFetchFundingSources = ({ enabled }: FetchFundingSourcesOptions = {}) => {
   const { t } = useTranslation();
 
   return useQuery({
+    enabled,
     queryKey: ['fundingSources'],
     queryFn: fetchFundingSources,
     meta: { errorMessage: t('feedback.error.get_funding_sources') },

--- a/src/pages/search/registration_search/filters/SearchForFundingSourceFacetItem.tsx
+++ b/src/pages/search/registration_search/filters/SearchForFundingSourceFacetItem.tsx
@@ -13,7 +13,8 @@ interface SearchForFundingSourceFacetItemProps {
 
 export const SearchForFundingSourceFacetItem = ({ onSelectFunder }: SearchForFundingSourceFacetItemProps) => {
   const { t } = useTranslation();
-  const fundingSourcesQuery = useFetchFundingSources();
+  const [enableFundingSourcesQuery, setEnableFundingSourcesQuery] = useState(false);
+  const fundingSourcesQuery = useFetchFundingSources({ enabled: enableFundingSourcesQuery });
   const fundingSourcesList = fundingSourcesQuery.data?.sources ?? [];
 
   const [searchQuery, setSearchQuery] = useState('');
@@ -30,6 +31,7 @@ export const SearchForFundingSourceFacetItem = ({ onSelectFunder }: SearchForFun
           setSearchQuery(value);
         }
       }}
+      loading={fundingSourcesQuery.isFetching}
       options={fundingSourcesList}
       filterOptions={fundingSourceAutocompleteFilterOptions}
       renderOption={({ key, ...props }, option) => (
@@ -44,9 +46,11 @@ export const SearchForFundingSourceFacetItem = ({ onSelectFunder }: SearchForFun
         }
         setSearchQuery('');
       }}
+      onOpen={() => setEnableFundingSourcesQuery(true)}
       renderInput={(params) => (
         <AutocompleteTextField
           {...params}
+          isLoading={fundingSourcesQuery.isFetching}
           data-testid={dataTestId.aggregations.fundingSourceFacetsSearchField}
           variant="outlined"
           aria-label={t('search.search_for_funder')}


### PR DESCRIPTION
# Description

Unngå at funding sources alltid lastes når man går til forsiden, til tross for at de (trolig) veldig sjelden vil brukes. I stedet lastes de nå bare når de skal brukes. 
Legger også inn fiks for å unngå feilmelding om siden unmounter mens søket pågår, som tidligere ga en feil hvor man fikk feilmelding om man logget inn mens søket pågikk.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
