### PR TITLE
NP-49353 Show loading skeleton fot NVI numbers

### DIFF
--- a/src/pages/messages/components/NviCandidatesNavigationAccordion.tsx
+++ b/src/pages/messages/components/NviCandidatesNavigationAccordion.tsx
@@ -20,6 +20,14 @@ const StyledNviStatusBox = styled(Box)(({ theme }) => ({
   marginBottom: '0.5rem',
 }));
 
+const StyledTypography = styled(Typography)({
+  display: 'flex',
+});
+
+const StyledSkeleton = styled(Skeleton)({
+  width: '2ch',
+});
+
 const progressLabel = 'progress-label';
 
 export const NviCandidatesNavigationAccordion = () => {
@@ -106,21 +114,22 @@ export const NviCandidatesNavigationAccordion = () => {
 
         <StyledNviStatusBox sx={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
           <Typography fontWeight="bold">{t('tasks.nvi.nvi_reporting_status')}:</Typography>
-          <Typography>
-            {t('tasks.nvi.candidates_for_control')} ({nviCandidatesTotal})
-          </Typography>
+          <StyledTypography>
+            {t('tasks.nvi.candidates_for_control')} (
+            {nviAggregationsQuery.isPending ? <StyledSkeleton /> : nviCandidatesTotal})
+          </StyledTypography>
           <Divider sx={{ bgcolor: 'black' }} />
           <Typography fontWeight="bold">{t('tasks.nvi.controlled')}:</Typography>
-          <Typography>
-            {t('tasks.nvi.status.Approved')} ({nviApprovedCount})
-          </Typography>
-          <Typography>
-            {t('tasks.nvi.status.Rejected')} ({nviRejectedCount})
-          </Typography>
+          <StyledTypography>
+            {t('tasks.nvi.status.Approved')} ({nviAggregationsQuery.isPending ? <StyledSkeleton /> : nviApprovedCount})
+          </StyledTypography>
+          <StyledTypography>
+            {t('tasks.nvi.status.Rejected')} ({nviAggregationsQuery.isPending ? <StyledSkeleton /> : nviRejectedCount})
+          </StyledTypography>
           <Divider sx={{ bgcolor: 'black' }} />
-          <Typography>
-            {t('tasks.nvi.status.Dispute')} ({nviDisputeCount})
-          </Typography>
+          <StyledTypography>
+            {t('tasks.nvi.status.Dispute')} ({nviAggregationsQuery.isPending ? <StyledSkeleton /> : nviDisputeCount})
+          </StyledTypography>
         </StyledNviStatusBox>
       </StyledTicketSearchFormGroup>
     </NavigationListAccordion>


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-49353

Vis lasteindikator i paranteser mens data hentes

Før:
![bilde](https://github.com/user-attachments/assets/facad1d3-308c-49a0-8add-478009984d52)

Etter:
![bilde](https://github.com/user-attachments/assets/9a5228e0-95cf-4a2f-a423-64d1ba9542cd)


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
