### PR TITLE
Ensure log entries are sorted chronologically

### DIFF
--- a/src/pages/public_registration/log/LogPanel.tsx
+++ b/src/pages/public_registration/log/LogPanel.tsx
@@ -19,6 +19,8 @@ interface LogPanelProps {
 export const LogPanel = ({ registration, tickets }: LogPanelProps) => {
   const { t } = useTranslation();
   const logQuery = useFetchRegistrationLog(registration.id);
+  const sortedLogEntries =
+    logQuery.data?.logEntries.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()) ?? [];
 
   return (
     <Box
@@ -43,7 +45,7 @@ export const LogPanel = ({ registration, tickets }: LogPanelProps) => {
           <Skeleton variant="rectangular" height={150} />
         </>
       ) : (
-        logQuery.data?.logEntries.toReversed().map((logEntry, index) => (
+        sortedLogEntries.map((logEntry, index) => (
           <ErrorBoundary key={index}>
             <LogEntryItem logEntry={logEntry} messages={getLogEntryMessages(logEntry, tickets)} />
           </ErrorBoundary>


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48542 (egentlig en standalone sak, men lenker til denne som er relatert)

Etter importkjøring har det dukket opp noen logg entries som ikke er sortert i kronologisk rekkefølge fra APIet, så vi må sørge for at de er riktig sortert i frontend også.
Eks: https://nva.sikt.no/registration/46205384-9f16-4995-9cf6-6f83a7e0d2a5

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
