### PR TITLE
Add @typescript-eslint packages to eslint dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
       eslint:
         patterns:
           - 'eslint*'
+          - '@typescript-eslint/*'
       react:
         patterns:
           - 'react'


### PR DESCRIPTION
Sørg for at `@typescript-eslint`-pakker kommer i samme dependabot-PR som andre eslint-pakker