### PR TITLE
NP-48526 Update header responsiveness

### DIFF
--- a/src/layout/header/Header.tsx
+++ b/src/layout/header/Header.tsx
@@ -85,56 +85,57 @@ export const Header = () => {
         aria-label={t('common.main')}
         component="nav"
         sx={{
-          display: 'grid',
-          justifyItems: 'center',
-          gridTemplateAreas: '"logo search new-result user-menu"',
-          gridTemplateColumns: { xs: 'auto auto 1fr auto', md: 'auto 1fr 10fr auto' },
+          display: 'flex',
+          flexWrap: 'wrap',
+          justifyContent: 'space-between',
           gap: { xs: '0.5rem', sm: '1rem' },
           px: '1rem',
         }}>
-        <Logo />
-        <MenuIconButton
-          color="inherit"
-          sx={{ gridArea: 'search' }}
-          title={t('common.search')}
-          isSelected={location.pathname === UrlPathTemplate.Root || currentPath === UrlPathTemplate.Root}
-          to={UrlPathTemplate.Root}>
-          <SearchIcon fontSize="large" />
-        </MenuIconButton>
+        <Box sx={{ display: 'flex', gap: '2rem' }} flex={1}>
+          <Logo />
+          <MenuIconButton
+            color="inherit"
+            title={t('common.search')}
+            isSelected={location.pathname === UrlPathTemplate.Root || currentPath === UrlPathTemplate.Root}
+            to={UrlPathTemplate.Root}>
+            <SearchIcon fontSize="large" />
+          </MenuIconButton>
+        </Box>
 
         {user?.isCreator && (
-          <MenuButton
-            sx={{
-              gridArea: 'new-result',
-              fontSize: '1.4rem',
-              fontWeight: 700,
-              gap: '0.5rem',
-              display: { xs: 'none', sm: 'inline-flex' },
-            }}
-            isSelected={currentPath === UrlPathTemplate.RegistrationNew}
-            color="inherit"
-            data-testid={dataTestId.header.newRegistrationLink}
-            to={UrlPathTemplate.RegistrationNew}
-            startIcon={
-              <AddIcon
-                sx={{
-                  color: 'white',
-                  bgcolor: 'primary.light',
-                  borderRadius: '50%',
-                  padding: '0.2rem',
-                  width: '2.25rem',
-                  height: '2.25rem',
-                }}
-              />
-            }>
-            {t('registration.new_registration')}
-          </MenuButton>
+          <Box sx={{ display: 'flex', justifyContent: 'center' }} flex={1}>
+            <MenuButton
+              sx={{
+                fontSize: '1.4rem',
+                fontWeight: 700,
+                gap: '0.5rem',
+                display: { xs: 'none', sm: 'inline-flex' },
+              }}
+              isSelected={currentPath === UrlPathTemplate.RegistrationNew}
+              color="inherit"
+              data-testid={dataTestId.header.newRegistrationLink}
+              to={UrlPathTemplate.RegistrationNew}
+              startIcon={
+                <AddIcon
+                  sx={{
+                    color: 'white',
+                    bgcolor: 'primary.light',
+                    borderRadius: '50%',
+                    padding: '0.2rem',
+                    width: '2.25rem',
+                    height: '2.25rem',
+                  }}
+                />
+              }>
+              {t('registration.new_registration')}
+            </MenuButton>
+          </Box>
         )}
         <Box
+          flex={1}
           sx={{
-            gridArea: 'user-menu',
+            justifyContent: 'end',
             display: 'flex',
-            alignItems: 'stretch',
             gap: '1rem',
             'a, button': {
               flexDirection: 'column',

--- a/src/layout/header/Header.tsx
+++ b/src/layout/header/Header.tsx
@@ -91,7 +91,7 @@ export const Header = () => {
           gap: { xs: '0.5rem', sm: '1rem' },
           px: '1rem',
         }}>
-        <Box sx={{ display: 'flex', gap: '2rem' }} flex={1}>
+        <Box sx={{ display: 'flex', flex: '1', gap: { sm: '1rem', md: '2rem' } }}>
           <Logo />
           <MenuIconButton
             color="inherit"
@@ -103,7 +103,7 @@ export const Header = () => {
         </Box>
 
         {user?.isCreator && (
-          <Box sx={{ display: 'flex', justifyContent: 'center' }} flex={1}>
+          <Box sx={{ display: 'flex', flex: '1', justifyContent: 'center' }}>
             <MenuButton
               sx={{
                 fontSize: '1.4rem',
@@ -132,10 +132,10 @@ export const Header = () => {
           </Box>
         )}
         <Box
-          flex={1}
           sx={{
             justifyContent: 'end',
             display: 'flex',
+            flex: '1',
             gap: '1rem',
             'a, button': {
               flexDirection: 'column',

--- a/src/layout/header/Logo.tsx
+++ b/src/layout/header/Logo.tsx
@@ -13,7 +13,7 @@ export const Logo = () => {
 
   const showShortLogo = showShortLogoAnonymous || showShortLogoLoggedIn;
   return (
-    <Button sx={{ gridArea: 'logo' }} data-testid="logo" component={RouterLink} to={UrlPathTemplate.Root}>
+    <Button data-testid="logo" component={RouterLink} to={UrlPathTemplate.Root}>
       <Typography variant="h5" component="span" sx={{ color: 'white', fontWeight: 900, fontSize: '3rem' }}>
         NVA
       </Typography>


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48526

In this PR:

- Made the `Header` component use `flex` instead of using `grid`. This is to ensure support for increasing text-size in the broser up to 200%. Previously, the content of the header would extend horizontally, without wrapping. Now, it allows elements to wrap with increased text-size, while still maintaining the correct layout in "default-mode".

Before:
![Screenshot 2025-03-11 at 09 32 48](https://github.com/user-attachments/assets/018a3942-c12d-4e71-90eb-542bfee406a1)

After:
![Screenshot 2025-03-11 at 09 33 45](https://github.com/user-attachments/assets/1bece0dc-968b-4f0e-955f-c32e1af4fa8b)


The screenshots above are taken with 200% text-zoom.

This is the first step in the process of adding support for text-zoom. There is still some horizontall scrolling due to `minWidth` being set on different componens.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
