### PR TITLE
Np 48863 validate funding

### DIFF
--- a/src/pages/registration/description_tab/RegistrationFunding.tsx
+++ b/src/pages/registration/description_tab/RegistrationFunding.tsx
@@ -91,7 +91,7 @@ export const RegistrationFunding = ({ currentFundings }: FundingsFieldProps) => 
                         </Field>
                         <TextField
                           value={funding.identifier}
-                          disabled={hasSelectedNfrSource}
+                          disabled
                           label={t('registration.description.funding.funding_id')}
                           fullWidth
                           variant="filled"
@@ -141,12 +141,10 @@ export const RegistrationFunding = ({ currentFundings }: FundingsFieldProps) => 
                           <TextField
                             {...field}
                             value={field.value ?? ''}
-                            disabled={hasSelectedNfrSource}
                             label={t('registration.description.funding.funding_name')}
                             fullWidth
                             variant="filled"
                             multiline
-                            required={!hasSelectedNfrSource}
                             sx={getTextFieldMargin(touched && !!error)}
                             error={touched && !!error}
                             helperText={touched && !!error ? error : undefined}

--- a/src/pages/registration/description_tab/RegistrationFunding.tsx
+++ b/src/pages/registration/description_tab/RegistrationFunding.tsx
@@ -141,11 +141,11 @@ export const RegistrationFunding = ({ currentFundings }: FundingsFieldProps) => 
                           <TextField
                             {...field}
                             value={field.value ?? ''}
-                            required
                             label={t('registration.description.funding.funding_name')}
                             fullWidth
                             variant="filled"
                             multiline
+                            required
                             sx={getTextFieldMargin(touched && !!error)}
                             error={touched && !!error}
                             helperText={touched && !!error ? error : undefined}

--- a/src/pages/registration/description_tab/RegistrationFunding.tsx
+++ b/src/pages/registration/description_tab/RegistrationFunding.tsx
@@ -141,6 +141,7 @@ export const RegistrationFunding = ({ currentFundings }: FundingsFieldProps) => 
                           <TextField
                             {...field}
                             value={field.value ?? ''}
+                            required
                             label={t('registration.description.funding.funding_name')}
                             fullWidth
                             variant="filled"
@@ -154,14 +155,15 @@ export const RegistrationFunding = ({ currentFundings }: FundingsFieldProps) => 
                       </Field>
 
                       <Field name={`${baseFieldName}.${SpecificFundingFieldNames.Identifier}`}>
-                        {({ field }: FieldProps<string>) => (
+                        {({ field, meta: { error, touched } }: FieldProps<string>) => (
                           <TextField
                             {...field}
                             value={field.value ?? ''}
-                            disabled={hasSelectedNfrSource}
+                            required
                             label={t('registration.description.funding.funding_id')}
                             fullWidth
                             variant="filled"
+                            error={touched && !!error}
                             data-testid={dataTestId.registrationWizard.description.fundingIdField}
                           />
                         )}
@@ -171,7 +173,6 @@ export const RegistrationFunding = ({ currentFundings }: FundingsFieldProps) => 
                         {({ field, meta: { error, touched } }: FieldProps<number>) => (
                           <TextField
                             {...field}
-                            disabled={hasSelectedNfrSource}
                             label={t('registration.description.funding.funding_sum')}
                             fullWidth
                             variant="filled"

--- a/src/utils/validation/registration/fundingValidation.ts
+++ b/src/utils/validation/registration/fundingValidation.ts
@@ -10,7 +10,7 @@ const fundingErrorMessage = {
     field: i18n.t('registration.description.funding.funding_name'),
   }),
   fundingNameOrIdentifierRequired: i18n.t('feedback.validation.is_required', {
-    field: `${i18n.t('registration.description.funding.funding_name')} eller ${i18n.t('registration.description.funding.funding_id')}`,
+    field: `${i18n.t('registration.description.funding.funding_name')} ${i18n.t('common.or').toLowerCase()} ${i18n.t('registration.description.funding.funding_id')}`,
   }),
   fundingNfrProjectRequired: i18n.t('feedback.validation.is_required', {
     field: i18n.t('registration.description.funding.nfr_project'),

--- a/src/utils/validation/registration/fundingValidation.ts
+++ b/src/utils/validation/registration/fundingValidation.ts
@@ -6,9 +6,6 @@ const fundingErrorMessage = {
   fundingSourceRequired: i18n.t('feedback.validation.is_required', {
     field: i18n.t('registration.description.funding.funder'),
   }),
-  fundingProjectRequired: i18n.t('feedback.validation.is_required', {
-    field: i18n.t('registration.description.funding.funding_name'),
-  }),
   fundingNameOrIdentifierRequired: i18n.t('feedback.validation.is_required', {
     field: `${i18n.t('registration.description.funding.funding_name')} ${i18n.t('common.or').toLowerCase()} ${i18n.t('registration.description.funding.funding_id')}`,
   }),
@@ -23,7 +20,7 @@ const fundingErrorMessage = {
 export const fundingValidationSchema = Yup.object({
   type: Yup.string<'ConfirmedFunding' | 'UnconfirmedFunding'>().defined(),
   identifier: Yup.string().when('labels.nb', {
-    is: (nb?: string) => !nb,
+    is: (label?: string) => !label,
     then: (schema) => schema.required(fundingErrorMessage.fundingNameOrIdentifierRequired),
     otherwise: (schema) => schema.optional(),
   }),

--- a/src/utils/validation/registration/fundingValidation.ts
+++ b/src/utils/validation/registration/fundingValidation.ts
@@ -22,7 +22,11 @@ const fundingErrorMessage = {
 
 export const fundingValidationSchema = Yup.object({
   type: Yup.string<'ConfirmedFunding' | 'UnconfirmedFunding'>().defined(),
-  identifier: Yup.string().optional(),
+  identifier: Yup.string().when('labels.nb', {
+    is: (nb?: string) => !nb,
+    then: (schema) => schema.required(fundingErrorMessage.fundingNameOrIdentifierRequired),
+    otherwise: (schema) => schema.optional(),
+  }),
   activeFrom: Yup.string().optional(),
   activeTo: Yup.string().optional(),
   source: Yup.string().required(fundingErrorMessage.fundingSourceRequired),
@@ -48,15 +52,8 @@ export const fundingValidationSchema = Yup.object({
             .optional(),
         })
   ),
-}).test('test-label-and-identifier', fundingErrorMessage.fundingNameOrIdentifierRequired, (value, context) => {
-  const labelValue = context.originalValue.labels?.nb;
-  const identifierValue = context.originalValue.identifier;
-
-  if (!labelValue && !identifierValue) {
-    context.createError({
-      path: `${context.path}.identifier`,
-      message: fundingErrorMessage.fundingNameOrIdentifierRequired,
-    });
+}).test('test-label', fundingErrorMessage.fundingNameOrIdentifierRequired, (value, context) => {
+  if (!value.labels?.nb && !value.identifier) {
     return context.createError({
       path: `${context.path}.labels.nb`,
       message: fundingErrorMessage.fundingNameOrIdentifierRequired,

--- a/src/utils/validation/registration/fundingValidation.ts
+++ b/src/utils/validation/registration/fundingValidation.ts
@@ -31,13 +31,7 @@ export const fundingValidationSchema = Yup.object({
     return true;
   }),
   labels: Yup.object({
-    nb: Yup.string().test('test-labels', fundingErrorMessage.fundingProjectRequired, (value, context) => {
-      const isNfrSource = context.from && context.from.some((item) => fundingSourceIsNfr(item.value.source));
-      if (!isNfrSource && !value) {
-        return false;
-      }
-      return true;
-    }),
+    nb: Yup.string(),
   }),
   fundingAmount: Yup.object().when(['source'], ([source], schema) =>
     fundingSourceIsNfr(source)

--- a/src/utils/validation/registration/fundingValidation.ts
+++ b/src/utils/validation/registration/fundingValidation.ts
@@ -9,6 +9,9 @@ const fundingErrorMessage = {
   fundingProjectRequired: i18n.t('feedback.validation.is_required', {
     field: i18n.t('registration.description.funding.funding_name'),
   }),
+  fundingNameOrIdentifierRequired: i18n.t('feedback.validation.is_required', {
+    field: `${i18n.t('registration.description.funding.funding_name')} eller ${i18n.t('registration.description.funding.funding_id')}`,
+  }),
   fundingNfrProjectRequired: i18n.t('feedback.validation.is_required', {
     field: i18n.t('registration.description.funding.nfr_project'),
   }),
@@ -19,7 +22,16 @@ const fundingErrorMessage = {
 
 export const fundingValidationSchema = Yup.object({
   type: Yup.string<'ConfirmedFunding' | 'UnconfirmedFunding'>().defined(),
-  identifier: Yup.string().optional(),
+  identifier: Yup.string().when('labels.nb', {
+    is: (nb?: string) => !nb,
+    then: (schema) => schema.required(fundingErrorMessage.fundingNameOrIdentifierRequired),
+    otherwise: (schema) => schema.optional(),
+  }),
+  // .test(
+  //   'identifier-test',
+  //   fundingErrorMessage.fundingNameOrIdentifierRequired,
+  //   (value, context) => !!value || !!context.parent.labels?.nb
+  // )
   activeFrom: Yup.string().optional(),
   activeTo: Yup.string().optional(),
   source: Yup.string().required(fundingErrorMessage.fundingSourceRequired),
@@ -31,7 +43,16 @@ export const fundingValidationSchema = Yup.object({
     return true;
   }),
   labels: Yup.object({
-    nb: Yup.string(),
+    nb: Yup.string().when('identifier', {
+      is: (identifier?: string) => !identifier,
+      then: (schema) => schema.required(fundingErrorMessage.fundingNameOrIdentifierRequired),
+      otherwise: (schema) => schema.optional(),
+    }),
+    // .test(
+    //   'labels-test',
+    //   fundingErrorMessage.fundingNameOrIdentifierRequired,
+    //   (value, context) => !!value || !!context.parent.identifier
+    // ),
   }),
   fundingAmount: Yup.object().when(['source'], ([source], schema) =>
     fundingSourceIsNfr(source)


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48863

Finansiering uten prosjekt krever nå _enten_ navn eller identifier for hver finansiering. Om begge mangler viser navn-feltet valideringsfeil for begge feltene, mens begge boksene er markert som error.

![bilde](https://github.com/user-attachments/assets/57b34582-f676-4709-be7a-640bc7f4ae77)
![bilde](https://github.com/user-attachments/assets/4e3d59e0-c1eb-471c-9904-634a0089b643)
![bilde](https://github.com/user-attachments/assets/836a1330-9e1c-4fbb-8c98-ab91a87f8cb8)



# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
