### PR TITLE
Add react group to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,9 @@ updates:
       eslint:
         patterns:
           - 'eslint*'
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - '@types/react'
+          - '@types/react-dom'


### PR DESCRIPTION
Samle alle React-oppdatering i samme PR fra dependabot.

I dag er disse delt i to grupper:
- `react`: https://github.com/BIBSYSDEV/NVA-Frontend/pull/7238
- `react-dom`: https://github.com/BIBSYSDEV/NVA-Frontend/pull/7235