### PR TITLE
NP-49288 Avoid showing loading state before user has searched

### DIFF
--- a/src/components/institution/SelectInstitutionForm.tsx
+++ b/src/components/institution/SelectInstitutionForm.tsx
@@ -152,7 +152,7 @@ export const SelectInstitutionForm = ({
                       resetForm({ values: initialValuesOrganizationForm });
                       setFieldValue(field.name, value);
                     }}
-                    loading={organizationSearchQuery.isPending}
+                    loading={organizationSearchQuery.isFetching}
                     renderInput={(params) => (
                       <TextField
                         {...params}


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-49288

Unngå at institutsjonsfelt er i loading state som default

Før:
![bilde](https://github.com/user-attachments/assets/9123ff5a-f0ca-4ae6-a875-b2b7e806a02d)

Etter:
![bilde](https://github.com/user-attachments/assets/beb510db-6693-4f0d-97b4-502553b04443)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
