### PR TITLE
NP-48668 Open DOI accordion if a new DOI request is created

### DIFF
--- a/src/pages/public_registration/action_accordions/DoiRequestAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/DoiRequestAccordion.tsx
@@ -21,7 +21,7 @@ import {
   Typography,
 } from '@mui/material';
 import { useMutation } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useLocation } from 'react-router';
@@ -210,7 +210,16 @@ export const DoiRequestAccordion = ({
     ? locationState.selectedTicketType === 'DoiRequest'
     : waitingForRemovalOfDoi || isPendingDoiRequest || isClosedDoiRequest;
 
-  const hasReservedDoi = !doiRequestTicket && registration.doi;
+  const hasReservedDoi = !doiRequestTicket && !!registration.doi;
+
+  const [openAccordion, setOpenAccordion] = useState(defaultExpanded);
+
+  useEffect(() => {
+    // Open accordion if a new DOI request is created
+    if (doiRequestTicket) {
+      setOpenAccordion(true);
+    }
+  }, [doiRequestTicket]);
 
   return (
     <Accordion
@@ -223,7 +232,8 @@ export const DoiRequestAccordion = ({
         },
       }}
       elevation={3}
-      defaultExpanded={defaultExpanded}>
+      expanded={openAccordion}
+      onChange={() => setOpenAccordion((open) => !open)}>
       <AccordionSummary sx={{ fontWeight: 700 }} expandIcon={<ExpandMoreIcon fontSize="large" />}>
         <Typography fontWeight="bold" sx={{ flexGrow: '1' }}>
           {t('common.doi')}


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48668

Åpne DOI-panelet automatisk om man publiserer et resultat som har en reservert DOI fra før, siden den da også vil ha en DOI-forespørsel.
Jobber videre med å justere suksessmelding ved publisering til å inkludere at DOI-forespørsel også er sendt til godkjenning.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
