### PR TITLE
Update eslint config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,8 +21,7 @@ updates:
           - '@tanstack/*'
       eslint:
         patterns:
-          - 'eslint*'
-          - '@typescript-eslint/*'
+          - '*eslint*'
       react:
         patterns:
           - 'react'

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,7 @@
 import tanstackQuery from '@tanstack/eslint-plugin-query';
 import eslintPluginTypeScript from '@typescript-eslint/eslint-plugin';
 import eslintParserTypeScript from '@typescript-eslint/parser';
-import eslintPluginJsxA11y from 'eslint-plugin-jsx-a11y';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 
@@ -16,7 +16,6 @@ export default [
     },
     plugins: {
       '@typescript-eslint': eslintPluginTypeScript,
-      'jsx-a11y': eslintPluginJsxA11y,
     },
     settings: {
       react: {
@@ -25,7 +24,6 @@ export default [
     },
     rules: {
       ...eslintPluginTypeScript.configs.recommended.rules,
-      ...eslintPluginJsxA11y.configs.recommended.rules,
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-unused-vars': ['warn', { ignoreRestSiblings: true }],
       'no-console': 'warn',
@@ -36,4 +34,5 @@ export default [
   react.configs.flat['jsx-runtime'],
   reactHooks.configs['recommended-latest'],
   ...tanstackQuery.configs['flat/recommended'],
+  jsxA11y.flatConfigs.recommended,
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,9 @@
 import tanstackQuery from '@tanstack/eslint-plugin-query';
-import eslintPluginTypeScript from '@typescript-eslint/eslint-plugin';
 import eslintParserTypeScript from '@typescript-eslint/parser';
 import jsxA11y from 'eslint-plugin-jsx-a11y';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
+import tseslint from 'typescript-eslint';
 
 export default [
   {
@@ -14,25 +14,25 @@ export default [
         project: './tsconfig.json',
       },
     },
-    plugins: {
-      '@typescript-eslint': eslintPluginTypeScript,
-    },
     settings: {
       react: {
         version: 'detect',
       },
     },
+  },
+  ...tseslint.configs.recommended,
+  react.configs.flat.recommended,
+  react.configs.flat['jsx-runtime'],
+  reactHooks.configs['recommended-latest'],
+  ...tanstackQuery.configs['flat/recommended'],
+  jsxA11y.flatConfigs.recommended,
+
+  {
     rules: {
-      ...eslintPluginTypeScript.configs.recommended.rules,
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-unused-vars': ['warn', { ignoreRestSiblings: true }],
       'no-console': 'warn',
       'no-debugger': 'warn',
     },
   },
-  react.configs.flat.recommended,
-  react.configs.flat['jsx-runtime'],
-  reactHooks.configs['recommended-latest'],
-  ...tanstackQuery.configs['flat/recommended'],
-  jsxA11y.flatConfigs.recommended,
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,8 +2,8 @@ import eslintPluginTanstackQuery from '@tanstack/eslint-plugin-query';
 import eslintPluginTypeScript from '@typescript-eslint/eslint-plugin';
 import eslintParserTypeScript from '@typescript-eslint/parser';
 import eslintPluginJsxA11y from 'eslint-plugin-jsx-a11y';
-import eslintPluginReact from 'eslint-plugin-react';
-import eslintPluginReactHooks from 'eslint-plugin-react-hooks';
+import react from 'eslint-plugin-react';
+import reactHooks from 'eslint-plugin-react-hooks';
 
 export default [
   {
@@ -18,8 +18,6 @@ export default [
       '@typescript-eslint': eslintPluginTypeScript,
       '@tanstack/query': eslintPluginTanstackQuery,
       'jsx-a11y': eslintPluginJsxA11y,
-      react: eslintPluginReact,
-      'react-hooks': eslintPluginReactHooks,
     },
     settings: {
       react: {
@@ -30,13 +28,13 @@ export default [
       ...eslintPluginTypeScript.configs.recommended.rules,
       ...eslintPluginTanstackQuery.configs.recommended.rules,
       ...eslintPluginJsxA11y.configs.recommended.rules,
-      ...eslintPluginReact.configs.recommended.rules,
-      ...eslintPluginReact.configs['jsx-runtime'].rules,
-      ...eslintPluginReactHooks.configs.recommended.rules,
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-unused-vars': ['warn', { ignoreRestSiblings: true }],
       'no-console': 'warn',
       'no-debugger': 'warn',
     },
   },
+  reactHooks.configs['recommended-latest'],
+  react.configs.flat.recommended,
+  react.configs.flat['jsx-runtime'],
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,6 @@
 import tanstackQuery from '@tanstack/eslint-plugin-query';
-import eslintParserTypeScript from '@typescript-eslint/parser';
 import jsxA11y from 'eslint-plugin-jsx-a11y';
+import prettier from 'eslint-plugin-prettier/recommended';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import tseslint from 'typescript-eslint';
@@ -9,7 +9,6 @@ export default [
   {
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
-      parser: eslintParserTypeScript,
       parserOptions: {
         project: './tsconfig.json',
       },
@@ -26,7 +25,6 @@ export default [
   reactHooks.configs['recommended-latest'],
   ...tanstackQuery.configs['flat/recommended'],
   jsxA11y.flatConfigs.recommended,
-
   {
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
@@ -35,4 +33,5 @@ export default [
       'no-debugger': 'warn',
     },
   },
+  prettier,
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,4 @@
-import eslintPluginTanstackQuery from '@tanstack/eslint-plugin-query';
+import tanstackQuery from '@tanstack/eslint-plugin-query';
 import eslintPluginTypeScript from '@typescript-eslint/eslint-plugin';
 import eslintParserTypeScript from '@typescript-eslint/parser';
 import eslintPluginJsxA11y from 'eslint-plugin-jsx-a11y';
@@ -16,7 +16,6 @@ export default [
     },
     plugins: {
       '@typescript-eslint': eslintPluginTypeScript,
-      '@tanstack/query': eslintPluginTanstackQuery,
       'jsx-a11y': eslintPluginJsxA11y,
     },
     settings: {
@@ -26,7 +25,6 @@ export default [
     },
     rules: {
       ...eslintPluginTypeScript.configs.recommended.rules,
-      ...eslintPluginTanstackQuery.configs.recommended.rules,
       ...eslintPluginJsxA11y.configs.recommended.rules,
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-unused-vars': ['warn', { ignoreRestSiblings: true }],
@@ -34,7 +32,8 @@ export default [
       'no-debugger': 'warn',
     },
   },
-  reactHooks.configs['recommended-latest'],
   react.configs.flat.recommended,
   react.configs.flat['jsx-runtime'],
+  reactHooks.configs['recommended-latest'],
+  ...tanstackQuery.configs['flat/recommended'],
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,8 +52,6 @@
         "@types/jest": "^30.0.0",
         "@types/react": "^18.3.13",
         "@types/react-dom": "^18.3.1",
-        "@typescript-eslint/eslint-plugin": "^8.35.1",
-        "@typescript-eslint/parser": "^8.32.1",
         "@vitejs/plugin-react": "^4.6.0",
         "axe-core": "^4.10.3",
         "axios-mock-adapter": "^2.1.0",
@@ -72,6 +70,7 @@
         "prettier": "^3.6.2",
         "start-server-and-test": "^2.0.12",
         "typescript": "^5.8.3",
+        "typescript-eslint": "^8.36.0",
         "vite": "^7.0.2",
         "vite-plugin-eslint": "^1.8.1",
         "vitest": "^3.2.4"
@@ -3266,6 +3265,7 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -3279,6 +3279,7 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -3288,6 +3289,7 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -5409,16 +5411,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.35.1.tgz",
-      "integrity": "sha512-9XNTlo7P7RJxbVeICaIIIEipqxLKguyh+3UbXuT2XQuFp6d8VOeDEGuz5IiX0dgZo8CiI6aOFLg4e8cF71SFVg==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.36.0.tgz",
+      "integrity": "sha512-lZNihHUVB6ZZiPBNgOQGSxUASI7UJWhT8nHyUGCnaQ28XFCw98IfrMCG3rUl1uwUWoAvodJQby2KTs79UTcrAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.35.1",
-        "@typescript-eslint/type-utils": "8.35.1",
-        "@typescript-eslint/utils": "8.35.1",
-        "@typescript-eslint/visitor-keys": "8.35.1",
+        "@typescript-eslint/scope-manager": "8.36.0",
+        "@typescript-eslint/type-utils": "8.36.0",
+        "@typescript-eslint/utils": "8.36.0",
+        "@typescript-eslint/visitor-keys": "8.36.0",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -5432,7 +5435,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.35.1",
+        "@typescript-eslint/parser": "^8.36.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
@@ -5448,15 +5451,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.35.1.tgz",
-      "integrity": "sha512-3MyiDfrfLeK06bi/g9DqJxP5pV74LNv4rFTyvGDmT3x2p1yp1lOd+qYZfiRPIOf/oON+WRZR5wxxuF85qOar+w==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.36.0.tgz",
+      "integrity": "sha512-FuYgkHwZLuPbZjQHzJXrtXreJdFMKl16BFYyRrLxDhWr6Qr7Kbcu2s1Yhu8tsiMXw1S0W1pjfFfYEt+R604s+Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.35.1",
-        "@typescript-eslint/types": "8.35.1",
-        "@typescript-eslint/typescript-estree": "8.35.1",
-        "@typescript-eslint/visitor-keys": "8.35.1",
+        "@typescript-eslint/scope-manager": "8.36.0",
+        "@typescript-eslint/types": "8.36.0",
+        "@typescript-eslint/typescript-estree": "8.36.0",
+        "@typescript-eslint/visitor-keys": "8.36.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -5472,13 +5476,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.35.1.tgz",
-      "integrity": "sha512-VYxn/5LOpVxADAuP3NrnxxHYfzVtQzLKeldIhDhzC8UHaiQvYlXvKuVho1qLduFbJjjy5U5bkGwa3rUGUb1Q6Q==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.36.0.tgz",
+      "integrity": "sha512-JAhQFIABkWccQYeLMrHadu/fhpzmSQ1F1KXkpzqiVxA/iYI6UnRt2trqXHt1sYEcw1mxLnB9rKMsOxXPxowN/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.35.1",
-        "@typescript-eslint/types": "^8.35.1",
+        "@typescript-eslint/tsconfig-utils": "^8.36.0",
+        "@typescript-eslint/types": "^8.36.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -5493,13 +5498,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.1.tgz",
-      "integrity": "sha512-s/Bpd4i7ht2934nG+UoSPlYXd08KYz3bmjLEb7Ye1UVob0d1ENiT3lY8bsCmik4RqfSbPw9xJJHbugpPpP5JUg==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.36.0.tgz",
+      "integrity": "sha512-wCnapIKnDkN62fYtTGv2+RY8FlnBYA3tNm0fm91kc2BjPhV2vIjwwozJ7LToaLAyb1ca8BxrS7vT+Pvvf7RvqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.35.1",
-        "@typescript-eslint/visitor-keys": "8.35.1"
+        "@typescript-eslint/types": "8.36.0",
+        "@typescript-eslint/visitor-keys": "8.36.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5510,10 +5516,11 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.1.tgz",
-      "integrity": "sha512-K5/U9VmT9dTHoNowWZpz+/TObS3xqC5h0xAIjXPw+MNcKV9qg6eSatEnmeAwkjHijhACH0/N7bkhKvbt1+DXWQ==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.36.0.tgz",
+      "integrity": "sha512-Nhh3TIEgN18mNbdXpd5Q8mSCBnrZQeY9V7Ca3dqYvNDStNIGRmJA6dmrIPMJ0kow3C7gcQbpsG2rPzy1Ks/AnA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -5526,13 +5533,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.35.1.tgz",
-      "integrity": "sha512-HOrUBlfVRz5W2LIKpXzZoy6VTZzMu2n8q9C2V/cFngIC5U1nStJgv0tMV4sZPzdf4wQm9/ToWUFPMN9Vq9VJQQ==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.36.0.tgz",
+      "integrity": "sha512-5aaGYG8cVDd6cxfk/ynpYzxBRZJk7w/ymto6uiyUFtdCozQIsQWh7M28/6r57Fwkbweng8qAzoMCPwSJfWlmsg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.35.1",
-        "@typescript-eslint/utils": "8.35.1",
+        "@typescript-eslint/typescript-estree": "8.36.0",
+        "@typescript-eslint/utils": "8.36.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -5549,10 +5557,11 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.1.tgz",
-      "integrity": "sha512-q/O04vVnKHfrrhNAscndAn1tuQhIkwqnaW+eu5waD5IPts2eX1dgJxgqcPx5BX109/qAz7IG6VrEPTOYKCNfRQ==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.36.0.tgz",
+      "integrity": "sha512-xGms6l5cTJKQPZOKM75Dl9yBfNdGeLRsIyufewnxT4vZTrjC0ImQT4fj8QmtJK84F58uSh5HVBSANwcfiXxABQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -5562,15 +5571,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.1.tgz",
-      "integrity": "sha512-Vvpuvj4tBxIka7cPs6Y1uvM7gJgdF5Uu9F+mBJBPY4MhvjrjWGK4H0lVgLJd/8PWZ23FTqsaJaLEkBCFUk8Y9g==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.36.0.tgz",
+      "integrity": "sha512-JaS8bDVrfVJX4av0jLpe4ye0BpAaUW7+tnS4Y4ETa3q7NoZgzYbN9zDQTJ8kPb5fQ4n0hliAt9tA4Pfs2zA2Hg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.35.1",
-        "@typescript-eslint/tsconfig-utils": "8.35.1",
-        "@typescript-eslint/types": "8.35.1",
-        "@typescript-eslint/visitor-keys": "8.35.1",
+        "@typescript-eslint/project-service": "8.36.0",
+        "@typescript-eslint/tsconfig-utils": "8.36.0",
+        "@typescript-eslint/types": "8.36.0",
+        "@typescript-eslint/visitor-keys": "8.36.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -5590,15 +5600,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.1.tgz",
-      "integrity": "sha512-lhnwatFmOFcazAsUm3ZnZFpXSxiwoa1Lj50HphnDe1Et01NF4+hrdXONSUHIcbVu2eFb1bAf+5yjXkGVkXBKAQ==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.36.0.tgz",
+      "integrity": "sha512-VOqmHu42aEMT+P2qYjylw6zP/3E/HvptRwdn/PZxyV27KhZg2IOszXod4NcXisWzPAGSS4trE/g4moNj6XmH2g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.35.1",
-        "@typescript-eslint/types": "8.35.1",
-        "@typescript-eslint/typescript-estree": "8.35.1"
+        "@typescript-eslint/scope-manager": "8.36.0",
+        "@typescript-eslint/types": "8.36.0",
+        "@typescript-eslint/typescript-estree": "8.36.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5613,12 +5624,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.1.tgz",
-      "integrity": "sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==",
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.36.0.tgz",
+      "integrity": "sha512-vZrhV2lRPWDuGoxcmrzRZyxAggPL+qp3WzUrlZD+slFueDiYHxeBa34dUXPuC0RmGKzl4lS5kFJYvKCq9cnNDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/types": "8.36.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -5634,6 +5646,7 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -6605,6 +6618,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -8402,6 +8416,7 @@
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -8418,6 +8433,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -8461,6 +8477,7 @@
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -11018,6 +11035,7 @@
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -11093,6 +11111,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -12033,7 +12052,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -12358,6 +12378,7 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -12429,6 +12450,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
@@ -13615,6 +13637,29 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.36.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.36.0.tgz",
+      "integrity": "sha512-fTCqxthY+h9QbEgSIBfL9iV6CvKDFuoxg6bHPNpJ9HIUzS+jy2lCEyCmGyZRWEBSaykqcDPf1SJ+BfCI8DRopA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.36.0",
+        "@typescript-eslint/parser": "8.36.0",
+        "@typescript-eslint/utils": "8.36.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/ulid": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
         "cypress": "^14.5.1",
         "cypress-axe": "^1.6.0",
         "eslint": "^9.30.1",
-        "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-prettier": "^5.5.1",
         "eslint-plugin-react": "^7.37.5",
@@ -7906,6 +7905,8 @@
       "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "cypress": "^14.5.1",
     "cypress-axe": "^1.6.0",
     "eslint": "^9.30.1",
-    "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-prettier": "^5.5.1",
     "eslint-plugin-react": "^7.37.5",

--- a/package.json
+++ b/package.json
@@ -76,8 +76,6 @@
     "@types/jest": "^30.0.0",
     "@types/react": "^18.3.13",
     "@types/react-dom": "^18.3.1",
-    "@typescript-eslint/eslint-plugin": "^8.35.1",
-    "@typescript-eslint/parser": "^8.32.1",
     "@vitejs/plugin-react": "^4.6.0",
     "axe-core": "^4.10.3",
     "axios-mock-adapter": "^2.1.0",
@@ -96,6 +94,7 @@
     "prettier": "^3.6.2",
     "start-server-and-test": "^2.0.12",
     "typescript": "^5.8.3",
+    "typescript-eslint": "^8.36.0",
     "vite": "^7.0.2",
     "vite-plugin-eslint": "^1.8.1",
     "vitest": "^3.2.4"

--- a/src/utils/tests/nviHelpers.test.ts
+++ b/src/utils/tests/nviHelpers.test.ts
@@ -48,7 +48,7 @@ describe('willResetNviStatuses()', () => {
   });
 
   test('Returns false when existing result could not be an NVI candidate', async () => {
-    let nonNviRegistration = structuredClone(nviRegistration);
+    const nonNviRegistration = structuredClone(nviRegistration);
     nonNviRegistration.entityDescription.reference!.publicationInstance.type = JournalType.Review;
 
     const result = await willResetNviStatuses(nonNviRegistration, nviRegistration);
@@ -56,10 +56,10 @@ describe('willResetNviStatuses()', () => {
   });
 
   test('Returns true when year is changed', async () => {
-    let persistedRegistration = structuredClone(nviRegistration);
+    const persistedRegistration = structuredClone(nviRegistration);
     persistedRegistration.entityDescription.publicationDate!.year = '2000';
 
-    let updatedRegistration = structuredClone(persistedRegistration);
+    const updatedRegistration = structuredClone(persistedRegistration);
     updatedRegistration.entityDescription.publicationDate!.year = '2001';
 
     const result = await willResetNviStatuses(persistedRegistration, updatedRegistration);
@@ -67,12 +67,12 @@ describe('willResetNviStatuses()', () => {
   });
 
   test('Returns false when date is changed within same year', async () => {
-    let persistedRegistration = structuredClone(nviRegistration);
+    const persistedRegistration = structuredClone(nviRegistration);
     persistedRegistration.entityDescription.publicationDate!.day = '1';
     persistedRegistration.entityDescription.publicationDate!.month = '1';
     persistedRegistration.entityDescription.publicationDate!.year = '2000';
 
-    let updatedRegistration = structuredClone(nviRegistration);
+    const updatedRegistration = structuredClone(nviRegistration);
     updatedRegistration.entityDescription.publicationDate!.day = '2';
     updatedRegistration.entityDescription.publicationDate!.month = '2';
     updatedRegistration.entityDescription.publicationDate!.year = '2000';
@@ -82,7 +82,7 @@ describe('willResetNviStatuses()', () => {
   });
 
   test('Returns true when category is changed', async () => {
-    let updatedRegistration = structuredClone(nviRegistration);
+    const updatedRegistration = structuredClone(nviRegistration);
     updatedRegistration.entityDescription.reference!.publicationInstance.type = JournalType.AcademicLiteratureReview;
 
     const result = await willResetNviStatuses(nviRegistration, updatedRegistration);
@@ -93,10 +93,10 @@ describe('willResetNviStatuses()', () => {
     const channelId1 = 'https://api.com/channel/1';
     const channelId2 = 'https://api.com/channel/2';
 
-    let persistedRegistration = structuredClone(nviRegistration);
+    const persistedRegistration = structuredClone(nviRegistration);
     persistedRegistration.entityDescription.reference!.publicationContext.id = channelId1;
 
-    let updatedRegistration = structuredClone(persistedRegistration);
+    const updatedRegistration = structuredClone(persistedRegistration);
     updatedRegistration.entityDescription.reference!.publicationContext.id = channelId2;
 
     const result = await willResetNviStatuses(persistedRegistration, updatedRegistration);
@@ -107,7 +107,7 @@ describe('willResetNviStatuses()', () => {
     const seriesId1 = 'https://api.com/channel/1';
     const seriesId2 = 'https://api.com/channel/2';
 
-    let persistedRegistration = structuredClone(nviRegistration) as BookRegistration;
+    const persistedRegistration = structuredClone(nviRegistration) as BookRegistration;
     persistedRegistration.entityDescription.reference!.publicationContext = {
       type: PublicationType.Book,
       isbnList: [],
@@ -118,7 +118,7 @@ describe('willResetNviStatuses()', () => {
       },
     };
 
-    let updatedRegistration = structuredClone(persistedRegistration) as BookRegistration;
+    const updatedRegistration = structuredClone(persistedRegistration) as BookRegistration;
     updatedRegistration.entityDescription.reference!.publicationContext.series!.id = seriesId2;
 
     const result = await willResetNviStatuses(persistedRegistration, updatedRegistration);
@@ -138,10 +138,10 @@ describe('willResetNviStatuses()', () => {
       role: { type: ContributorRole.Creator },
       sequence: 1,
     };
-    let persistedRegistration = structuredClone(nviRegistration);
+    const persistedRegistration = structuredClone(nviRegistration);
     persistedRegistration.entityDescription.contributors = [persistedContributor];
 
-    let updatedRegistration = structuredClone(persistedRegistration);
+    const updatedRegistration = structuredClone(persistedRegistration);
     const newInstitutionAffiliation: Affiliation = { type: 'Organization', id: institutionB.id };
     updatedRegistration.entityDescription.contributors[0].affiliations = [
       ...persistedAffiliations,
@@ -165,10 +165,10 @@ describe('willResetNviStatuses()', () => {
       role: { type: ContributorRole.Creator },
       sequence: 1,
     };
-    let persistedRegistration = structuredClone(nviRegistration);
+    const persistedRegistration = structuredClone(nviRegistration);
     persistedRegistration.entityDescription.contributors = [persistedContributor];
 
-    let updatedRegistration = structuredClone(persistedRegistration);
+    const updatedRegistration = structuredClone(persistedRegistration);
     updatedRegistration.entityDescription.contributors[0].affiliations = [
       ...persistedAffiliations,
       { type: 'Organization', id: subunitOnInstitutionA.id },
@@ -190,10 +190,10 @@ describe('willResetNviStatuses()', () => {
       role: { type: ContributorRole.Creator },
       sequence: 1,
     };
-    let persistedRegistration = structuredClone(nviRegistration);
+    const persistedRegistration = structuredClone(nviRegistration);
     persistedRegistration.entityDescription.contributors = [persistedContributor];
 
-    let updatedRegistration = structuredClone(persistedRegistration);
+    const updatedRegistration = structuredClone(persistedRegistration);
     updatedRegistration.entityDescription.contributors[0].affiliations = [
       { type: 'Organization', id: institutionB.id },
     ];
@@ -214,10 +214,10 @@ describe('willResetNviStatuses()', () => {
       role: { type: ContributorRole.Creator },
       sequence: 1,
     };
-    let persistedRegistration = structuredClone(nviRegistration);
+    const persistedRegistration = structuredClone(nviRegistration);
     persistedRegistration.entityDescription.contributors = [persistedContributor];
 
-    let updatedRegistration = structuredClone(persistedRegistration);
+    const updatedRegistration = structuredClone(persistedRegistration);
     updatedRegistration.entityDescription.contributors[0].affiliations = [
       { type: 'Organization', id: subunitOnInstitutionA.id },
     ];
@@ -239,10 +239,10 @@ describe('willResetNviStatuses()', () => {
       sequence: 1,
     };
 
-    let persistedRegistration = structuredClone(nviRegistration);
+    const persistedRegistration = structuredClone(nviRegistration);
     persistedRegistration.entityDescription.contributors = [persistedContributor];
 
-    let updatedRegistration = structuredClone(persistedRegistration);
+    const updatedRegistration = structuredClone(persistedRegistration);
     updatedRegistration.entityDescription.contributors[0].affiliations = [];
 
     const result = await willResetNviStatuses(persistedRegistration, updatedRegistration);
@@ -262,7 +262,7 @@ describe('willResetNviStatuses()', () => {
       sequence: 1,
     };
 
-    let persistedRegistration = structuredClone(nviRegistration);
+    const persistedRegistration = structuredClone(nviRegistration);
     persistedRegistration.entityDescription.contributors = [persistedContributor];
 
     const newContributor: Contributor = {
@@ -276,7 +276,7 @@ describe('willResetNviStatuses()', () => {
       role: { type: ContributorRole.Creator },
       sequence: 1,
     };
-    let updatedRegistration = structuredClone(persistedRegistration);
+    const updatedRegistration = structuredClone(persistedRegistration);
     updatedRegistration.entityDescription.contributors = [persistedContributor, newContributor];
 
     const result = await willResetNviStatuses(persistedRegistration, updatedRegistration);


### PR DESCRIPTION
Forenkler og forbedrer eslint config nå som alt har støtte for flat config.
Har erstattet `@typescript-eslint/eslint-plugin` og `@typescript-eslint/parser` med `typescript-eslint`, og tatt i bruk `eslint-plugin-prettier` som tilsynelatende har vært i package.json uten å ha vært konfigurert opp tidligere 😬 
