### PR TITLE
Set node version in amplify.yml

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -20,3 +20,6 @@ frontend:
   cache:
     paths:
       - node_modules/**/*
+  build:
+    environment:
+      NODE_VERSION: 22


### PR DESCRIPTION
Sett node-versjon til 22 for bygget i amplify, da v18 som brukes i dag ikke virker for vite v7.
Trodde vi allerede brukte siste versjon av node i bygget her også, men tydeligvis ikke.

Har verifisert at det virker å sette dette direkte i amplify, men foretrekker å ha det som IaC her i stedet.
![bilde](https://github.com/user-attachments/assets/f7bb5643-0ae6-4b7d-b4c0-d714a7d20105)
