### PR TITLE
NP-48772 Avoid frontend filtering of hits after API response

### DIFF
--- a/src/pages/editor/curators/AddCuratorDialog.tsx
+++ b/src/pages/editor/curators/AddCuratorDialog.tsx
@@ -123,6 +123,7 @@ export const AddCuratorDialog = ({
               {getFullCristinName(option.names)}
             </li>
           )}
+          filterOptions={(options) => options}
           onInputChange={(_, value) => setSearchQuery(value)}
           onChange={async (_, value) => {
             setSearchQuery('');


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48772

Unngå at frontend sin Autocomplete filtrerer enda en gang på søketraff fra APIet. Default funksjonalitet er at bare options som matcher nøyaktig med innskrevet tekst blir vist.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
