### PR TITLE
NP-49038 Add button to show read messages when no unread

### DIFF
--- a/src/pages/messages/components/TicketList.tsx
+++ b/src/pages/messages/components/TicketList.tsx
@@ -194,27 +194,25 @@ export const TicketList = ({ ticketsQuery, title }: TicketListProps) => {
         {ticketsQuery.isPending ? (
           <ListSkeleton minWidth={100} maxWidth={100} height={100} />
         ) : tickets.length === 0 ? (
-          <>
-            {viewedByNotParam === showAllViewedByParamValue ? (
-              <Typography>{t('my_page.messages.no_dialogues')}</Typography>
-            ) : (
-              <>
-                <Typography gutterBottom>{t('my_page.messages.no_unread_dialogues')}</Typography>
-                <Button
-                  variant="outlined"
-                  size="small"
-                  sx={{ textTransform: 'none' }}
-                  onClick={() => {
-                    const syncedParams = syncParamsWithSearchFields(searchParams);
-                    syncedParams.delete(TicketSearchParam.ViewedByNot);
-                    syncedParams.delete(TicketSearchParam.From);
-                    navigate({ search: syncedParams.toString() });
-                  }}>
-                  {t('my_page.messages.show_read_dialogues')}
-                </Button>
-              </>
-            )}
-          </>
+          viewedByNotParam === showAllViewedByParamValue ? (
+            <Typography>{t('my_page.messages.no_dialogues')}</Typography>
+          ) : (
+            <>
+              <Typography gutterBottom>{t('my_page.messages.no_unread_dialogues')}</Typography>
+              <Button
+                variant="outlined"
+                size="small"
+                sx={{ textTransform: 'none' }}
+                onClick={() => {
+                  const syncedParams = syncParamsWithSearchFields(searchParams);
+                  syncedParams.delete(TicketSearchParam.ViewedByNot);
+                  syncedParams.delete(TicketSearchParam.From);
+                  navigate({ search: syncedParams.toString() });
+                }}>
+                {t('my_page.messages.show_read_dialogues')}
+              </Button>
+            </>
+          )
         ) : (
           <List disablePadding sx={{ my: '0.5rem' }}>
             {tickets.map((ticket) => (

--- a/src/pages/messages/components/TicketList.tsx
+++ b/src/pages/messages/components/TicketList.tsx
@@ -202,6 +202,7 @@ export const TicketList = ({ ticketsQuery, title }: TicketListProps) => {
                 <Button
                   variant="outlined"
                   size="small"
+                  sx={{ textTransform: 'none' }}
                   onClick={() => {
                     const syncedParams = syncParamsWithSearchFields(searchParams);
                     syncedParams.delete(TicketSearchParam.ViewedByNot);

--- a/src/pages/messages/components/TicketList.tsx
+++ b/src/pages/messages/components/TicketList.tsx
@@ -34,7 +34,7 @@ interface TicketListProps {
 }
 
 const viewedByLabelId = 'viewed-by-select';
-const showAllViewedByParamValue = 'show-all';
+const showAllViewedByValue = 'show-all';
 
 export const TicketList = ({ ticketsQuery, title }: TicketListProps) => {
   const { t } = useTranslation();
@@ -84,7 +84,7 @@ export const TicketList = ({ ticketsQuery, title }: TicketListProps) => {
   );
 
   const searchParams = new URLSearchParams(location.search);
-  const viewedByNotParam = searchParams.get(TicketSearchParam.ViewedByNot) || showAllViewedByParamValue;
+  const viewedByNotParam = searchParams.get(TicketSearchParam.ViewedByNot) || showAllViewedByValue;
   const resultsParam = searchParams.get(TicketSearchParam.Results);
   const fromParam = searchParams.get(TicketSearchParam.From);
   const rowsPerPage = (resultsParam && +resultsParam) || ROWS_PER_PAGE_OPTIONS[0];
@@ -126,7 +126,7 @@ export const TicketList = ({ ticketsQuery, title }: TicketListProps) => {
                 onChange={(event) => {
                   const value = event.target.value;
                   const syncedParams = syncParamsWithSearchFields(searchParams);
-                  if (value === showAllViewedByParamValue) {
+                  if (value === showAllViewedByValue) {
                     syncedParams.delete(TicketSearchParam.ViewedByNot);
                   } else {
                     syncedParams.set(TicketSearchParam.ViewedByNot, value);
@@ -134,7 +134,7 @@ export const TicketList = ({ ticketsQuery, title }: TicketListProps) => {
                   syncedParams.delete(TicketSearchParam.From);
                   navigate({ search: syncedParams.toString() });
                 }}>
-                <MenuItem value={showAllViewedByParamValue}>{t('common.show_all')}</MenuItem>
+                <MenuItem value={showAllViewedByValue}>{t('common.show_all')}</MenuItem>
                 <MenuItem value={user.nvaUsername}>{t('tasks.unread_only')}</MenuItem>
               </Select>
             </FormControl>
@@ -194,7 +194,7 @@ export const TicketList = ({ ticketsQuery, title }: TicketListProps) => {
         {ticketsQuery.isPending ? (
           <ListSkeleton minWidth={100} maxWidth={100} height={100} />
         ) : tickets.length === 0 ? (
-          viewedByNotParam === showAllViewedByParamValue ? (
+          viewedByNotParam === showAllViewedByValue ? (
             <Typography>{t('my_page.messages.no_dialogues')}</Typography>
           ) : (
             <>

--- a/src/pages/messages/components/TicketList.tsx
+++ b/src/pages/messages/components/TicketList.tsx
@@ -195,10 +195,10 @@ export const TicketList = ({ ticketsQuery, title }: TicketListProps) => {
         ) : tickets.length === 0 ? (
           <>
             {viewedByNotParam === 'show-all' ? (
-              <Typography>{t('my_page.messages.no_messages')}</Typography>
+              <Typography>{t('my_page.messages.no_dialogues')}</Typography>
             ) : (
               <>
-                <Typography gutterBottom>{t('my_page.messages.no_unread_messages')}</Typography>
+                <Typography gutterBottom>{t('my_page.messages.no_unread_dialogues')}</Typography>
                 <Button
                   variant="outlined"
                   size="small"
@@ -208,7 +208,7 @@ export const TicketList = ({ ticketsQuery, title }: TicketListProps) => {
                     syncedParams.delete(TicketSearchParam.From);
                     navigate({ search: syncedParams.toString() });
                   }}>
-                  {t('my_page.messages.show_read_messages')}
+                  {t('my_page.messages.show_read_dialogues')}
                 </Button>
               </>
             )}

--- a/src/pages/messages/components/TicketList.tsx
+++ b/src/pages/messages/components/TicketList.tsx
@@ -34,6 +34,7 @@ interface TicketListProps {
 }
 
 const viewedByLabelId = 'viewed-by-select';
+const showAllViewedByParamValue = 'show-all';
 
 export const TicketList = ({ ticketsQuery, title }: TicketListProps) => {
   const { t } = useTranslation();
@@ -83,7 +84,7 @@ export const TicketList = ({ ticketsQuery, title }: TicketListProps) => {
   );
 
   const searchParams = new URLSearchParams(location.search);
-  const viewedByNotParam = searchParams.get(TicketSearchParam.ViewedByNot) || 'show-all';
+  const viewedByNotParam = searchParams.get(TicketSearchParam.ViewedByNot) || showAllViewedByParamValue;
   const resultsParam = searchParams.get(TicketSearchParam.Results);
   const fromParam = searchParams.get(TicketSearchParam.From);
   const rowsPerPage = (resultsParam && +resultsParam) || ROWS_PER_PAGE_OPTIONS[0];
@@ -125,7 +126,7 @@ export const TicketList = ({ ticketsQuery, title }: TicketListProps) => {
                 onChange={(event) => {
                   const value = event.target.value;
                   const syncedParams = syncParamsWithSearchFields(searchParams);
-                  if (value === 'show-all') {
+                  if (value === showAllViewedByParamValue) {
                     syncedParams.delete(TicketSearchParam.ViewedByNot);
                   } else {
                     syncedParams.set(TicketSearchParam.ViewedByNot, value);
@@ -133,7 +134,7 @@ export const TicketList = ({ ticketsQuery, title }: TicketListProps) => {
                   syncedParams.delete(TicketSearchParam.From);
                   navigate({ search: syncedParams.toString() });
                 }}>
-                <MenuItem value={'show-all'}>{t('common.show_all')}</MenuItem>
+                <MenuItem value={showAllViewedByParamValue}>{t('common.show_all')}</MenuItem>
                 <MenuItem value={user.nvaUsername}>{t('tasks.unread_only')}</MenuItem>
               </Select>
             </FormControl>
@@ -194,7 +195,7 @@ export const TicketList = ({ ticketsQuery, title }: TicketListProps) => {
           <ListSkeleton minWidth={100} maxWidth={100} height={100} />
         ) : tickets.length === 0 ? (
           <>
-            {viewedByNotParam === 'show-all' ? (
+            {viewedByNotParam === showAllViewedByParamValue ? (
               <Typography>{t('my_page.messages.no_dialogues')}</Typography>
             ) : (
               <>

--- a/src/pages/messages/components/TicketList.tsx
+++ b/src/pages/messages/components/TicketList.tsx
@@ -1,4 +1,4 @@
-import { FormControl, Grid, InputLabel, List, MenuItem, Select, Typography } from '@mui/material';
+import { Button, FormControl, Grid, InputLabel, List, MenuItem, Select, Typography } from '@mui/material';
 import { visuallyHidden } from '@mui/utils';
 import { UseQueryResult } from '@tanstack/react-query';
 import { useEffect, useMemo } from 'react';
@@ -193,7 +193,26 @@ export const TicketList = ({ ticketsQuery, title }: TicketListProps) => {
         {ticketsQuery.isPending ? (
           <ListSkeleton minWidth={100} maxWidth={100} height={100} />
         ) : tickets.length === 0 ? (
-          <Typography>{t('my_page.messages.no_messages')}</Typography>
+          <>
+            {viewedByNotParam === 'show-all' ? (
+              <Typography>{t('my_page.messages.no_messages')}</Typography>
+            ) : (
+              <>
+                <Typography gutterBottom>{t('my_page.messages.no_unread_messages')}</Typography>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={() => {
+                    const syncedParams = syncParamsWithSearchFields(searchParams);
+                    syncedParams.delete(TicketSearchParam.ViewedByNot);
+                    syncedParams.delete(TicketSearchParam.From);
+                    navigate({ search: syncedParams.toString() });
+                  }}>
+                  {t('my_page.messages.show_read_messages')}
+                </Button>
+              </>
+            )}
+          </>
         ) : (
           <List disablePadding sx={{ my: '0.5rem' }}>
             {tickets.map((ticket) => (

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -817,8 +817,8 @@
       "mark_as_completed": "Sett til ferdig",
       "message_deleted": "Meldingen er slettet",
       "metadata_published": "Metadata publisert",
-      "no_dialogues": "Du har ingen dialoger.",
-      "no_unread_dialogues": "Du har ingen uleste dialoger.",
+      "no_dialogues": "Du har ingen dialoger for dette søket.",
+      "no_unread_dialogues": "Du har ingen uleste dialoger for dette søket.",
       "pending_curator": "Venter på kurator",
       "show_read_dialogues": "Vis leste dialoger",
       "ticket_types": {

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -817,10 +817,10 @@
       "mark_as_completed": "Sett til ferdig",
       "message_deleted": "Meldingen er slettet",
       "metadata_published": "Metadata publisert",
-      "no_messages": "Du har ingen meldinger.",
-      "no_unread_messages": "Du har ingen uleste meldinger.",
+      "no_dialogues": "Du har ingen dialoger.",
+      "no_unread_dialogues": "Du har ingen uleste dialoger.",
       "pending_curator": "Venter på kurator",
-      "show_read_messages": "Vis leste meldinger",
+      "show_read_dialogues": "Vis leste dialoger",
       "ticket_types": {
         "Closed": "Avvist",
         "Completed": "Ferdig",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -331,10 +331,6 @@
     "yes": "Ja"
   },
   "disciplines": {
-    "0001": "Humaniora",
-    "0002": "Samfunnsvitenskap",
-    "0003": "Medisin og helsefag",
-    "0004": "Realfag og teknologi",
     "1003": "Arkeologi og konservering",
     "1005": "Asiatiske og afrikanske studier",
     "1007": "Engelsk",
@@ -406,7 +402,11 @@
     "1162": "Konstruksjonsfag",
     "1166": "Filosofi",
     "1168": "Historie og idéhistorie",
-    "1170": "Kunst, design og arkitektur"
+    "1170": "Kunst, design og arkitektur",
+    "0001": "Humaniora",
+    "0002": "Samfunnsvitenskap",
+    "0003": "Medisin og helsefag",
+    "0004": "Realfag og teknologi"
   },
   "editor": {
     "categories_with_files": "Kategorier med filopplasting",
@@ -817,8 +817,10 @@
       "mark_as_completed": "Sett til ferdig",
       "message_deleted": "Meldingen er slettet",
       "metadata_published": "Metadata publisert",
-      "no_messages": "Du har ingen meldinger",
+      "no_messages": "Du har ingen meldinger.",
+      "no_unread_messages": "Du har ingen uleste meldinger.",
       "pending_curator": "Venter på kurator",
+      "show_read_messages": "Vis leste meldinger",
       "ticket_types": {
         "Closed": "Avvist",
         "Completed": "Ferdig",


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-49038

GI bruker snarvei til å se leste/alle dialoger når man søker etter uleste meldinger men ikke får noen treff

![bilde](https://github.com/user-attachments/assets/143584bc-1318-4c69-9c77-a3bce860927f)

![bilde](https://github.com/user-attachments/assets/e33afebd-d8f8-4acb-9657-6b4777e3d5d8)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] ~Interactive elements have data-testids~ (droppes her da det er en nisjesak, og bruker kan like godt bruke visningsalternativer i toppmeny. data-testid kan ev. legges til senere ved behov
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
