### PR TITLE
Set html lang outside react-helmet-async

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,14 +86,12 @@ const Root = () => {
 
 export const App = () => {
   useMatomoTracking();
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const maintenanceInfo = getMaintenanceInfo();
 
   return (
     <>
-      <Helmet defaultTitle={t('common.page_title')} titleTemplate={`%s - ${t('common.page_title')}`}>
-        <html lang={getLanguageTagValue(i18n.language)} />
-      </Helmet>
+      <Helmet defaultTitle={t('common.page_title')} titleTemplate={`%s - ${t('common.page_title')}`} />
 
       <Suspense fallback={<PageSpinner aria-label={t('common.page_title')} />}>
         {maintenanceInfo ? (

--- a/src/translations/i18n.ts
+++ b/src/translations/i18n.ts
@@ -23,4 +23,18 @@ i18n.use(LanguageDetector).init({
   debug: false,
 });
 
+const getLanguageTagValue = (language: string) => {
+  if (language === 'eng') {
+    return 'en';
+  }
+  return 'no';
+};
+
+if (document) {
+  document.documentElement.lang = getLanguageTagValue(i18n.language);
+  i18n.on('languageChanged', (newLanguage) => {
+    document.documentElement.lang = getLanguageTagValue(newLanguage);
+  });
+}
+
 export default i18n;


### PR DESCRIPTION
Fjerner avhengigeten til `react-helmet-async` for å sette `<html lang=xxx>`. Virker i praksis likt å håndtere dette med ren JS uten React.
Gjør dette nå som et første steg i å bevege oss bort fra `react-hemlet-async` som ikke støtter React v19