### PR TITLE
NP-49255 Avoid openening doi accordion for all tasks where result has an doi request

### DIFF
--- a/src/pages/public_registration/action_accordions/DoiRequestAccordion.tsx
+++ b/src/pages/public_registration/action_accordions/DoiRequestAccordion.tsx
@@ -20,7 +20,7 @@ import {
   Typography,
 } from '@mui/material';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useLocation } from 'react-router';
@@ -217,9 +217,10 @@ export const DoiRequestAccordion = ({
 
   const [openAccordion, setOpenAccordion] = useState(defaultExpanded);
 
+  const initialDoiRequest = useRef(doiRequestTicket);
   useEffect(() => {
-    // Open accordion if a new DOI request is created
-    if (doiRequestTicket) {
+    // Open accordion if a new DOI request is created, e.g. when publishing a result with a draft DOI
+    if (!initialDoiRequest.current && doiRequestTicket) {
       setOpenAccordion(true);
     }
   }, [doiRequestTicket]);


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-49255

Løser feil hvor DOI-panelet alltid utvides om man åpner en oppgave for et resultat som har en DOI-forespørsel. DOI-forespørselen skal ikke vises som standard om man åpner en publiseringsforespørsel eller en support-ticket.

Bugen ble implementert her: https://github.com/BIBSYSDEV/NVA-Frontend/pull/7100

DOI-panelet skal åpnes av seg selv om man publiserer et resultat med en reservert DOI, siden det da opprettes en DOI-forespørsel. Pga av noen tregheter kan det være at den ikke dukker opp med en gang, men det vil skje etter hvert.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
