### PR TITLE
Show unknown when artistic output has no values to show

### DIFF
--- a/src/pages/public_registration/PublicPublicationContext.tsx
+++ b/src/pages/public_registration/PublicPublicationContext.tsx
@@ -333,7 +333,7 @@ const PublicOutputRow = ({ output, showType }: PublicOutputRowProps) => {
 
   return (
     <Box sx={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
-      <Typography>{rowString}</Typography>
+      <Typography>{rowString?.trim() || <i>{t('common.unknown')}</i>}</Typography>
       <Tooltip title={t('common.show_details')}>
         <IconButton
           size="small"
@@ -344,7 +344,6 @@ const PublicOutputRow = ({ output, showType }: PublicOutputRowProps) => {
           <OpenInNewIcon fontSize="small" />
         </IconButton>
       </Tooltip>
-
       <Dialog open={openModal} onClose={toggleModal} fullWidth>
         <DialogTitle>{t('registration.resource_type.artistic.announcement')}</DialogTitle>
         <ErrorBoundary>


### PR DESCRIPTION
# Description

Link to Jira issue: Delvis utspring fra https://sikt.atlassian.net/browse/NP-48754

Før:
![bilde](https://github.com/user-attachments/assets/75dcfc6b-9070-4d6b-8ab2-70c87fedd54f)

Etter:
![bilde](https://github.com/user-attachments/assets/6ec33ba5-c16c-4db8-9095-b670121cbb2c)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
