### PR TITLE
NP-49444 Import mathjax only when it is needed

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@
         font-size: 100% !important;
       }
     </style>
-    <script async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/utils/mathJaxHelpers.ts
+++ b/src/utils/mathJaxHelpers.ts
@@ -6,10 +6,22 @@ interface MathJaxWindow extends Window {
   MathJax?: MathJax;
 }
 
+const mathJaxScriptId = 'mathjax-script';
+
 export const typesetMathJax = () => {
   const mathJaxWindow = window as MathJaxWindow;
   if (mathJaxWindow.MathJax?.typesetPromise) {
     mathJaxWindow.MathJax.typesetPromise();
+  } else if (!document.getElementById(mathJaxScriptId)) {
+    const script = document.createElement('script');
+    script.id = mathJaxScriptId;
+    script.src = 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js';
+    script.async = true;
+    script.onload = () => {
+      mathJaxWindow.MathJax?.typesetPromise?.();
+    };
+
+    document.head.appendChild(script);
   }
 };
 


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-49444

Vent til vi faktisk trenger mathjax før vi laster ned. Med dette unngår vi å laste ned over 1MB for noe et fåtall av brukere trenger, som gjør at første lasting av appen også vil gå litt raskere.

Eneste ulempen som jeg ser det er at første gang man kommer over mathjax vil innholdet "hoppe" fra vanlig tekst til mathjax når mathjax er lastet inn, mens det tidligere skjedde med en gang siden mathjax alltid var lastet inn på forskudd. Men syns fordelene med denne endringen veier opp for det.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
