### PR TITLE
Ensure user must select month for date pickers

### DIFF
--- a/src/pages/basic_data/fields/StartDateField.tsx
+++ b/src/pages/basic_data/fields/StartDateField.tsx
@@ -25,7 +25,6 @@ export const StartDateField = ({ fieldName, maxDate, disabled = false, dataTestI
             }
             setFieldValue(field.name, date ?? '');
           }}
-          views={['year', 'month', 'day']}
           maxDate={maxDate}
           slotProps={{
             textField: {

--- a/src/pages/basic_data/institution_admin/AddAffiliationSection.tsx
+++ b/src/pages/basic_data/institution_admin/AddAffiliationSection.tsx
@@ -108,7 +108,6 @@ export const AddAffiliationSection = () => {
                   }
                   setFieldValue(field.name, date ?? '');
                 }}
-                views={['year', 'month', 'day']}
                 minDate={values.affiliation.startDate ? new Date(values.affiliation.startDate) : undefined}
                 slotProps={{
                   textField: {

--- a/src/pages/basic_data/institution_admin/edit_user/AffiliationFormSection.tsx
+++ b/src/pages/basic_data/institution_admin/edit_user/AffiliationFormSection.tsx
@@ -94,7 +94,6 @@ export const AffiliationFormSection = () => {
                   label={t('common.end_date')}
                   value={field.value ? new Date(field.value) : null}
                   onChange={(date: any) => setFieldValue(field.name, date ?? '')}
-                  views={['year', 'month', 'day']}
                   minDate={
                     employments[employmentIndex].startDate
                       ? new Date(employments[employmentIndex].startDate)

--- a/src/pages/messages/components/TicketDateIntervalFilter.tsx
+++ b/src/pages/messages/components/TicketDateIntervalFilter.tsx
@@ -8,7 +8,6 @@ import { formatDateStringToISO } from '../../../utils/date-helpers';
 import { syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 
 const commonDatepickerProps: Partial<DatePickerProps<Date>> = {
-  views: ['year', 'month', 'day'],
   disableHighlightToday: true,
   slotProps: {
     textField: { sx: { maxWidth: '10rem' }, size: 'small' },

--- a/src/pages/registration/resource_type_tab/components/PeriodFields.tsx
+++ b/src/pages/registration/resource_type_tab/components/PeriodFields.tsx
@@ -29,7 +29,6 @@ export const PeriodFields = ({ fromFieldName, toFieldName }: PeriodFieldsProps) 
               }
               setFieldValue(field.name, date ?? '');
             }}
-            views={['year', 'month', 'day']}
             maxDate={toValue ? new Date(toValue) : maxDate}
             slotProps={{
               textField: {
@@ -55,7 +54,6 @@ export const PeriodFields = ({ fromFieldName, toFieldName }: PeriodFieldsProps) 
               }
               setFieldValue(field.name, date ?? '');
             }}
-            views={['year', 'month', 'day']}
             minDate={fromValue ? new Date(fromValue) : undefined}
             maxDate={maxDate}
             slotProps={{

--- a/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/architecture/CompetitionModal.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/architecture/CompetitionModal.tsx
@@ -122,7 +122,6 @@ export const CompetitionModal = ({ competition, onSubmit, open, closeModal }: Co
                       }
                       setFieldValue(field.name, date ?? '');
                     }}
-                    views={['year', 'month', 'day']}
                     slotProps={{
                       textField: {
                         inputProps: {

--- a/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/architecture/PublicationMentionModal.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/architecture/PublicationMentionModal.tsx
@@ -117,7 +117,6 @@ export const PublicationMentionModal = ({
                         }
                         setFieldValue(field.name, date ?? '');
                       }}
-                      views={['year', 'month', 'day']}
                       slotProps={{
                         textField: {
                           inputProps: {

--- a/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/literary_art/LiteraryArtsPerformanceModal.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/artistic_types/literary_art/LiteraryArtsPerformanceModal.tsx
@@ -161,7 +161,6 @@ export const LiteraryArtsPerformanceModal = ({
                         setFieldValue('publicationDate', emptyRegistrationDate);
                       }
                     }}
-                    views={['year', 'month', 'day']}
                     slotProps={{
                       textField: {
                         inputProps: {

--- a/src/themes/mainTheme.ts
+++ b/src/themes/mainTheme.ts
@@ -1,5 +1,6 @@
 import { createTheme, PaletteColorOptions, SxProps } from '@mui/material';
 import { enUS as coreEnUs, nbNO as coreNbNo, nnNO as coreNnNo } from '@mui/material/locale';
+import type {} from '@mui/x-date-pickers/themeAugmentation';
 import i18n from '../translations/i18n';
 
 // Colors: https://www.figma.com/file/3hggk6SX2ca81U8kwaZKFs/Farger-NVA
@@ -210,6 +211,11 @@ export const mainTheme = createTheme(
           legend: {
             padding: 0,
           },
+        },
+      },
+      MuiDatePicker: {
+        defaultProps: {
+          views: ['year', 'month', 'day'],
         },
       },
       MuiMenu: {


### PR DESCRIPTION
# Description

Løser bug som ble oppdaget i e2e av  @Eiriknil, med at bruker noen ganger ikke får lov til å velge måned når man skal velge dato.

Legger inn at vi som default skal vise år, måned og dag for alle date pickers ved å oppdatere i theme: https://mui.com/x/react-date-pickers/quickstart/#theme-augmentation

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
