### PR TITLE
Set node version in amplify

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,5 +1,7 @@
 version: 1
 frontend:
+  environment:
+    NODE_VERSION: 22
   phases:
     preBuild:
       commands:
@@ -20,6 +22,3 @@ frontend:
   cache:
     paths:
       - node_modules/**/*
-  build:
-    environment:
-      NODE_VERSION: 22

--- a/amplify.yml
+++ b/amplify.yml
@@ -1,7 +1,5 @@
 version: 1
 frontend:
-  environment:
-    NODE_VERSION: 22
   phases:
     preBuild:
       commands:


### PR DESCRIPTION
Følger opp https://github.com/BIBSYSDEV/NVA-Frontend/pull/7533 da dette ikke virker.
Fiksen er i stedet å sette enten node:22 som image, eller å bruke Amazon Linux 2023, og sette node-versjon til 22 under "Live package updates". Har nå gått for førstnevnte.

![bilde](https://github.com/user-attachments/assets/b41a5716-c96f-46ff-bb7b-746c8590dc05)

