### PR TITLE
Np 47365 show loading state for central import facets

### DIFF
--- a/src/pages/basic_data/app_admin/central_import/ImportCandidatesMenuFilters.tsx
+++ b/src/pages/basic_data/app_admin/central_import/ImportCandidatesMenuFilters.tsx
@@ -124,8 +124,11 @@ export const ImportCandidatesMenuFilters = () => {
       </RadioGroup>
 
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem', mt: '0.5rem' }}>
-        {typeAggregations?.length > 0 && (
-          <FacetItem title={t('common.category')} dataTestId={dataTestId.aggregations.typeFacets}>
+        {(importCandidateQuery.isPending || typeAggregations.length > 0) && (
+          <FacetItem
+            title={t('common.category')}
+            dataTestId={dataTestId.aggregations.typeFacets}
+            isPending={importCandidateQuery.isPending}>
             {typeAggregations.map((facet) => (
               <FacetListItem
                 key={facet.key}
@@ -140,8 +143,11 @@ export const ImportCandidatesMenuFilters = () => {
           </FacetItem>
         )}
 
-        {topLevelOrgAggregations?.length > 0 && (
-          <FacetItem title={t('common.institution')} dataTestId={dataTestId.aggregations.typeFacets}>
+        {(importCandidateQuery.isPending || topLevelOrgAggregations.length > 0) && (
+          <FacetItem
+            title={t('common.institution')}
+            dataTestId={dataTestId.aggregations.typeFacets}
+            isPending={importCandidateQuery.isPending}>
             {topLevelOrgAggregations.map((facet) => (
               <FacetListItem
                 key={facet.key}
@@ -156,10 +162,11 @@ export const ImportCandidatesMenuFilters = () => {
           </FacetItem>
         )}
 
-        {collaborationTypeAggregations?.length > 0 && (
+        {(importCandidateQuery.isPending || collaborationTypeAggregations.length > 0) && (
           <FacetItem
             title={t('basic_data.central_import.collaboration_type.Collaborative')}
-            dataTestId={dataTestId.aggregations.collaboardationTypeFacets}>
+            dataTestId={dataTestId.aggregations.collaboardationTypeFacets}
+            isPending={importCandidateQuery.isPending}>
             {collaborationTypeAggregations.map((facet) => (
               <FacetListItem
                 key={facet.key}
@@ -174,8 +181,11 @@ export const ImportCandidatesMenuFilters = () => {
           </FacetItem>
         )}
 
-        {filesAggregations?.length > 0 && (
-          <FacetItem title={t('registration.files_and_license.files')} dataTestId={dataTestId.aggregations.filesFacets}>
+        {(importCandidateQuery.isPending || filesAggregations.length > 0) && (
+          <FacetItem
+            title={t('registration.files_and_license.files')}
+            dataTestId={dataTestId.aggregations.filesFacets}
+            isPending={importCandidateQuery.isPending}>
             {filesAggregations.map((facet) => (
               <FacetListItem
                 key={facet.key}

--- a/src/pages/basic_data/app_admin/central_import/ImportCandidatesMenuFilters.tsx
+++ b/src/pages/basic_data/app_admin/central_import/ImportCandidatesMenuFilters.tsx
@@ -133,7 +133,6 @@ export const ImportCandidatesMenuFilters = () => {
               <FacetListItem
                 key={facet.key}
                 dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                isLoading={importCandidatesFacetsQuery.isLoading}
                 isSelected={importCandidateParams.type === facet.key}
                 label={t(`registration.publication_types.${facet.key}`)}
                 count={facet.count}
@@ -152,7 +151,6 @@ export const ImportCandidatesMenuFilters = () => {
               <FacetListItem
                 key={facet.key}
                 dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                isLoading={importCandidatesFacetsQuery.isLoading}
                 isSelected={importCandidateParams.topLevelOrganization === facet.key}
                 label={getLanguageString(facet.labels) || getIdentifierFromId(facet.key)}
                 count={facet.count}
@@ -171,7 +169,6 @@ export const ImportCandidatesMenuFilters = () => {
               <FacetListItem
                 key={facet.key}
                 dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                isLoading={importCandidatesFacetsQuery.isLoading}
                 isSelected={importCandidateParams.collaborationType === facet.key}
                 label={t(`basic_data.central_import.collaboration_type.${facet.key}`)}
                 count={facet.count}
@@ -190,7 +187,6 @@ export const ImportCandidatesMenuFilters = () => {
               <FacetListItem
                 key={facet.key}
                 dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                isLoading={importCandidatesFacetsQuery.isLoading}
                 isSelected={importCandidateParams.files === facet.key}
                 label={getFileFacetText(facet.key, t)}
                 count={facet.count}

--- a/src/pages/search/FacetListItem.tsx
+++ b/src/pages/search/FacetListItem.tsx
@@ -11,23 +11,15 @@ const StyledListItemButton = styled(ListItemButton)(({ theme }) => ({
 
 interface FacetListItemProps {
   dataTestId: string;
-  isLoading: boolean;
   isSelected: boolean;
   onClickFacet: () => void;
   label: string;
   count: number;
 }
 
-export const FacetListItem = ({
-  dataTestId,
-  isLoading,
-  isSelected,
-  label,
-  count,
-  onClickFacet,
-}: FacetListItemProps) => (
+export const FacetListItem = ({ dataTestId, isSelected, label, count, onClickFacet }: FacetListItemProps) => (
   <ListItem disablePadding data-testid={dataTestId}>
-    <StyledListItemButton disabled={isLoading} dense selected={isSelected} onClick={onClickFacet}>
+    <StyledListItemButton dense selected={isSelected} onClick={onClickFacet}>
       <Typography component="span" sx={{ wordBreak: 'break-word' }}>
         {label}
       </Typography>

--- a/src/pages/search/person_search/PersonFacetsFilter.tsx
+++ b/src/pages/search/person_search/PersonFacetsFilter.tsx
@@ -54,7 +54,6 @@ export const PersonFacetsFilter = ({ personQuery }: PersonFacetsFilterProps) => 
               <FacetListItem
                 key={facet.key}
                 dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                isLoading={personQuery.isPending}
                 isSelected={isSelected}
                 label={getLanguageString(facet.labels)}
                 count={facet.count}
@@ -80,7 +79,6 @@ export const PersonFacetsFilter = ({ personQuery }: PersonFacetsFilterProps) => 
               <FacetListItem
                 key={facet.key}
                 dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                isLoading={personQuery.isPending}
                 isSelected={isSelected}
                 label={getLanguageString(facet.labels)}
                 count={facet.count}

--- a/src/pages/search/project_search/ProjectFacetsFilter.tsx
+++ b/src/pages/search/project_search/ProjectFacetsFilter.tsx
@@ -67,7 +67,6 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
               <FacetListItem
                 key={facet.key}
                 dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                isLoading={projectQuery.isPending}
                 isSelected={isSelected}
                 label={getLanguageString(facet.labels)}
                 count={facet.count}
@@ -93,7 +92,6 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
               <FacetListItem
                 key={facet.key}
                 dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                isLoading={projectQuery.isPending}
                 isSelected={isSelected}
                 label={getLanguageString(facet.labels)}
                 count={facet.count}
@@ -119,7 +117,6 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
               <FacetListItem
                 key={facet.key}
                 dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                isLoading={projectQuery.isPending}
                 isSelected={isSelected}
                 label={getLanguageString(facet.labels)}
                 count={facet.count}
@@ -145,7 +142,6 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
               <FacetListItem
                 key={facet.key}
                 dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                isLoading={projectQuery.isPending}
                 isSelected={isSelected}
                 label={getLanguageString(facet.labels)}
                 count={facet.count}
@@ -171,7 +167,6 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
               <FacetListItem
                 key={facet.key}
                 dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                isLoading={projectQuery.isPending}
                 isSelected={isSelected}
                 label={getLanguageString(facet.labels)}
                 count={facet.count}
@@ -197,7 +192,6 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
               <FacetListItem
                 key={facet.key}
                 dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                isLoading={projectQuery.isPending}
                 isSelected={isSelected}
                 label={getLanguageString(facet.labels)}
                 count={facet.count}
@@ -223,7 +217,6 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
               <FacetListItem
                 key={facet.key}
                 dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                isLoading={projectQuery.isPending}
                 isSelected={isSelected}
                 label={getLanguageString(facet.labels)}
                 count={facet.count}
@@ -249,7 +242,6 @@ export const ProjectFacetsFilter = ({ projectQuery }: ProjectFacetsFilterProps) 
               <FacetListItem
                 key={facet.key}
                 dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                isLoading={projectQuery.isPending}
                 isSelected={isSelected}
                 label={getLanguageString(facet.labels)}
                 count={facet.count}

--- a/src/pages/search/registration_search/filters/RegistrationFacetsFilter.tsx
+++ b/src/pages/search/registration_search/filters/RegistrationFacetsFilter.tsx
@@ -77,7 +77,6 @@ export const RegistrationFacetsFilter = ({ registrationQuery }: Pick<SearchPageP
               <FacetListItem
                 key={facet.key}
                 dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                isLoading={registrationQuery.isPending}
                 isSelected={isSelected}
                 label={t(`registration.publication_types.${facet.key}`)}
                 count={facet.count}
@@ -110,7 +109,6 @@ export const RegistrationFacetsFilter = ({ registrationQuery }: Pick<SearchPageP
               <FacetListItem
                 key={facet.key}
                 dataTestId={dataTestId.aggregations.facetItem(institutionIdentifier)}
-                isLoading={registrationQuery.isPending}
                 isSelected={isSelected}
                 label={getLanguageString(facet.labels) || institutionIdentifier}
                 count={facet.count}
@@ -143,7 +141,6 @@ export const RegistrationFacetsFilter = ({ registrationQuery }: Pick<SearchPageP
               <FacetListItem
                 key={facet.key}
                 dataTestId={dataTestId.aggregations.facetItem(contributorIdentifier)}
-                isLoading={registrationQuery.isPending}
                 isSelected={isSelected}
                 label={getLanguageString(facet.labels)}
                 count={facet.count}
@@ -176,7 +173,6 @@ export const RegistrationFacetsFilter = ({ registrationQuery }: Pick<SearchPageP
                 <FacetListItem
                   key={facet.key}
                   dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                  isLoading={registrationQuery.isPending}
                   isSelected={isSelected}
                   label={getLanguageString(facet.labels)}
                   count={facet.count}
@@ -210,7 +206,6 @@ export const RegistrationFacetsFilter = ({ registrationQuery }: Pick<SearchPageP
               <FacetListItem
                 key={facet.key}
                 dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                isLoading={registrationQuery.isPending}
                 isSelected={isSelected}
                 label={getLanguageString(facet.labels) || t('registration.missing_name')}
                 count={facet.count}
@@ -245,7 +240,6 @@ export const RegistrationFacetsFilter = ({ registrationQuery }: Pick<SearchPageP
               <FacetListItem
                 key={facet.key}
                 dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                isLoading={registrationQuery.isPending}
                 isSelected={isSelected}
                 label={getLanguageString(facet.labels) || t('registration.missing_name')}
                 count={facet.count}
@@ -280,7 +274,6 @@ export const RegistrationFacetsFilter = ({ registrationQuery }: Pick<SearchPageP
               <FacetListItem
                 key={facet.key}
                 dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                isLoading={registrationQuery.isPending}
                 isSelected={isSelected}
                 label={getLanguageString(facet.labels) || t('registration.missing_name')}
                 count={facet.count}
@@ -309,7 +302,6 @@ export const RegistrationFacetsFilter = ({ registrationQuery }: Pick<SearchPageP
                 <FacetListItem
                   key={facet.key}
                   dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                  isLoading={registrationQuery.isPending}
                   isSelected={isSelected}
                   label={facet.key}
                   count={facet.count}
@@ -341,7 +333,6 @@ export const RegistrationFacetsFilter = ({ registrationQuery }: Pick<SearchPageP
                 <FacetListItem
                   key={facet.key}
                   dataTestId={dataTestId.aggregations.facetItem(facet.key)}
-                  isLoading={registrationQuery.isPending}
                   isSelected={isSelected}
                   label={getFileFacetText(facet.key, t)}
                   count={facet.count}


### PR DESCRIPTION
# Description

Bruk samme loading prop i sentralimport som for andre søk for å vise lasting i fasettene. Fjerner også den gamle måten med å disable verdier når man laster den, siden den nå er erstattet av denne nye.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
