### PR TITLE
NP-48883 Fix duplicate search when starting registration with DOI

### DIFF
--- a/src/api/registrationApi.ts
+++ b/src/api/registrationApi.ts
@@ -7,6 +7,7 @@ import {
   Registration,
   UpdateRegistrationStatusRequest,
 } from '../types/registration.types';
+import { makeDoiUrl } from '../utils/general-helpers';
 import { doNotRedirectQueryParam } from '../utils/urlPaths';
 import { PublicationsApiPath } from './apiPaths';
 import { apiRequest2, authenticatedApiRequest, authenticatedApiRequest2 } from './apiRequest';
@@ -36,10 +37,10 @@ export const updateRegistrationStatus = async (
     data: updateRequest,
   });
 
-export const getRegistrationByDoi = async (doiUrl: string) => {
+export const getRegistrationByDoi = async (value: string) => {
   const getRegistrationByDoiResponse = await authenticatedApiRequest2<DoiPreview>({
     url: PublicationsApiPath.DoiLookup,
-    data: { doiUrl },
+    data: { doiUrl: makeDoiUrl(value) },
     method: 'POST',
   });
 

--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -20,6 +20,7 @@ import {
   RegistrationStatus,
 } from '../types/registration.types';
 import { CristinPerson } from '../types/user.types';
+import { getDoiValue } from '../utils/general-helpers';
 import { SearchApiPath } from './apiPaths';
 import { apiRequest2, authenticatedApiRequest2 } from './apiRequest';
 
@@ -459,7 +460,8 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
     searchParams.set(ResultParam.CristinIdentifier, params.cristinIdentifier);
   }
   if (params.doi) {
-    searchParams.set(ResultParam.Doi, params.doi);
+    const formattedDoiValue = getDoiValue(params.doi);
+    searchParams.set(ResultParam.Doi, formattedDoiValue);
   }
   if (params.excludeSubunits) {
     searchParams.set(ResultParam.ExcludeSubunits, params.excludeSubunits.toString());

--- a/src/pages/registration/new_registration/LinkRegistration.tsx
+++ b/src/pages/registration/new_registration/LinkRegistration.tsx
@@ -13,7 +13,7 @@ import {
   Typography,
 } from '@mui/material';
 import { AxiosResponse } from 'axios';
-import { Field, FieldProps, Form, Formik, FormikHelpers } from 'formik';
+import { Field, FieldProps, Form, Formik } from 'formik';
 import { ChangeEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
@@ -23,7 +23,7 @@ import { useLookupDoi } from '../../../api/hooks/useLookupDoi';
 import { RegistrationList } from '../../../components/RegistrationList';
 import { Registration } from '../../../types/registration.types';
 import { dataTestId } from '../../../utils/dataTestIds';
-import { doiUrlBase, makeDoiUrl } from '../../../utils/general-helpers';
+import { doiUrlBase } from '../../../utils/general-helpers';
 import { getRegistrationWizardPath } from '../../../utils/urlPaths';
 import { RegistrationAccordion } from './RegistrationAccordion';
 
@@ -62,13 +62,6 @@ export const LinkRegistration = ({ expanded, onChange }: StartRegistrationAccord
   const { registrationsWithDoi, isLookingUpDoi, noHits, doiPreview } = useLookupDoi(doiQuery);
   const createRegistrationFromDoi = useCreateRegistrationFromDoi(onCreateRegistrationSuccess);
 
-  const onSubmit = async (values: DoiFormValues, { setValues }: FormikHelpers<DoiFormValues>) => {
-    const doiUrl = makeDoiUrl(values.link);
-
-    setDoiQuery(doiUrl);
-    setValues({ link: doiUrl });
-  };
-
   const persistRegistration = () => {
     if (!doiPreview) {
       return;
@@ -93,7 +86,10 @@ export const LinkRegistration = ({ expanded, onChange }: StartRegistrationAccord
       </AccordionSummary>
 
       <AccordionDetails>
-        <Formik onSubmit={onSubmit} initialValues={emptyDoiFormValues} validationSchema={doiValidationSchema}>
+        <Formik
+          onSubmit={async (values) => setDoiQuery(values.link)}
+          initialValues={emptyDoiFormValues}
+          validationSchema={doiValidationSchema}>
           {({ isSubmitting }) => (
             <Form noValidate>
               <Box sx={{ display: 'flex', alignItems: 'center' }}>

--- a/src/utils/general-helpers.ts
+++ b/src/utils/general-helpers.ts
@@ -19,6 +19,12 @@ export const makeDoiUrl = (doiInput: string) => {
   return doiUrl;
 };
 
+export const getDoiValue = (value: string) => {
+  const trimmedValue = value.trim();
+  const doi = isValidUrl(trimmedValue) ? new URL(trimmedValue).pathname.slice(1) : trimmedValue;
+  return doi;
+};
+
 export const getPeriodString = (from: string | undefined, to: string | undefined) => {
   const fromDate = from ? toDateString(from) : '';
   const toDate = to ? toDateString(to) : '';


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48883

Sørg for at bruker får advarsel om at DOIen allerede finnes i NVA uansett om den er oppgitt som `<DOI>`, `https://doi.org/<DOI>`, `https://dx.doi.org/<DOI>`, etc. Nå vil vi ikke lenger automatisk omformatere en DOI til en DOI-URL.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
