### PR TITLE
Add Matomo error tracking

### DIFF
--- a/src/matomo/matomo.ts
+++ b/src/matomo/matomo.ts
@@ -1,6 +1,7 @@
 declare global {
   interface Window {
     _mtm?: Array<Record<string, unknown>>;
+    _paq?: Array<unknown>;
   }
 }
 
@@ -10,6 +11,9 @@ export const initializeMatomo = (matomoContainerUrl: string) => {
     'mtm.startTime': new Date().getTime(),
     event: 'mtm.Start',
   });
+
+  const _paq = (window._paq = window._paq || []);
+  _paq.push(['enableJSErrorTracking']);
 
   const documentRef = document;
   const newScriptElement = documentRef.createElement('script');


### PR DESCRIPTION
https://matomo.org/faq/how-to/how-do-i-enable-basic-javascript-error-tracking-and-reporting-in-matomo-browser-console-error-messages/

Test ut løsning som logger errors i konsollen til Matomo.
Merk at disse ikke vil inkludere noe stacktrace, så vil ikke nødvendigvis gjøre det enkelt å vite hvordan errors kan løses, men kan i hvert fall gi oss en indikasjon på hvor brukere opplever feil.

