### PR TITLE
Np 48984 show all alternative abstracts

### DIFF
--- a/src/pages/public_registration/PublicSummaryContent.tsx
+++ b/src/pages/public_registration/PublicSummaryContent.tsx
@@ -41,7 +41,10 @@ export const PublicSummaryContent = ({ registration }: PublicRegistrationContent
             <Typography variant="h3" color="primary" gutterBottom>
               {heading}
             </Typography>
-            <Typography lang={languageObject?.iso6391Code} style={{ whiteSpace: 'pre-line' }} sx={{ mb: '1rem' }}>
+            <Typography
+              lang={languageObject?.iso6391Code}
+              style={{ whiteSpace: 'pre-line', overflowWrap: 'anywhere' }}
+              sx={{ mb: '1rem' }}>
               {abstract}
             </Typography>
           </Fragment>
@@ -53,7 +56,7 @@ export const PublicSummaryContent = ({ registration }: PublicRegistrationContent
           <Typography variant="h3" color="primary" gutterBottom>
             {t('registration.description.description_of_content')}
           </Typography>
-          <Typography style={{ whiteSpace: 'pre-line' }} sx={{ mb: '1rem' }}>
+          <Typography style={{ whiteSpace: 'pre-line', overflowWrap: 'anywhere' }} sx={{ mb: '1rem' }}>
             {entityDescription.description}
           </Typography>
         </>

--- a/src/pages/public_registration/PublicSummaryContent.tsx
+++ b/src/pages/public_registration/PublicSummaryContent.tsx
@@ -1,9 +1,10 @@
 import { Typography } from '@mui/material';
+import { getLanguageByIso6391Code, getLanguageByIso6392Code, getLanguageByIso6393Code } from 'nva-language';
 import { useTranslation } from 'react-i18next';
 import { PublicRegistrationContentProps } from './PublicRegistrationContent';
 
 export const PublicSummaryContent = ({ registration }: PublicRegistrationContentProps) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const { entityDescription } = registration;
 
@@ -15,16 +16,36 @@ export const PublicSummaryContent = ({ registration }: PublicRegistrationContent
         </Typography>
       )}
 
-      {Object.entries(entityDescription.alternativeAbstracts).map(([langKey, abstract]) => (
-        <>
-          <Typography variant="h3" color="primary" gutterBottom>
-            {t('registration.description.alternative_abstract')} ({langKey})
-          </Typography>
-          <Typography style={{ whiteSpace: 'pre-line', overflowWrap: 'anywhere' }} sx={{ mb: '1rem' }}>
-            {abstract}
-          </Typography>
-        </>
-      ))}
+      {Object.entries(entityDescription.alternativeAbstracts).map(([languageKey, abstract]) => {
+        const languageObject =
+          languageKey === 'und'
+            ? null
+            : getLanguageByIso6391Code(languageKey) ||
+              getLanguageByIso6392Code(languageKey) ||
+              getLanguageByIso6393Code(languageKey);
+
+        const translatedLanguage =
+          i18n.language === 'nob'
+            ? languageObject?.nob.toLowerCase()
+            : i18n.language === 'nno'
+              ? languageObject?.nno.toLowerCase()
+              : languageObject?.eng;
+
+        const heading = translatedLanguage
+          ? `${t('registration.description.alternative_abstract')} (${translatedLanguage})`
+          : t('registration.description.alternative_abstract');
+
+        return (
+          <>
+            <Typography variant="h3" color="primary" gutterBottom>
+              {heading}
+            </Typography>
+            <Typography style={{ whiteSpace: 'pre-line', overflowWrap: 'anywhere' }} sx={{ mb: '1rem' }}>
+              {abstract}
+            </Typography>
+          </>
+        );
+      })}
 
       {entityDescription.description && (
         <>

--- a/src/pages/public_registration/PublicSummaryContent.tsx
+++ b/src/pages/public_registration/PublicSummaryContent.tsx
@@ -1,6 +1,7 @@
 import { Typography } from '@mui/material';
 import { getLanguageByIso6391Code, getLanguageByIso6392Code, getLanguageByIso6393Code } from 'nva-language';
 import { useTranslation } from 'react-i18next';
+import { Fragment } from 'react/jsx-runtime';
 import { PublicRegistrationContentProps } from './PublicRegistrationContent';
 
 export const PublicSummaryContent = ({ registration }: PublicRegistrationContentProps) => {
@@ -36,14 +37,14 @@ export const PublicSummaryContent = ({ registration }: PublicRegistrationContent
           : t('registration.description.alternative_abstract');
 
         return (
-          <>
+          <Fragment key={languageKey}>
             <Typography variant="h3" color="primary" gutterBottom>
               {heading}
             </Typography>
-            <Typography style={{ whiteSpace: 'pre-line', overflowWrap: 'anywhere' }} sx={{ mb: '1rem' }}>
+            <Typography lang={languageObject?.iso6391Code} style={{ whiteSpace: 'pre-line' }} sx={{ mb: '1rem' }}>
               {abstract}
             </Typography>
-          </>
+          </Fragment>
         );
       })}
 
@@ -52,7 +53,7 @@ export const PublicSummaryContent = ({ registration }: PublicRegistrationContent
           <Typography variant="h3" color="primary" gutterBottom>
             {t('registration.description.description_of_content')}
           </Typography>
-          <Typography style={{ whiteSpace: 'pre-line', overflowWrap: 'anywhere' }} sx={{ mb: '1rem' }}>
+          <Typography style={{ whiteSpace: 'pre-line' }} sx={{ mb: '1rem' }}>
             {entityDescription.description}
           </Typography>
         </>

--- a/src/pages/public_registration/PublicSummaryContent.tsx
+++ b/src/pages/public_registration/PublicSummaryContent.tsx
@@ -14,16 +14,18 @@ export const PublicSummaryContent = ({ registration }: PublicRegistrationContent
           {entityDescription.abstract}
         </Typography>
       )}
-      {entityDescription.alternativeAbstracts.und && (
+
+      {Object.entries(entityDescription.alternativeAbstracts).map(([langKey, abstract]) => (
         <>
           <Typography variant="h3" color="primary" gutterBottom>
-            {t('registration.description.alternative_abstract')}
+            {t('registration.description.alternative_abstract')} ({langKey})
           </Typography>
           <Typography style={{ whiteSpace: 'pre-line', overflowWrap: 'anywhere' }} sx={{ mb: '1rem' }}>
-            {entityDescription.alternativeAbstracts.und}
+            {abstract}
           </Typography>
         </>
-      )}
+      ))}
+
       {entityDescription.description && (
         <>
           <Typography variant="h3" color="primary" gutterBottom>


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-48984

Vis alle sammendrag uansett hvilket språk de er angitt på. Prøver også å slå opp navnet på språket med å finne matchende ISO-kode. For `und` (undefined) viser vi ingenting.

Når language er satt til `und`:
![bilde](https://github.com/user-attachments/assets/0b8a08d9-84b7-475b-b6cb-0dd53cd12148)

Men norsk språk i appen (liten forbokstav på språk):
![bilde](https://github.com/user-attachments/assets/f688eaaa-a6fb-4eba-9769-aa98c5034bd6)

Men engelsk språk i appen (stor forbokstav på språk):
![bilde](https://github.com/user-attachments/assets/083c778e-dcd2-4527-9820-9169d105b57c)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
