### PR TITLE
Np 48754 show contributor with invalid role on landing page

### DIFF
--- a/src/pages/public_registration/PublicRegistrationContributors.tsx
+++ b/src/pages/public_registration/PublicRegistrationContributors.tsx
@@ -140,11 +140,25 @@ const ContributorsRow = ({ contributors, distinctUnits, hiddenCount, registratio
           .filter((affiliationIndex) => affiliationIndex)
           .sort();
 
-        const hasValidRole =
-          contributorConfig[registrationType].primaryRoles.includes(contributor.role.type) ||
-          contributorConfig[registrationType].secondaryRoles.includes(contributor.role.type);
+        const allRelevantRoles = [
+          ...contributorConfig[registrationType].primaryRoles,
+          ...contributorConfig[registrationType].secondaryRoles,
+        ];
 
-        const showRole = contributor.role.type !== ContributorRole.Creator && hasValidRole;
+        const hasValidRole = allRelevantRoles.includes(contributor.role.type);
+
+        const showRole =
+          contributor.role.type !== ContributorRole.Creator || !allRelevantRoles.includes(ContributorRole.Creator);
+
+        const roleContent = showRole && (
+          <Box component="span" sx={{ ml: '0.2rem' }}>
+            {hasValidRole ? (
+              <>({t(`registration.contributors.types.${contributor.role.type}`)})</>
+            ) : (
+              <i>({t('registration.public_page.unknown_role')})</i>
+            )}
+          </Box>
+        );
 
         return (
           <Box key={index} component="li" sx={{ display: 'flex', alignItems: 'end' }}>
@@ -159,9 +173,13 @@ const ContributorsRow = ({ contributors, distinctUnits, hiddenCount, registratio
               ) : (
                 name
               )}
-              {showRole && ` (${t(`registration.contributors.types.${contributor.role.type}`)})`}
+
+              {roleContent}
+
               {affiliationIndexes && affiliationIndexes.length > 0 && (
-                <sup>{affiliationIndexes && affiliationIndexes.length > 0 && affiliationIndexes.join(',')}</sup>
+                <sup style={{ marginLeft: '0.1rem' }}>
+                  {affiliationIndexes && affiliationIndexes.length > 0 && affiliationIndexes.join(',')}
+                </sup>
               )}
             </Typography>
             <ContributorIndicators

--- a/src/pages/public_registration/PublicRegistrationContributors.tsx
+++ b/src/pages/public_registration/PublicRegistrationContributors.tsx
@@ -42,6 +42,11 @@ export const PublicRegistrationContributors = ({
   );
   const distinctUnits = getDistinctContributorUnits([...primaryContributorsToShow, ...secondaryContributorsToShow]);
 
+  const relevantRoles = [
+    ...contributorConfig[registrationType].primaryRoles,
+    ...contributorConfig[registrationType].secondaryRoles,
+  ];
+
   return (
     <Box
       data-testid={dataTestId.registrationLandingPage.contributors}
@@ -57,13 +62,13 @@ export const PublicRegistrationContributors = ({
             contributors={primaryContributorsToShow}
             distinctUnits={distinctUnits}
             hiddenCount={showAll ? undefined : hiddenContributorsCount.current}
-            registrationType={registrationType}
+            relevantRoles={relevantRoles}
           />
           {showAll && secondaryContributorsToShow.length > 0 && (
             <ContributorsRow
               contributors={secondaryContributorsToShow}
               distinctUnits={distinctUnits}
-              registrationType={registrationType}
+              relevantRoles={relevantRoles}
             />
           )}
         </Box>
@@ -111,10 +116,10 @@ interface ContributorsRowProps {
   contributors: Contributor[];
   distinctUnits: string[];
   hiddenCount?: number;
-  registrationType: PublicationInstanceType;
+  relevantRoles: ContributorRole[];
 }
 
-const ContributorsRow = ({ contributors, distinctUnits, hiddenCount, registrationType }: ContributorsRowProps) => {
+const ContributorsRow = ({ contributors, distinctUnits, hiddenCount, relevantRoles }: ContributorsRowProps) => {
   const { t } = useTranslation();
 
   return (
@@ -140,15 +145,10 @@ const ContributorsRow = ({ contributors, distinctUnits, hiddenCount, registratio
           .filter((affiliationIndex) => affiliationIndex)
           .sort();
 
-        const allRelevantRoles = [
-          ...contributorConfig[registrationType].primaryRoles,
-          ...contributorConfig[registrationType].secondaryRoles,
-        ];
-
-        const hasValidRole = allRelevantRoles.includes(contributor.role.type);
+        const hasValidRole = relevantRoles.includes(contributor.role.type);
 
         const showRole =
-          contributor.role.type !== ContributorRole.Creator || !allRelevantRoles.includes(ContributorRole.Creator);
+          contributor.role.type !== ContributorRole.Creator || !relevantRoles.includes(ContributorRole.Creator);
 
         const roleContent = showRole && (
           <Box component="span" sx={{ ml: '0.2rem' }}>

--- a/src/pages/public_registration/PublicRegistrationContributors.tsx
+++ b/src/pages/public_registration/PublicRegistrationContributors.tsx
@@ -147,8 +147,9 @@ const ContributorsRow = ({ contributors, distinctUnits, hiddenCount, relevantRol
 
         const hasValidRole = relevantRoles.includes(contributor.role.type);
 
-        const showRole =
-          contributor.role.type !== ContributorRole.Creator || !relevantRoles.includes(ContributorRole.Creator);
+        const showRole = relevantRoles.includes(ContributorRole.Creator)
+          ? contributor.role.type !== ContributorRole.Creator
+          : true;
 
         const roleContent = showRole && (
           <Box component="span" sx={{ ml: '0.2rem' }}>

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1601,6 +1601,7 @@
         "terminate_result_description": "<0>Slett resultatet om det er feilregistrert.</0><0>Slettes resultatet er det ikke mulig å gjenopprette informasjon og filer på resultatet.</0>",
         "waiting_for_rejected_doi": "Det kan ta litt tid før en reservert DOI forsvinner. Last innholdet på nytt for å sjekke igjen."
       },
+      "unknown_role": "Ukjent rolle",
       "validation_errors": "Valideringsfeil"
     },
     "publication_types": {

--- a/src/utils/registration-helpers.ts
+++ b/src/utils/registration-helpers.ts
@@ -609,17 +609,6 @@ export const getContributorsWithPrimaryRole = (
   });
 };
 
-export const getContributorsWithSecondaryRole = (
-  contributors: PreviewContributor[] | Contributor[],
-  registrationType: PublicationInstanceType
-) => {
-  const { secondaryRoles } = contributorConfig[registrationType];
-  return contributors.filter((contributor) => {
-    const roleValue = typeof contributor.role === 'string' ? contributor.role : contributor.role.type;
-    return secondaryRoles.includes(roleValue);
-  });
-};
-
 export const getOutputName = (item: OutputItem): string => {
   switch (item.type) {
     case 'Venue':


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48754

Vis bidragsytere med roller som ikke er kompatible med valgt kategori på landing page. Tidligere ble disse skjult.

Se eksempel under for bilde med et resultat hvor Isar har en rolle som egentlig ikke er kompatibel med kategorien.
Før:
![bilde](https://github.com/user-attachments/assets/8afddd94-9595-4483-b50f-332948dd6e7c)

Etter:
![bilde](https://github.com/user-attachments/assets/43f4665d-d949-4823-963f-a691b663239f)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
