### PR TITLE
NP-48542 Use new log by default

### DIFF
--- a/src/pages/messages/components/NviCandidateActionPanel.tsx
+++ b/src/pages/messages/components/NviCandidateActionPanel.tsx
@@ -7,7 +7,7 @@ import { useFetchRegistrationTickets } from '../../../api/hooks/useFetchRegistra
 import { NviCandidate } from '../../../types/nvi.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { getIdentifierFromId } from '../../../utils/general-helpers';
-import { LogPanel } from '../../public_registration/LogPanel';
+import { LogPanel } from '../../public_registration/log/LogPanel';
 import { NviDialoguePanel } from './NviDialoguePanel';
 
 interface NviCandidateActionPanelProps {

--- a/src/pages/public_registration/ActionPanel.tsx
+++ b/src/pages/public_registration/ActionPanel.tsx
@@ -6,19 +6,16 @@ import { ErrorBoundary } from '../../components/ErrorBoundary';
 import { RootState } from '../../redux/store';
 import { PublishingTicket, Ticket } from '../../types/publication_types/ticket.types';
 import { RegistrationStatus } from '../../types/registration.types';
-import { LocalStorageKey } from '../../utils/constants';
 import { dataTestId } from '../../utils/dataTestIds';
 import { userHasAccessRight } from '../../utils/registration-helpers';
 import { UrlPathTemplate } from '../../utils/urlPaths';
 import { ActionPanelContent } from './ActionPanelContent';
-import { LogPanel as LogPanel2 } from './log/LogPanel';
-import { LogPanel } from './LogPanel';
+import { LogPanel } from './log/LogPanel';
 import { PublicRegistrationContentProps } from './PublicRegistrationContent';
 
 enum TabValue {
   Tasks,
   Log,
-  Log2,
 }
 
 interface ActionPanelProps extends PublicRegistrationContentProps {
@@ -79,8 +76,6 @@ export const ActionPanel = ({
 
   const [tabValue, setTabValue] = useState(canSeeTasksPanel ? TabValue.Tasks : TabValue.Log);
 
-  const isBeta = localStorage.getItem(LocalStorageKey.Beta) === 'true';
-
   return (
     <Paper
       elevation={0}
@@ -108,38 +103,27 @@ export const ActionPanel = ({
           id="action-panel-tab-1"
           aria-controls="action-panel-tab-panel-1"
         />
-        {isBeta && (
-          <Tab
-            value={TabValue.Log2}
-            label={t('common.log') + 2}
-            id="action-panel-tab-2"
-            aria-controls="action-panel-tab-panel-2"
-          />
-        )}
       </Tabs>
       <TabPanel tabValue={tabValue} index={0}>
-        <ActionPanelContent
-          refetchData={refetchRegistrationAndTickets}
-          isLoadingData={isLoadingData}
-          registration={registration}
-          shouldSeePublishingAccordion={shouldSeePublishingAccordion}
-          shouldSeeDoiAccordion={shouldSeeDoiAccordion}
-          shouldSeeSupportAccordion={shouldSeeSupportAccordion}
-          publishingRequestTickets={publishingRequestTickets}
-          newestDoiRequestTicket={newestDoiRequestTicket}
-          newestSupportTicket={newestSupportTicket}
-        />
+        <ErrorBoundary>
+          <ActionPanelContent
+            refetchData={refetchRegistrationAndTickets}
+            isLoadingData={isLoadingData}
+            registration={registration}
+            shouldSeePublishingAccordion={shouldSeePublishingAccordion}
+            shouldSeeDoiAccordion={shouldSeeDoiAccordion}
+            shouldSeeSupportAccordion={shouldSeeSupportAccordion}
+            publishingRequestTickets={publishingRequestTickets}
+            newestDoiRequestTicket={newestDoiRequestTicket}
+            newestSupportTicket={newestSupportTicket}
+          />
+        </ErrorBoundary>
       </TabPanel>
       <TabPanel tabValue={tabValue} index={1}>
-        <LogPanel tickets={tickets} registration={registration} />
+        <ErrorBoundary>
+          <LogPanel registration={registration} tickets={tickets} />
+        </ErrorBoundary>
       </TabPanel>
-      {isBeta && (
-        <TabPanel tabValue={tabValue} index={2}>
-          <ErrorBoundary>
-            <LogPanel2 registration={registration} tickets={tickets} />
-          </ErrorBoundary>
-        </TabPanel>
-      )}
     </Paper>
   );
 };


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48542

Vis den nye loggen i stedet for den gamle også når man ikke har satt `beta=true`.
Fjerner logikk knyttet til gammel logg.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
