### PR TITLE
NP-49305 Ensure only channel ids are fetched as channel claims

### DIFF
--- a/src/api/hooks/useFetchChannelClaim.ts
+++ b/src/api/hooks/useFetchChannelClaim.ts
@@ -1,11 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { getIdentifierFromId, removeTrailingYearPathFromUrl } from '../../utils/general-helpers';
+import { PublicationChannelApiPath } from '../apiPaths';
 import { fetchChannelClaim } from '../customerInstitutionsApi';
 
 export const useFetchChannelClaim = (id = '', { enabled = !!id } = {}) => {
   const { t } = useTranslation();
-  const channelIdentifier = getIdentifierFromId(removeTrailingYearPathFromUrl(id));
+
+  const isChannelId =
+    id.includes(PublicationChannelApiPath.Publisher) || id.includes(PublicationChannelApiPath.SerialPublication);
+
+  const channelIdentifier = isChannelId ? getIdentifierFromId(removeTrailingYearPathFromUrl(id)) : '';
 
   return useQuery({
     queryKey: ['channelClaim', channelIdentifier],


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-49305

Løst feil hvor publication id ble brukt som id noen steder vi prøver å hente channel claim. Dette skjer fordi kapittel (bl.a.) har id til resultatet det er publisert i i `publicationContext.id`, og ikke tidsskrift som vi forventer for andre kategorier. Den enkleste løsningen der er å sjekke om id faktisk er til en kanal før vi prøver å hente channel claim.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
