### PR TITLE
NP-48693 Handle loading of selected area of responsibility

### DIFF
--- a/src/pages/basic_data/institution_admin/edit_user/AreaOfResponsibility.tsx
+++ b/src/pages/basic_data/institution_admin/edit_user/AreaOfResponsibility.tsx
@@ -26,6 +26,7 @@ export const AreaOfResponsibility = ({ viewingScopes, updateViewingScopes }: Are
   const { t } = useTranslation();
   const topOrgCristinId = useSelector((store: RootState) => store.user?.topOrgCristinId);
   const [addAreaOfResponsibility, setAddAreaOfResponsibility] = useState(false);
+  const [isUpdatingValue, setIsUpdatingValue] = useState(false);
 
   const { isSubmitting } = useFormikContext();
 
@@ -74,9 +75,10 @@ export const AreaOfResponsibility = ({ viewingScopes, updateViewingScopes }: Are
           renderOption={({ key, ...props }, option) => (
             <OrganizationRenderOption key={option.id} props={props} option={option} />
           )}
-          disabled={isSubmitting}
+          disabled={isSubmitting || isUpdatingValue}
           onChange={async (_, value) => {
             if (value) {
+              setIsUpdatingValue(true);
               const fetchedUnit = await fetchOrganization(value.id);
               const allParentIds = getOrganizationHierarchy(fetchedUnit).map((unit) => unit.id);
               const allChildrenIds = getAllChildOrganizations([value]).map((unit) => unit.id);
@@ -90,10 +92,11 @@ export const AreaOfResponsibility = ({ viewingScopes, updateViewingScopes }: Are
               const newViewingScopes = Array.from(new Set([...filteredScopes, value.id]));
               updateViewingScopes(newViewingScopes);
             }
+            setIsUpdatingValue(false);
             setAddAreaOfResponsibility(false);
           }}
           renderInput={(params) => (
-            <TextField {...params} fullWidth placeholder={t('basic_data.person_register.select_unit')} />
+            <TextField {...params} variant="filled" fullWidth label={t('basic_data.person_register.select_unit')} />
           )}
         />
       ) : (


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48693

Legger til en lasteindikator når man velger ansvarsområde. Uten dette ble det noen gang stående som et input-felt man fortsatt kunne endre

Utbedring av glipp fra https://github.com/BIBSYSDEV/NVA-Frontend/pull/7129.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
