### PR TITLE
Ensure AutocompleteTextField handles label shrink correctly

### DIFF
--- a/src/components/AutocompleteTextField.tsx
+++ b/src/components/AutocompleteTextField.tsx
@@ -25,17 +25,21 @@ export const AutocompleteTextField = ({
     slotProps={{
       input: {
         ...params.InputProps,
-        startAdornment: (
+        startAdornment: showSearchIcon ? (
           <>
             {params.InputProps.startAdornment}
             {showSearchIcon && <SearchIcon color="disabled" />}
           </>
+        ) : (
+          params.InputProps.startAdornment
         ),
-        endAdornment: (
+        endAdornment: isLoading ? (
           <>
             {isLoading && <CircularProgress size={20} aria-labelledby={params.InputLabelProps.id} />}
             {params.InputProps.endAdornment}
           </>
+        ) : (
+          params.InputProps.endAdornment
         ),
       },
     }}


### PR DESCRIPTION
Løst en feil med `AutocompleteTextField` hvor label tidligere kunnne bli minimert selv om den ikke hadde noen innhold, fordi `<></>` tolkes som innhold.

Før:
![bilde](https://github.com/user-attachments/assets/1c01814c-57b6-4032-adde-c18370541581)

Etter:
![bilde](https://github.com/user-attachments/assets/c6665cd4-530d-41cf-aeb3-b1ff520cd76f)

