### PR TITLE
Set cyclomatic complexity threshold to 20

### DIFF
--- a/.codescene/code-health-rules.json
+++ b/.codescene/code-health-rules.json
@@ -1,0 +1,13 @@
+{
+  "rule_sets": [
+    {
+      "matching_content_path": "**",
+      "thresholds": [
+        {
+          "name": "function_cyclomatic_complexity_warning",
+          "value": 20
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Øker grensen fra 10 til 20 for cyclomatic complexity for codescene. 10 føles ofte veldig strengt på komponenter, da alternativet er å splitte opp i mange komponenter og man må i stedet hoppe gjennom mange ulike filer for å få oversikt. Selv om det stort sett gir mening med 10 på hjelpefunksjoner o.l. blir det en del støy for mange komponenter nå. Foreslår derfor å øke til 20, så kan det ev. revurderes igjen senere.

Forslaget her stammer egentlig fra https://github.com/BIBSYSDEV/NVA-Frontend/pull/7598#discussion_r2263061793