### PR TITLE
Np 48758 avoid wrong warning about nvi reset

### DIFF
--- a/src/utils/nviHelpers.ts
+++ b/src/utils/nviHelpers.ts
@@ -45,7 +45,9 @@ const hasChangedContributorsOrAffiliations = async (
 
   for (const persistedContributor of persistedContributors) {
     const updatedContributor = updatedContributors.find(
-      (contributor) => contributor.identity.id === persistedContributor.identity.id
+      (contributor) =>
+        (contributor.identity.id && contributor.identity.id === persistedContributor.identity.id) ||
+        contributor.identity.name === persistedContributor.identity.name
     );
     if (updatedContributor) {
       const persistedAffiliations = persistedContributor.affiliations ?? [];
@@ -74,7 +76,6 @@ const hasChangedContributorsOrAffiliations = async (
       return true;
     }
   }
-
   return false;
 };
 

--- a/src/utils/nviHelpers.ts
+++ b/src/utils/nviHelpers.ts
@@ -76,6 +76,7 @@ const hasChangedContributorsOrAffiliations = async (
       return true;
     }
   }
+
   return false;
 };
 


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48758

Håndter ubekreftede bidragsytere for advarsel om NVI-nullstillinger. Mistenker vi kunne gjort flere andre forenklinger i flyten her, som er kommentert i Jira: https://sikt.atlassian.net/browse/NP-48758?focusedCommentId=113435

Jobber videre med ny PR som legger inn testing av dette rundt når NVI-advarsler skal vises.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
