### PR TITLE
NP-49267 Update wording of license texts

### DIFF
--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -726,15 +726,15 @@
       "cc0": "<p>Se <link1>Åndsverksloven</link1> §3, §8, §11 og §14</p>"
     },
     "description": {
-      "cc0": "<p>Verket er frigitt til offentlig bruk, uten opphavsrettigheter, så langt loven tillater.</p><p>Bruker du denne lisensen, last opp et dokument der du begrunner hvorfor.</p>",
-      "cc_by": "<p>Du kan: kopiere, dele og endre verket for alle typer bruk, også kommersielle.</p><p>Du må: gi riktig kreditering og si fra om endringer.</p>",
-      "cc_by_nc": "<p>Du kan: kopiere, dele og endre verket, men kun for ikke-kommersielle formål. Du må: gi riktig kreditering og si fra om endringer.</p>",
-      "cc_by_nc_nd": "<p>Du kan: kopiere og dele verket for ikke-kommersielle formål</p><p>Du kan ikke: endre eller tilpasse verket.</p><p>Du må: gi riktig kreditering.</p>",
-      "cc_by_nc_sa": "<p>Du kan: kopiere, dele og endre verket for ikke-kommersielle formål.</p><p>Du må: gi riktig kreditering, si fra om endringer, og bruke samme lisens for det nye verket.</p>",
-      "cc_by_nd": "<p>Du kan: kopiere og dele verket for alle typer bruk, også kommersielle.</p><p>Du kan ikke: endre eller tilpasse verket.</p><p>Du må: gi riktig kreditering.</p>",
-      "cc_by_sa": "<p>Du kan: kopiere, dele og endre verket for alle typer bruk, også kommersielle.</p><p>Du må: gi riktig kreditering, si fra om endringer, og bruke samme lisens for det nye verket.</p>",
+      "cc0": "<p>Verket er frigitt til offentlig bruk, uten opphavsrettigheter, så langt loven tillater.</p><p>Brukes denne lisensen, last opp et dokument der du begrunner hvorfor.</p>",
+      "cc_by": "<p>Brukeren kan: kopiere, dele og endre verket for alle typer bruk, også kommersielle.</p><p>Brukeren må: gi riktig kreditering og si fra om endringer.</p>",
+      "cc_by_nc": "<p>Brukeren kan: kopiere, dele og endre verket, men kun for ikke-kommersielle formål.</p><p>Brukeren må: gi riktig kreditering og si fra om endringer.</p>",
+      "cc_by_nc_nd": "<p>Brukeren kan: kopiere og dele verket for ikke-kommersielle formål</p><p>Brukeren kan ikke: endre eller tilpasse verket.</p><p>Brukeren må: gi riktig kreditering.</p>",
+      "cc_by_nc_sa": "<p>Brukeren kan: kopiere, dele og endre verket for ikke-kommersielle formål.</p><p>Brukeren må: gi riktig kreditering, si fra om endringer, og bruke samme lisens for det nye verket.</p>",
+      "cc_by_nd": "<p>Brukeren kan: kopiere og dele verket for alle typer bruk, også kommersielle.</p><p>Brukeren kan ikke: endre eller tilpasse verket.</p><p>Brukeren må: gi riktig kreditering.</p>",
+      "cc_by_sa": "<p>Brukeren kan: kopiere, dele og endre verket for alle typer bruk, også kommersielle.</p><p>Brukeren må: gi riktig kreditering, si fra om endringer, og bruke samme lisens for det nye verket.</p>",
       "older_licenses": "Skal du registrere et eldre forskningsresultat som ble publisert med en tidligere lisensversjon, trykk på \"Vis alle tidligere versjoner\" i nedtrekksmenyen for å finne riktig lisens",
-      "rights_reserved": "<p>Dette verket har ikke en lisens som tydeliggjør rettigheter for gjenbruk. Du må selv kontakte opphavsperson for å finne ut om, og hvordan, du kan gjenbruke arbeidet.</p>"
+      "rights_reserved": "<p>Dette verket har ikke en lisens som tydeliggjør rettigheter for gjenbruk. Brukeren må selv kontakte opphavsperson for å finne ut om, og hvordan, arbeidet kan gjenbrukes.</p>"
     },
     "labels": {
       "cc0": "CC0 ({{version}})",


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-49267

Erstatt "Du kan" etc med "Brukeren kan".

Nye tekster:
![bilde](https://github.com/user-attachments/assets/586f5d37-edb4-4bfc-a89f-406266e57dae)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
