### PR TITLE
Fix layout responsiveness

### DIFF
--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -35,7 +35,7 @@ export const MinimizedMenuIconButton = ({ children, to, ...props }: CustomIconBu
 };
 
 export const SideMenu = ({ children, expanded, minimizedMenu }: SideMenuProps) => (
-  <Box component="nav" aria-labelledby={sideNavHeaderId} sx={{ minWidth: '5rem' }}>
+  <Box component="nav" aria-labelledby={sideNavHeaderId}>
     {expanded || !minimizedMenu ? (
       <Box sx={{ bgcolor: 'secondary.main', width: { xs: '100%', md: '20rem' }, height: '100%' }}>{children}</Box>
     ) : (


### PR DESCRIPTION
# Description


In this PR:

- Removed `minWidth` from `<SideMenu />`, as it interfered with the responsiveness of the grid in `<PageWithSideMenu />`
- Added `overflowX: 'auto'` to `<BackgroundDiv />` since the above change resulted in a horizontal overflow on the right side for pages with tables (could alternatively have wrapped the tables in its own container, but after checking all references it seems like a global overflowX does the trick)

References for `<BackgroundDiv />`:
![Screenshot 2025-03-06 at 14 09 31](https://github.com/user-attachments/assets/68c516a0-dc3f-467d-a59f-d8fc25875292)
 

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [ ] The changes are working as expected
- [ ] The changes are tested OK for different screen sizes
- [ ] The changes are tested OK for a11y
- [ ] Interactive elements have data-testids
- [ ] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
