### PR TITLE
Update channel query keys

### DIFF
--- a/src/api/hooks/useFetchPublisher.ts
+++ b/src/api/hooks/useFetchPublisher.ts
@@ -8,7 +8,7 @@ export const useFetchPublisher = (id: string) => {
 
   return useQuery({
     enabled: !!id,
-    queryKey: ['channel', id],
+    queryKey: ['publisher', id],
     queryFn: () => fetchPublisher(getIdentifierFromId(id)),
     meta: { errorMessage: t('feedback.error.get_publisher') },
     staleTime: Infinity,

--- a/src/pages/editor/ChannelClaimTableRow.tsx
+++ b/src/pages/editor/ChannelClaimTableRow.tsx
@@ -50,8 +50,8 @@ export const ChannelClaimTableRow = ({ claimedChannel, channelType, isOnSettings
 
   const serialPublicationQuery = useQuery({
     enabled: !isPublisherChannel,
-    queryKey: ['channel', channelId],
-    queryFn: () => fetchResource<SerialPublication>(channelId + '/2024'), // TODO: Remove year when NP-48868 is merged
+    queryKey: ['serial-publication', channelId],
+    queryFn: () => fetchResource<SerialPublication>(channelId + '/2023'), // TODO: Remove year when NP-48868 is merged
     meta: { errorMessage: t('feedback.error.get_journal') },
     staleTime: Infinity,
   });


### PR DESCRIPTION
Use different query keys for serial publication and publisher since having the samw key provided the wrong error message due to caching.