### PR TITLE
NP-48810 Keep license when version is selected

### DIFF
--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -276,7 +276,7 @@ export const FilesTableRow = ({
                           sx={{ flexWrap: 'nowrap' }}
                           onChange={(event) => {
                             const newFileVersion = event.target.value as FileVersion;
-                            const previousFileVersion = field.value as FileVersion;
+                            const previousFileVersion = field.value;
                             setFieldValue(field.name, newFileVersion);
 
                             if (isRrsApplicableCategory) {
@@ -286,7 +286,7 @@ export const FilesTableRow = ({
                                   configuredType: rrsStrategy,
                                 };
                                 setFieldValue(rrsFieldName, nullRrsValue);
-                                if (!!previousFileVersion) {
+                                if (previousFileVersion === FileVersion.Accepted) {
                                   setFieldValue(licenseFieldName, null);
                                 }
                               } else if (isCustomerRrs || isOverridableRrs) {

--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -280,21 +280,16 @@ export const FilesTableRow = ({
                             setFieldValue(field.name, newFileVersion);
 
                             if (isRrsApplicableCategory) {
-                              if (
-                                newFileVersion === FileVersion.Published &&
-                                previousFileVersion === FileVersion.Accepted
-                              ) {
+                              if (newFileVersion === FileVersion.Published) {
                                 const nullRrsValue: FileRrs = {
                                   type: 'NullRightsRetentionStrategy',
                                   configuredType: rrsStrategy,
                                 };
                                 setFieldValue(rrsFieldName, nullRrsValue);
-                                setFieldValue(licenseFieldName, null);
-                              } else if (
-                                newFileVersion === FileVersion.Accepted &&
-                                previousFileVersion === FileVersion.Published &&
-                                (isCustomerRrs || isOverridableRrs)
-                              ) {
+                                if (!!previousFileVersion) {
+                                  setFieldValue(licenseFieldName, null);
+                                }
+                              } else if (isCustomerRrs || isOverridableRrs) {
                                 const customerRrsValue: FileRrs = {
                                   type: 'CustomerRightsRetentionStrategy',
                                   configuredType: rrsStrategy,

--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -275,18 +275,17 @@ export const FilesTableRow = ({
                           row
                           sx={{ flexWrap: 'nowrap' }}
                           onChange={(event) => {
-                            const newFileVersion = event.target.value as FileVersion;
-                            const previousFileVersion = field.value;
-                            setFieldValue(field.name, newFileVersion);
+                            const fileVersion = event.target.value as FileVersion;
+                            setFieldValue(field.name, fileVersion);
 
                             if (isRrsApplicableCategory) {
-                              if (newFileVersion === FileVersion.Published) {
+                              if (fileVersion === FileVersion.Published) {
                                 const nullRrsValue: FileRrs = {
                                   type: 'NullRightsRetentionStrategy',
                                   configuredType: rrsStrategy,
                                 };
                                 setFieldValue(rrsFieldName, nullRrsValue);
-                                if (previousFileVersion === FileVersion.Accepted) {
+                                if (field.value === FileVersion.Accepted) {
                                   setFieldValue(licenseFieldName, null);
                                 }
                               } else if (isCustomerRrs || isOverridableRrs) {

--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -292,7 +292,8 @@ export const FilesTableRow = ({
                                 setFieldValue(licenseFieldName, null);
                               } else if (
                                 newFileVersion === FileVersion.Accepted &&
-                                previousFileVersion === FileVersion.Published
+                                previousFileVersion === FileVersion.Published &&
+                                (isCustomerRrs || isOverridableRrs)
                               ) {
                                 const customerRrsValue: FileRrs = {
                                   type: 'CustomerRightsRetentionStrategy',

--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -275,18 +275,25 @@ export const FilesTableRow = ({
                           row
                           sx={{ flexWrap: 'nowrap' }}
                           onChange={(event) => {
-                            const fileVersion = event.target.value as FileVersion;
-                            setFieldValue(field.name, fileVersion);
+                            const newFileVersion = event.target.value as FileVersion;
+                            const previousFileVersion = field.value as FileVersion;
+                            setFieldValue(field.name, newFileVersion);
 
                             if (isRrsApplicableCategory) {
-                              if (fileVersion === FileVersion.Published) {
+                              if (
+                                newFileVersion === FileVersion.Published &&
+                                previousFileVersion === FileVersion.Accepted
+                              ) {
                                 const nullRrsValue: FileRrs = {
                                   type: 'NullRightsRetentionStrategy',
                                   configuredType: rrsStrategy,
                                 };
                                 setFieldValue(rrsFieldName, nullRrsValue);
                                 setFieldValue(licenseFieldName, null);
-                              } else if (isCustomerRrs || isOverridableRrs) {
+                              } else if (
+                                newFileVersion === FileVersion.Accepted &&
+                                previousFileVersion === FileVersion.Published
+                              ) {
                                 const customerRrsValue: FileRrs = {
                                   type: 'CustomerRightsRetentionStrategy',
                                   configuredType: rrsStrategy,


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48810

When a user has already selected a license, but not a file version, the license field was reset when "published version" was selected. Now, the selected license remains unless the previously selected version was "Accepted"

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
