### PR TITLE
Remove loading state for fetching channel claim

### DIFF
--- a/src/pages/registration/RegistrationForm.tsx
+++ b/src/pages/registration/RegistrationForm.tsx
@@ -75,7 +75,7 @@ export const RegistrationForm = ({ identifier }: RegistrationFormProps) => {
   }, [tabNumber]);
 
   return registrationQuery.isPending ||
-    channelClaimData.channelClaimQuery.isLoading ||
+    // channelClaimData.channelClaimQuery.isLoading || // TODO: Ensure this loading does not trigger an infinite loop
     (canHaveNviCandidate && nviReportedStatus.isPending) ? (
     <PageSpinner aria-label={t('common.result')} />
   ) : !canEditRegistration ? (


### PR DESCRIPTION
Tar bort loading for henting av channel claim da det i mange tilfeller fører til evig loop med refetching og loading state her.

Må jobbes videre med å finne en bedre løsning.