### PR TITLE
Update staging 28.03.25

### DIFF
--- a/src/pages/messages/components/NviApprovals.tsx
+++ b/src/pages/messages/components/NviApprovals.tsx
@@ -17,13 +17,7 @@ export const NviApprovals = ({ approvals }: NviApprovalsProps) => {
 
   return (
     <Box sx={{ border: '1px solid', borderColor: 'nvi.main', gridArea: 'approvals' }}>
-      <Table
-        size="small"
-        sx={{
-          'th, td': {
-            borderBottomColor: 'nvi.main',
-          },
-        }}>
+      <Table size="small" sx={{ 'th, td': { borderBottomColor: 'nvi.main', px: '0.5rem' } }}>
         <TableHead>
           <TableRow sx={{ bgcolor: 'nvi.main' }}>
             <TableCell>{t('common.institution')}</TableCell>
@@ -92,7 +86,7 @@ const InstitutionStatus = ({ status }: InstitutionStatusProps) => {
     ) : null;
 
   return (
-    <Box sx={{ display: 'flex', gap: '0.2rem' }}>
+    <Box sx={{ display: 'flex', gap: '0.1rem' }}>
       {icon}
       <Typography sx={{ whiteSpace: 'nowrap' }}>{t(`tasks.nvi.status.${status}`)}</Typography>
     </Box>

--- a/src/pages/messages/components/NviCandidateActionPanel.tsx
+++ b/src/pages/messages/components/NviCandidateActionPanel.tsx
@@ -7,6 +7,7 @@ import { useFetchRegistrationTickets } from '../../../api/hooks/useFetchRegistra
 import { NviCandidate } from '../../../types/nvi.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { getIdentifierFromId } from '../../../utils/general-helpers';
+import { userHasAccessRight } from '../../../utils/registration-helpers';
 import { LogPanel } from '../../public_registration/log/LogPanel';
 import { NviDialoguePanel } from './NviDialoguePanel';
 
@@ -29,9 +30,10 @@ export const NviCandidateActionPanel = ({ nviCandidate, nviCandidateQueryKey }: 
   const { t } = useTranslation();
   const [tabValue, setTabValue] = useState(TabValue.Dialogue);
 
-  const ticketsQuery = useFetchRegistrationTickets(nviCandidate.publicationId);
   const registrationQuery = useFetchRegistration(getIdentifierFromId(nviCandidate.publicationId));
+  const canEditRegistration = userHasAccessRight(registrationQuery.data, 'update');
 
+  const ticketsQuery = useFetchRegistrationTickets(nviCandidate.publicationId, { enabled: canEditRegistration });
   const tickets = ticketsQuery.data?.tickets ?? [];
 
   return (
@@ -50,21 +52,25 @@ export const NviCandidateActionPanel = ({ nviCandidate, nviCandidateQueryKey }: 
           onChange={(_, newValue: TabValue) => setTabValue(newValue)}
           sx={{ bgcolor: 'primary.main', color: 'primary.contrastText', px: '0.5rem' }}
           textColor="inherit"
-          TabIndicatorProps={{ style: { backgroundColor: 'white', height: '0.4rem' } }}>
+          slotProps={{ indicator: { sx: { backgroundColor: 'white', height: '0.4rem' } } }}>
           <Tab
             label={t('common.dialogue')}
             value={TabValue.Dialogue}
             data-testid={dataTestId.tasksPage.nvi.dialogTabButton}
           />
-          <Tab label={t('common.log')} value={TabValue.Log} data-testid={dataTestId.tasksPage.nvi.logTabButton} />
+          {canEditRegistration && (
+            <Tab label={t('common.log')} value={TabValue.Log} data-testid={dataTestId.tasksPage.nvi.logTabButton} />
+          )}
         </TabList>
 
         <StyledTabPanel value={TabValue.Dialogue}>
           <NviDialoguePanel nviCandidate={nviCandidate} nviCandidateQueryKey={nviCandidateQueryKey} />
         </StyledTabPanel>
-        <StyledTabPanel value={TabValue.Log}>
-          {registrationQuery.data && <LogPanel tickets={tickets} registration={registrationQuery.data} />}
-        </StyledTabPanel>
+        {canEditRegistration && (
+          <StyledTabPanel value={TabValue.Log}>
+            {registrationQuery.data && <LogPanel tickets={tickets} registration={registrationQuery.data} />}
+          </StyledTabPanel>
+        )}
       </TabContext>
     </Paper>
   );

--- a/src/pages/messages/components/NviDialoguePanel.tsx
+++ b/src/pages/messages/components/NviDialoguePanel.tsx
@@ -47,7 +47,7 @@ export const NviDialoguePanel = ({ nviCandidate, nviCandidateQueryKey }: NviDial
               ? "'curator' 'approvals' 'divider0' 'problem' 'divider1' 'comment' 'divider2' 'actions'"
               : "'curator' 'approvals' 'divider1' 'comment' 'divider2' 'actions'",
         }}>
-        {periodStatus === 'OpenPeriod' && nviCandidate ? (
+        {periodStatus === 'OpenPeriod' && nviCandidate.allowedOperations.length > 0 ? (
           <NviCandidateActions nviCandidate={nviCandidate} nviCandidateQueryKey={nviCandidateQueryKey} />
         ) : periodStatus === 'ClosedPeriod' ? (
           <Typography sx={{ p: '1rem', bgcolor: 'nvi.main' }}>{t('tasks.nvi.reporting_period_closed')}</Typography>

--- a/src/pages/messages/components/TicketListItem.tsx
+++ b/src/pages/messages/components/TicketListItem.tsx
@@ -10,11 +10,16 @@ import { SearchListItem } from '../../../components/styled/Wrappers';
 import { RootState } from '../../../redux/store';
 import { PreviousSearchLocationState, SelectedTicketTypeLocationState } from '../../../types/locationState.types';
 import { ExpandedPublishingTicket, ExpandedTicket } from '../../../types/publication_types/ticket.types';
-import { emptyRegistration, Registration } from '../../../types/registration.types';
+import { emptyRegistration, Registration, RegistrationStatus } from '../../../types/registration.types';
 import { toDateString, toDateStringWithTime } from '../../../utils/date-helpers';
 import { getInitials } from '../../../utils/general-helpers';
 import { convertToRegistrationSearchItem } from '../../../utils/registration-helpers';
-import { getMyMessagesRegistrationPath, getTasksRegistrationPath, UrlPathTemplate } from '../../../utils/urlPaths';
+import {
+  doNotRedirectQueryParam,
+  getMyMessagesRegistrationPath,
+  getTasksRegistrationPath,
+  UrlPathTemplate,
+} from '../../../utils/urlPaths';
 import { getFullName } from '../../../utils/user-helpers';
 import { StyledVerifiedContributor } from '../../registration/contributors_tab/ContributorIndicator';
 import { DoiRequestMessagesColumn } from './DoiRequestMessagesColumn';
@@ -85,6 +90,7 @@ export const TicketListItem = ({ ticket }: TicketListItemProps) => {
             : isOnMyPageMessages
               ? getMyMessagesRegistrationPath(identifier)
               : '',
+          search: ticket.publication.status === RegistrationStatus.Unpublished ? `${doNotRedirectQueryParam}=true` : '',
         }}
         onClick={() => {
           if (!viewedByUser) {

--- a/src/pages/public_registration/PublicRegistration.tsx
+++ b/src/pages/public_registration/PublicRegistration.tsx
@@ -1,7 +1,7 @@
 import SearchIcon from '@mui/icons-material/Search';
 import { Box } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import { MinimizedMenuIconButton } from '../../components/SideMenu';
 import { PreviousPathLocationState } from '../../types/locationState.types';
 import { RegistrationLandingPage } from './RegistrationLandingPage';
@@ -9,6 +9,7 @@ import { RegistrationLandingPage } from './RegistrationLandingPage';
 const PublicRegistration = () => {
   const { t } = useTranslation();
   const location = useLocation();
+  const navigate = useNavigate();
   const locationState = location.state as PreviousPathLocationState;
   const previousPath = locationState?.previousPath;
 
@@ -23,7 +24,7 @@ const PublicRegistration = () => {
       }}>
       {previousPath && (
         <Box sx={{ alignSelf: 'start', justifySelf: 'start' }}>
-          <MinimizedMenuIconButton title={t('common.search')} to={previousPath}>
+          <MinimizedMenuIconButton title={t('common.search')} onClick={() => navigate(-1)}>
             <SearchIcon />
           </MinimizedMenuIconButton>
         </Box>

--- a/src/pages/public_registration/RegistrationLandingPage.tsx
+++ b/src/pages/public_registration/RegistrationLandingPage.tsx
@@ -24,10 +24,10 @@ export const RegistrationLandingPage = () => {
   const registration = registrationQuery.data;
   const registrationId = registration?.id;
 
-  if (identifier && identifier !== registration?.identifier && !!registration?.identifier) {
+  if (identifier && !!registration?.identifier && identifier !== registration.identifier) {
+    // Update URL with the correct identifier if the original result yields an redirect due to being unpublished
     const newPath = location.pathname.replace(identifier, registration.identifier);
-    const searchParams = location.search ?? '';
-    navigate(newPath + searchParams, { replace: true });
+    navigate(newPath + location.search, { replace: true, state: location.state });
   }
 
   const canEditRegistration = userHasAccessRight(registration, 'update');

--- a/src/pages/public_registration/RegistrationSummary.tsx
+++ b/src/pages/public_registration/RegistrationSummary.tsx
@@ -1,6 +1,7 @@
 import { Link, Skeleton } from '@mui/material';
 import { Link as RouterLink } from 'react-router';
 import { useFetchRegistration } from '../../api/hooks/useFetchRegistration';
+import { PreviousPathLocationState } from '../../types/locationState.types';
 import { getIdentifierFromId } from '../../utils/general-helpers';
 import { getTitleString } from '../../utils/registration-helpers';
 import { getRegistrationLandingPagePath } from '../../utils/urlPaths';
@@ -18,7 +19,10 @@ export const RegistrationSummary = ({ id }: RegistrationSummaryProps) => {
   return containerQuery.isPending ? (
     <Skeleton width={400} />
   ) : container ? (
-    <Link component={RouterLink} to={getRegistrationLandingPagePath(identifier)}>
+    <Link
+      component={RouterLink}
+      state={{ previousPath: `${location.pathname}${location.search}` } satisfies PreviousPathLocationState}
+      to={getRegistrationLandingPagePath(identifier)}>
       {getTitleString(container.entityDescription?.mainTitle)}
     </Link>
   ) : null;

--- a/src/pages/public_registration/log/LogPanel.tsx
+++ b/src/pages/public_registration/log/LogPanel.tsx
@@ -19,6 +19,8 @@ interface LogPanelProps {
 export const LogPanel = ({ registration, tickets }: LogPanelProps) => {
   const { t } = useTranslation();
   const logQuery = useFetchRegistrationLog(registration.id);
+  const sortedLogEntries =
+    logQuery.data?.logEntries.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()) ?? [];
 
   return (
     <Box
@@ -43,7 +45,7 @@ export const LogPanel = ({ registration, tickets }: LogPanelProps) => {
           <Skeleton variant="rectangular" height={150} />
         </>
       ) : (
-        logQuery.data?.logEntries.toReversed().map((logEntry, index) => (
+        sortedLogEntries.map((logEntry, index) => (
           <ErrorBoundary key={index}>
             <LogEntryItem logEntry={logEntry} messages={getLogEntryMessages(logEntry, tickets)} />
           </ErrorBoundary>

--- a/src/pages/registration/FileList.tsx
+++ b/src/pages/registration/FileList.tsx
@@ -28,8 +28,8 @@ import {
   isOpenFile,
   isPendingOpenFile,
 } from '../../utils/registration-helpers';
-import { HelperTextModal } from './HelperTextModal';
 import { FilesTableRow } from './files_and_license_tab/FilesTableRow';
+import { HelperTextModal } from './HelperTextModal';
 
 const StyledTableCell = styled(TableCell)({
   pt: '0.75rem',
@@ -165,6 +165,16 @@ export const FileList = ({ title, files, uppy, remove, baseFieldName }: FileList
                               <Link href={license.link} target="blank">
                                 {license.link}
                               </Link>
+                            )}
+                            {license.additionalInformation && (
+                              <Trans
+                                defaults={license.additionalInformation}
+                                components={{
+                                  p: <Typography sx={{ mt: '1rem' }} />,
+                                  ol: <ol style={{ listStyleType: 'lower-roman' }} />,
+                                  li: <li style={{ marginBottom: '0.5rem' }} />,
+                                }}
+                              />
                             )}
                           </Box>
                         ))}

--- a/src/pages/registration/new_registration/EditRegistration.tsx
+++ b/src/pages/registration/new_registration/EditRegistration.tsx
@@ -8,10 +8,12 @@ import { IdentifierParams } from '../../../utils/urlPaths';
 import { RegistrationForm } from '../RegistrationForm';
 import { LinkRegistration } from './LinkRegistration';
 import { StartEmptyRegistration } from './StartEmptyRegistration';
+import { UploadRegistration } from './UploadFileRegistration';
 
 enum PanelName {
   LinkPanel,
   EmptyPanel,
+  UploadFilePanel,
 }
 
 const EditRegistration = () => {
@@ -33,6 +35,10 @@ const EditRegistration = () => {
           gap: '2rem',
         }}>
         <LinkRegistration expanded={expanded === PanelName.LinkPanel} onChange={handleChange(PanelName.LinkPanel)} />
+        <UploadRegistration
+          expanded={expanded === PanelName.UploadFilePanel}
+          onChange={handleChange(PanelName.UploadFilePanel)}
+        />
         <StartEmptyRegistration onChange={handleChange(PanelName.EmptyPanel)} />
       </Box>
     </StyledPageContent>

--- a/src/pages/registration/new_registration/UploadFileRegistration.tsx
+++ b/src/pages/registration/new_registration/UploadFileRegistration.tsx
@@ -1,0 +1,167 @@
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import CloudUploadIcon from '@mui/icons-material/CloudUploadOutlined';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import UploadIcon from '@mui/icons-material/Upload';
+import {
+  AccordionActions,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  IconButton,
+  Typography,
+} from '@mui/material';
+import { useMutation } from '@tanstack/react-query';
+import Uppy from '@uppy/core';
+import { useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
+import { Link } from 'react-router';
+import { deleteRegistrationFile } from '../../../api/fileApi';
+import { createRegistration } from '../../../api/registrationApi';
+import { setNotification } from '../../../redux/notificationSlice';
+import { AssociatedFile } from '../../../types/associatedArtifact.types';
+import { dataTestId } from '../../../utils/dataTestIds';
+import { createUppy } from '../../../utils/uppy/uppy-config';
+import { getRegistrationWizardPath } from '../../../utils/urlPaths';
+import { FileUploader } from '../files_and_license_tab/FileUploader';
+import { StartRegistrationAccordionProps } from './LinkRegistration';
+import { RegistrationAccordion } from './RegistrationAccordion';
+
+interface DeleteFileMutationParams {
+  registrationIdentifier: string;
+  fileIdentifier: string;
+}
+
+export const UploadRegistration = ({ expanded, onChange }: StartRegistrationAccordionProps) => {
+  const { t, i18n } = useTranslation();
+  const dispatch = useDispatch();
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uppy, setUppy] = useState<Uppy>();
+  const [uploadedFiles, setUploadedFiles] = useState<AssociatedFile[]>([]);
+
+  const createRegistrationMutation = useMutation({
+    mutationFn: async () => {
+      const newRegistration = await createRegistration();
+      return newRegistration.data;
+    },
+    onError: () => dispatch(setNotification({ message: t('feedback.error.create_registration'), variant: 'error' })),
+  });
+
+  const deleteFileMutation = useMutation({
+    mutationFn: async ({ registrationIdentifier, fileIdentifier }: DeleteFileMutationParams) => {
+      if (registrationIdentifier && fileIdentifier) {
+        await deleteRegistrationFile(registrationIdentifier, fileIdentifier);
+      }
+    },
+    onSuccess: () => dispatch(setNotification({ message: t('feedback.success.delete_file'), variant: 'success' })),
+    onError: () => dispatch(setNotification({ message: t('feedback.error.delete_file'), variant: 'error' })),
+  });
+
+  return (
+    <RegistrationAccordion elevation={5} expanded={expanded} onChange={onChange}>
+      <AccordionSummary
+        data-testid={dataTestId.registrationWizard.new.fileAccordion}
+        expandIcon={<ExpandMoreIcon fontSize="large" />}>
+        <CloudUploadIcon />
+        <div>
+          <Typography variant="h2">{t('registration.registration.start_with_uploading_file_title')}</Typography>
+          <Typography>{t('registration.registration.start_with_uploading_file_description')}</Typography>
+        </div>
+      </AccordionSummary>
+
+      <AccordionDetails>
+        {uppy ? (
+          <FileUploader uppy={uppy} addFile={(newFile) => setUploadedFiles((files) => [newFile, ...files])} />
+        ) : (
+          <Button
+            data-testid={dataTestId.registrationWizard.new.uploadFileButton}
+            variant="contained"
+            sx={{ alignSelf: 'center' }}
+            endIcon={<UploadIcon />}
+            loadingPosition="end"
+            loading={createRegistrationMutation.isPending}
+            onClick={() => fileInputRef.current?.click()}>
+            {t('common.select_file')}
+            <input
+              type="file"
+              hidden
+              ref={fileInputRef}
+              onChange={async (event) => {
+                const newRegistration = await createRegistrationMutation.mutateAsync();
+                const newUppyInstance = createUppy(i18n.language, newRegistration.identifier);
+                setUppy(newUppyInstance);
+                const file = event.target.files?.[0];
+                if (file) {
+                  newUppyInstance.addFile(file);
+                }
+              }}
+            />
+          </Button>
+        )}
+
+        {uppy && uploadedFiles.length > 0 && (
+          <>
+            <Typography variant="h3">{t('registration.files_and_license.files')}:</Typography>
+            {uploadedFiles.map((file) => (
+              <Box key={file.identifier} sx={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <Typography sx={{ wordBreak: 'break-all' }}>{file.name}</Typography>
+                <IconButton
+                  title={t('registration.files_and_license.delete_file')}
+                  color="primary"
+                  data-testid={dataTestId.registrationWizard.files.deleteFile}
+                  loading={
+                    deleteFileMutation.isPending && deleteFileMutation.variables.fileIdentifier === file.identifier
+                  }
+                  onClick={async () => {
+                    const registrationIdentifier = createRegistrationMutation.data?.identifier;
+                    if (registrationIdentifier && file.identifier) {
+                      await deleteFileMutation.mutateAsync({
+                        registrationIdentifier,
+                        fileIdentifier: file.identifier,
+                      });
+                    }
+
+                    const uppyFiles = uppy.getFiles();
+                    const uppyId = uppyFiles.find(
+                      (uppyFile) => uppyFile.response?.body?.identifier === file.identifier
+                    )?.id;
+                    if (uppyId) {
+                      uppy.removeFile(uppyId);
+                    }
+
+                    setUploadedFiles(
+                      uploadedFiles.filter((uploadedFile) => uploadedFile.identifier !== file.identifier)
+                    );
+                  }}>
+                  <DeleteIcon />
+                </IconButton>
+              </Box>
+            ))}
+          </>
+        )}
+      </AccordionDetails>
+
+      <AccordionActions>
+        <Button
+          data-testid={dataTestId.registrationWizard.new.startRegistrationButton}
+          endIcon={<ArrowForwardIcon fontSize="large" />}
+          variant="contained"
+          disabled={
+            !createRegistrationMutation.data?.identifier || uploadedFiles.length === 0 || deleteFileMutation.isPending
+          }
+          component={Link}
+          to={
+            createRegistrationMutation.data?.identifier
+              ? getRegistrationWizardPath(createRegistrationMutation.data.identifier)
+              : ''
+          }
+          state={{ highestValidatedTab: -1 }}>
+          {t('registration.registration.start_registration')}
+        </Button>
+      </AccordionActions>
+    </RegistrationAccordion>
+  );
+};

--- a/src/translations/enTranslations.json
+++ b/src/translations/enTranslations.json
@@ -282,6 +282,7 @@
     "search_summary_one": "{{count}} result for \"{{searchTerm}}\"",
     "search_summary_other": "{{count}} results for \"{{searchTerm}}\"",
     "select": "Select",
+    "select_file": "Select file",
     "select_institution": "Select institution",
     "select_role": "Select role",
     "select_unit": "Select unit",
@@ -671,6 +672,9 @@
     "to_top": "To the top"
   },
   "licenses": {
+    "additional_info": {
+      "cc0": ""
+    },
     "description": {
       "cc0": "The person who has associated a work with this deed has, to the extent the law allows, declared this work to be in the public domain by waiving all copyright and related rights that they had to the work.",
       "cc_by": "Share — copy, distribute and transmit the work in any medium or format. Adapt — remix, transform, and build upon the material for any purpose, including commercially.\n\nYou must give appropriate credit, provide a link to the licence, and indicate if changes have been made.",
@@ -731,7 +735,7 @@
       "file_deleted": "File deleted",
       "file_hidden": "File hidden",
       "file_retracted": "File redacted",
-      "file_type_updated": "",
+      "file_type_updated": "File changed to {{newFileType}}",
       "files_published_one": "File published",
       "files_published_other": "Files published",
       "files_rejected_one": "File rejected",
@@ -1683,7 +1687,9 @@
       "start_with_empty_registration_description": "Enter information later",
       "start_with_empty_registration_title": "Start in a blank registration form",
       "start_with_link_to_resource_description": "Link to the original version if the resource is already published on the Internet",
-      "start_with_link_to_resource_title": "Start with link to original version"
+      "start_with_link_to_resource_title": "Start with link to original version",
+      "start_with_uploading_file_description": "Upload file if the resource is not published on the internet",
+      "start_with_uploading_file_title": "Start by uploading file"
     },
     "registration_id": "Result ID",
     "resource_type": {
@@ -1859,7 +1865,7 @@
       "change_registration_type": "Change registration type?",
       "change_registration_type_description": "Note that this may result in you losing some data you have entered in cases where existing data is not valid for the new type. Are you sure you want to change the registration type?",
       "chapter": {
-        "info_anthology": "The anthology where the chapter is published must be published first",
+        "info_anthology": "The anthology where the chapter is published, must be registered and made public in NVA before you can register the chapter",
         "info_book_of_abstracts": "The abstract collection where the abstract is published must be published first",
         "info_report": "The report where the chapter is published must be published first",
         "published_in": "Published in",

--- a/src/translations/enTranslations.json
+++ b/src/translations/enTranslations.json
@@ -156,7 +156,6 @@
       "no_eligable_roles": "Persons without a national identity number cannot have roles",
       "no_employees_found": "No employees found",
       "other_employments": "Other active employments",
-      "person_id": "Person ID",
       "person_register": "Person register",
       "previous_employments": "Previous employments",
       "remove_employment": "Remove employment",
@@ -732,6 +731,7 @@
       "file_deleted": "File deleted",
       "file_hidden": "File hidden",
       "file_retracted": "File redacted",
+      "file_type_updated": "",
       "files_published_one": "File published",
       "files_published_other": "Files published",
       "files_rejected_one": "File rejected",
@@ -811,12 +811,9 @@
         "roles": "Roles"
       },
       "identity": {
-        "identity": "Identity",
-        "identity_numbers": "Identity numbers",
         "upload_profile_photo": "Upload profile picture",
         "upload_profile_photo_info": "Maximum size: 1 MB. Supported file types: .jpg or .jpeg"
       },
-      "identity_numbers_description": "Identity numbers are retrieved from the login.",
       "link_to_projects_search": "See <0>the search page</0> to filter among all projects.",
       "link_to_results_search": "See <0>the search page</0> to filter among all results.",
       "list_contains_all_registration_you_have_created": "The list shows all the projects you have registered",
@@ -1601,7 +1598,7 @@
         "terminate_result_description": "<0>Delete the result if it has been incorrectly registered.</0><0>If the result is deleted, it is not possible to restore the information and files associated with the result.</0>",
         "waiting_for_rejected_doi": "It may take some time before a reserved DOI is removed. Reload the page to check again."
       },
-      "unknown_role": "",
+      "unknown_role": "Unknown role",
       "validation_errors": "Validation errors"
     },
     "publication_types": {

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -325,6 +325,10 @@
     "yes": "Ja"
   },
   "disciplines": {
+    "0001": "Humaniora",
+    "0002": "Samfunnsvitenskap",
+    "0003": "Medisin og helsefag",
+    "0004": "Realfag og teknologi",
     "1003": "Arkeologi og konservering",
     "1005": "Asiatiske og afrikanske studier",
     "1007": "Engelsk",
@@ -396,11 +400,7 @@
     "1162": "Konstruksjonsfag",
     "1166": "Filosofi",
     "1168": "Historie og idéhistorie",
-    "1170": "Kunst, design og arkitektur",
-    "0001": "Humaniora",
-    "0002": "Samfunnsvitenskap",
-    "0003": "Medisin og helsefag",
-    "0004": "Realfag og teknologi"
+    "1170": "Kunst, design og arkitektur"
   },
   "editor": {
     "categories_with_files": "Kategorier med filopplasting",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -282,6 +282,7 @@
     "search_summary_one": "{{count}} treff for \"{{searchTerm}}\"",
     "search_summary_other": "{{count}} treff for \"{{searchTerm}}\"",
     "select": "Velg",
+    "select_file": "Velg fil",
     "select_institution": "Velg institusjon",
     "select_role": "Velg rolle",
     "select_unit": "Velg enhet",
@@ -324,10 +325,6 @@
     "yes": "Ja"
   },
   "disciplines": {
-    "0001": "Humaniora",
-    "0002": "Samfunnsvitenskap",
-    "0003": "Medisin og helsefag",
-    "0004": "Realfag og teknologi",
     "1003": "Arkeologi og konservering",
     "1005": "Asiatiske og afrikanske studier",
     "1007": "Engelsk",
@@ -399,7 +396,11 @@
     "1162": "Konstruksjonsfag",
     "1166": "Filosofi",
     "1168": "Historie og idéhistorie",
-    "1170": "Kunst, design og arkitektur"
+    "1170": "Kunst, design og arkitektur",
+    "0001": "Humaniora",
+    "0002": "Samfunnsvitenskap",
+    "0003": "Medisin og helsefag",
+    "0004": "Realfag og teknologi"
   },
   "editor": {
     "categories_with_files": "Kategorier med filopplasting",
@@ -1685,8 +1686,10 @@
       "start_registration": "Start registrering",
       "start_with_empty_registration_description": "Legg inn informasjon etterpå",
       "start_with_empty_registration_title": "Start i tomt registreringsskjema",
-      "start_with_link_to_resource_description": "Lenke til original versjon hvis ressursen allerede er publisert på Internett",
-      "start_with_link_to_resource_title": "Start med lenke til original versjon"
+      "start_with_link_to_resource_description": "Lenke til original versjon hvis ressursen allerede er publisert på internett",
+      "start_with_link_to_resource_title": "Start med lenke til original versjon",
+      "start_with_uploading_file_description": "Last opp fil hvis ressursen ikke er publisert på internett",
+      "start_with_uploading_file_title": "Start med å laste opp fil"
     },
     "registration_id": "Resultat-ID",
     "resource_type": {

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1859,7 +1859,7 @@
       "change_registration_type": "Bytte registreringstype?",
       "change_registration_type_description": "Merk at dette kan føre til at du mister noe av dataene du har lagt inn i de tilfellene hvor eksisterende data ikke er gyldig for den nye typen. Er du sikker på at du vil bytte registreringstype?",
       "chapter": {
-        "info_anthology": "Antologien hvor kapittelet er publisert i må være publisert først",
+        "info_anthology": "Antologien som kapittelet er publisert i, må være registrert og offentliggjort i NVA før du kan registrere kapittelet",
         "info_book_of_abstracts": "Abstraktsamlingen hvor abstraktet er publisert i må være publisert først",
         "info_report": "Rapporten hvor kapittelet er publisert i må være publisert først",
         "published_in": "Publisert i",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -671,6 +671,9 @@
     "to_top": "Til toppen"
   },
   "licenses": {
+    "additional_info": {
+      "cc0": "<p>Det bør deles et åpent eller lukket notat, sammen med verket som:</p><ol><li>Gjør rede for konklusjonen om at verket er å oppfatte som et \"fellesgode/public domain\", som definert av Åndsverksloven §11 Opphavsrettens vernetid eller §14 Åndsverk som ikke har opphavsrettslig vern, eller etter en annen lignende bestemmelse</li><li>Dokumenterer at opphaver frasier seg alle opphavsrettigheter og relaterte rettigheter de hadde til verket, som for eksempel omtalt i Åndsverksloven §3 Opphavsrettens innhold og §8 Fellesverk, og at verket er å oppfatte som et \"fellesgode/public domain\"</li></ol>"
+    },
     "description": {
       "cc0": "Den person som har knyttet et verk til dette aktstykke (deed) har, i den utstrekning loven tillater, erklært dette verket er i det fri ved å si fra seg alle de opphavsrettigheter og nærstående rettigheter som vedkommende hadde til verket.",
       "cc_by": "Dele — kopiere, distribuere og spre verket i hvilket som helst medium eller format. \nBearbeide — remixe, endre, og bygge videre på materialet til et hvilket som helst formål, inkludert kommersielle. \n\nDu må oppgi korrekt kreditering, oppgi en lenke til lisensen, og indikere om endringer er blitt gjort.",

--- a/src/translations/nnTranslations.json
+++ b/src/translations/nnTranslations.json
@@ -156,7 +156,6 @@
       "no_eligable_roles": "Personar utan fødselsnummer kan ikkje ha roller",
       "no_employees_found": "Ingen tilsette funne",
       "other_employments": "Andre aktive tilsetjingar",
-      "person_id": "PersonID",
       "person_register": "Personregister",
       "previous_employments": "Tidlegare tilsetjingar",
       "remove_employment": "Fjern tilsetjing",
@@ -732,6 +731,7 @@
       "file_deleted": "Fil sletta",
       "file_hidden": "Fil skjult",
       "file_retracted": "Fil trukket tilbake",
+      "file_type_updated": "",
       "files_published_one": "Fil publisert",
       "files_published_other": "Filer publiserte",
       "files_rejected_one": "Fil avvist",
@@ -811,12 +811,9 @@
         "roles": "Roller"
       },
       "identity": {
-        "identity": "Identitet",
-        "identity_numbers": "Identitetsnummer",
         "upload_profile_photo": "Last opp profilbilete",
         "upload_profile_photo_info": "Maksimum storleik: 1 MB. Støtta filtypar: .jpg eller .jpeg"
       },
-      "identity_numbers_description": "Identitetsnummer blir henta frå innlogginga.",
       "link_to_projects_search": "Sjå <0>søkesida</0> for å filtrere blant alle prosjekt.",
       "link_to_results_search": "Sjå <0>søkesida</0> for å filtrere blant alle resultat.",
       "list_contains_all_registration_you_have_created": "Lista viser alle prosjekt du har registrert",
@@ -1601,7 +1598,7 @@
         "terminate_result_description": "<0>Slett resultatet om det er feilregistrert.</0><0>Slettar du resultatet er det ikkje mogleg å gjenopprette informasjon og filer på resultatet.</0>",
         "waiting_for_rejected_doi": "Det kan ta litt tid før ein reservert DOI forsvinn. Last innhaldet på nytt for å sjekke igjen."
       },
-      "unknown_role": "",
+      "unknown_role": "Ukjend rolle",
       "validation_errors": "Valideringsfeil"
     },
     "publication_types": {
@@ -2110,7 +2107,7 @@
       "correction_list_type": {
         "anthology_with_applicable_chapter": "Antologiar med teljande kapittel",
         "anthology_without_chapter": "Antologiar utan kapittel",
-        "applicable_category_in_non_applicable_channel": "Teljande katgoriar i ikkje-teljande kanalar",
+        "applicable_category_in_non_applicable_channel": "Teljande kategoriar i ikkje-teljande kanalar",
         "book_with_less_than_50_pages": "Bøker med færre enn 50 sider",
         "non_applicable_category_in_applicable_channel": "Ikkje-teljande kategoriar i teljande kanalar",
         "unidentified_contributor_with_identified_affiliation": "Uidentifisert bidragsytar med identifisert institusjon"

--- a/src/translations/nnTranslations.json
+++ b/src/translations/nnTranslations.json
@@ -282,6 +282,7 @@
     "search_summary_one": "{{count}} treff for \"{{searchTerm}}\"",
     "search_summary_other": "{{count}} treff for \"{{searchTerm}}\"",
     "select": "Vel",
+    "select_file": "Vel fil",
     "select_institution": "Vel institusjon",
     "select_role": "Vel rolle",
     "select_unit": "Vel eining",
@@ -671,6 +672,9 @@
     "to_top": "Til toppen"
   },
   "licenses": {
+    "additional_info": {
+      "cc0": ""
+    },
     "description": {
       "cc0": "Den person som har knytt eit verk til dette aktstykke (deed) har, i den utstrekning lova tillèt, erklært at dette verket er i det fri ved å seie frå seg alle opphavsrettar og nærståande rettar som vedkomande hadde til verket.",
       "cc_by": "Dele — kopiere, distribuere og spre verket i kva som helst medium eller format. \nBearbeide — remixe, endre, og byggje vidare på materialet til eit kva som helst føremål, inkludert kommersielle. \n\nDu må oppgi korrekt kreditering, oppgi ei lenkje til lisensen, og indikere om endringar er blitt gjort.",
@@ -731,7 +735,7 @@
       "file_deleted": "Fil sletta",
       "file_hidden": "Fil skjult",
       "file_retracted": "Fil trukket tilbake",
-      "file_type_updated": "",
+      "file_type_updated": "Fil endra til {{newFileType}}",
       "files_published_one": "Fil publisert",
       "files_published_other": "Filer publiserte",
       "files_rejected_one": "Fil avvist",
@@ -1683,7 +1687,9 @@
       "start_with_empty_registration_description": "Legg inn informasjon etterpå",
       "start_with_empty_registration_title": "Start i tomt registreringsskjema",
       "start_with_link_to_resource_description": "Lenkje til original versjon viss ressursen allereie er publisert på Internett",
-      "start_with_link_to_resource_title": "Start med lenkje til original versjon"
+      "start_with_link_to_resource_title": "Start med lenkje til original versjon",
+      "start_with_uploading_file_description": "Last opp fil dersom ressursen ikkje finst på internett",
+      "start_with_uploading_file_title": "Start med å laste opp fil"
     },
     "registration_id": "Resultat-ID",
     "resource_type": {
@@ -1859,7 +1865,7 @@
       "change_registration_type": "Byte registreringstype?",
       "change_registration_type_description": "Merk at dette kan føre til at du mister noko av data du har lagt inn i dei tilfella der eksisterande data ikkje er gyldig for den nye typen. Er du sikker på at du vil byte registreringstype?",
       "chapter": {
-        "info_anthology": "Antologien som kapittelet er publisert i må vere publisert først",
+        "info_anthology": "Antologien som kapittelet er publisert i, må vere registrert og offentleggjort i NVA før du kan registrere kapittelet",
         "info_book_of_abstracts": "Abstraktsamlinga som abstraktet er publisert i må vere publisert først",
         "info_report": "Rapporten som kapittelet er publisert i må vere publisert først",
         "published_in": "Publisert i",

--- a/src/types/license.types.ts
+++ b/src/types/license.types.ts
@@ -43,6 +43,7 @@ interface LicenseInfo {
   logo: string;
   link: string;
   version?: 1 | 2 | 2.5 | 3 | 4;
+  additionalInformation?: string;
 }
 
 export const licenses: LicenseInfo[] = [
@@ -292,6 +293,7 @@ export const licenses: LicenseInfo[] = [
     description: i18n.t('licenses.description.cc0'),
     link: i18n.t('licenses.links.cc0'),
     logo: LicenseImages.cc0Logo,
+    additionalInformation: i18n.t('licenses.additional_info.cc0'),
   },
   {
     id: LicenseUri.RightsReserved,

--- a/src/utils/dataTestIds.ts
+++ b/src/utils/dataTestIds.ts
@@ -501,9 +501,12 @@ export const dataTestId = {
     },
     new: {
       emptyRegistrationAccordion: 'new-registration-empty',
+      fileAccordion: 'file-accordion',
       linkAccordion: 'new-registration-link',
       linkMetadata: 'link-metadata',
+      removeFileButton: 'remove-file-button',
       startRegistrationButton: 'registration-start-button',
+      uploadFileButton: 'upload-file-button',
     },
     formActions: {
       cancelEditButton: 'cancel-edit-button',


### PR DESCRIPTION
:rocket: Ny funksjonalitet :rocket:

* Legg til støtte for å starte registrering med filopplasting ([NP-48761](https://sikt.atlassian.net/browse/NP-48761))
    * NB! Vi har har hatt støtte for dette tidligere også, men det ble midlertidig tatt vekk i starten av februar pga tekniske endringer
* Tillat åpning av en NVI-kandidat man ikke har lov til å godkjenne, men skjul knapper og felter som da ikke er relevante ([NP-48820](https://sikt.atlassian.net/browse/NP-48820))


:bug: Bugfiks :bug:

* Løst feil hvor tilbake-knappen noen ganger forsvant om man navigerte videre til andre resultater fra et søketreff ([NP-48798](https://sikt.atlassian.net/browse/NP-48798))
* Løst feil hvor det ikke var mulig for kurator å åpne en ticket knyttet til et resultat som var avpublisert med en duplikat, da man automatisk ble sendt til duplikaten i stedet ([NP-48773](https://sikt.atlassian.net/browse/NP-48773))
* Løst feil hvor logginnslag noen ganger ikke ble vist i kronologisk rekkefølge for importerte poster ([PR](https://github.com/BIBSYSDEV/NVA-Frontend/pull/7222))


:art: Designendringer :art:

* Oppdatert hjelpetekst for CC0-lisens ([NP-48746](https://sikt.atlassian.net/browse/NP-48746))

[NP-48761]: https://sikt.atlassian.net/browse/NP-48761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NP-48820]: https://sikt.atlassian.net/browse/NP-48820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NP-48798]: https://sikt.atlassian.net/browse/NP-48798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NP-48773]: https://sikt.atlassian.net/browse/NP-48773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NP-48746]: https://sikt.atlassian.net/browse/NP-48746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ