### PR TITLE
NP-49285 Always allow ticket transfer from allowedOperations

### DIFF
--- a/src/pages/public_registration/ActionPanel.tsx
+++ b/src/pages/public_registration/ActionPanel.tsx
@@ -46,7 +46,7 @@ export const ActionPanel = ({
   const isNotOnTasksDialoguePage = !window.location.pathname.startsWith(UrlPathTemplate.TasksDialogue);
 
   const canCreatePublishingTicket = userHasAccessRight(registration, 'publishing-request-create');
-  const canApprovePublishingTicket = publishingRequestTickets.some((ticket) => ticket.allowedOperations.length > 0);
+  const canHandlePublishingTicket = publishingRequestTickets.some((ticket) => ticket.allowedOperations.length > 0);
   const hasOtherPublishingRights =
     userHasAccessRight(registration, 'unpublish') ||
     userHasAccessRight(registration, 'republish') ||
@@ -63,7 +63,7 @@ export const ActionPanel = ({
   const canApproveSupportTicket = !!newestSupportTicket && userHasAccessRight(registration, 'support-request-approve');
 
   const shouldSeePublishingAccordion =
-    canCreatePublishingTicket || canApprovePublishingTicket || hasOtherPublishingRights;
+    canCreatePublishingTicket || canHandlePublishingTicket || hasOtherPublishingRights;
   const shouldSeeDoiAccordion =
     !registration.entityDescription?.reference?.doi &&
     !!customerHasConfiguredDoi &&

--- a/src/pages/public_registration/ActionPanel.tsx
+++ b/src/pages/public_registration/ActionPanel.tsx
@@ -46,9 +46,7 @@ export const ActionPanel = ({
   const isNotOnTasksDialoguePage = !window.location.pathname.startsWith(UrlPathTemplate.TasksDialogue);
 
   const canCreatePublishingTicket = userHasAccessRight(registration, 'publishing-request-create');
-  const canApprovePublishingTicket = publishingRequestTickets.some(
-    (ticket) => (ticket.status === 'New' || ticket.status === 'Pending') && ticket.allowedOperations.includes('approve')
-  );
+  const canApprovePublishingTicket = publishingRequestTickets.some((ticket) => ticket.allowedOperations.length > 0);
   const hasOtherPublishingRights =
     userHasAccessRight(registration, 'unpublish') ||
     userHasAccessRight(registration, 'republish') ||


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-49285

Tillat alltid å flytte ticket om APIet sier det er lov i allowedoperations på ticket

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
