### PR TITLE
NP-49449 Allow using old and new mering functionality

### DIFF
--- a/src/components/BetaFunctionality.tsx
+++ b/src/components/BetaFunctionality.tsx
@@ -6,10 +6,10 @@ interface BetaFunctionalityProps extends BoxProps {
   children: ReactNode;
 }
 
-export const BetaFunctionality = ({ children, ...props }: BetaFunctionalityProps) => {
+export const BetaFunctionality = ({ children, sx, ...props }: BetaFunctionalityProps) => {
   const betaEnabled = useBetaFlag();
   return betaEnabled ? (
-    <Box sx={{ border: '3px dashed', padding: '0.5rem' }} {...props}>
+    <Box sx={{ border: '3px dashed', padding: '0.5rem', ...sx }} {...props}>
       {children}
     </Box>
   ) : null;

--- a/src/pages/basic_data/BasicDataPage.tsx
+++ b/src/pages/basic_data/BasicDataPage.tsx
@@ -232,13 +232,14 @@ const BasicDataPage = () => {
           />
           <Route
             path={getSubUrl(UrlPathTemplate.BasicDataCentralImportCandidateMerge, UrlPathTemplate.BasicData)}
-            element={
-              <PrivateRoute
-                isAuthorized={isInternalImporter}
-                element={beta ? <MergeImportCandidate /> : <CentralImportCandidateMerge />}
-              />
-            }
+            element={<PrivateRoute isAuthorized={isInternalImporter} element={<CentralImportCandidateMerge />} />}
           />
+          {beta && (
+            <Route
+              path={getSubUrl(UrlPathTemplate.BasicDataCentralImportCandidateMergeBeta, UrlPathTemplate.BasicData)}
+              element={<PrivateRoute isAuthorized={isInternalImporter} element={<MergeImportCandidate />} />}
+            />
+          )}
           <Route
             path={getSubUrl(UrlPathTemplate.BasicDataAddEmployee, UrlPathTemplate.BasicData)}
             element={<PrivateRoute isAuthorized={isInstitutionAdmin} element={<AddEmployeePage />} />}

--- a/src/pages/basic_data/app_admin/central_import/CentralImportDuplicationCheckPage.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportDuplicationCheckPage.tsx
@@ -7,6 +7,7 @@ import { Link, useLocation, useParams } from 'react-router';
 import { useFetchRegistration } from '../../../../api/hooks/useFetchRegistration';
 import { fetchImportCandidate, updateImportCandidateStatus } from '../../../../api/registrationApi';
 import { fetchImportCandidates, FetchImportCandidatesParams } from '../../../../api/searchApi';
+import { BetaFunctionality } from '../../../../components/BetaFunctionality';
 import { ConfirmMessageDialog } from '../../../../components/ConfirmMessageDialog';
 import { HeadTitle } from '../../../../components/HeadTitle';
 import { PageSpinner } from '../../../../components/PageSpinner';
@@ -20,6 +21,7 @@ import { getIdentifierFromId } from '../../../../utils/general-helpers';
 import { stringIncludesMathJax, typesetMathJax } from '../../../../utils/mathJaxHelpers';
 import { convertToRegistrationSearchItem } from '../../../../utils/registration-helpers';
 import {
+  getImportCandidateMergeBetaPath,
   getImportCandidateMergePath,
   getImportCandidateWizardPath,
   IdentifierParams,
@@ -208,6 +210,22 @@ export const CentralImportDuplicationCheckPage = () => {
                   {t('basic_data.central_import.merge_candidate.merge')}
                 </Button>
               )}
+
+              <BetaFunctionality sx={{ mt: '1rem' }}>
+                {registrationIdentifier ? (
+                  <Link
+                    to={{ pathname: getImportCandidateMergeBetaPath(identifier ?? '', registrationIdentifier) }}
+                    state={locationState}>
+                    <Button variant="outlined" fullWidth size="small">
+                      {t('basic_data.central_import.merge_candidate.merge')} (BETA)
+                    </Button>
+                  </Link>
+                ) : (
+                  <Button variant="outlined" fullWidth size="small" disabled>
+                    {t('basic_data.central_import.merge_candidate.merge')} (BETA)
+                  </Button>
+                )}
+              </BetaFunctionality>
 
               <Divider sx={{ my: '1rem' }} />
 

--- a/src/utils/urlPaths.ts
+++ b/src/utils/urlPaths.ts
@@ -14,6 +14,7 @@ export enum UrlPathTemplate {
   BasicDataCentralImportCandidate = '/basic-data/central-import/:identifier',
   BasicDataCentralImportCandidateWizard = '/basic-data/central-import/:identifier/edit',
   BasicDataCentralImportCandidateMerge = '/basic-data/central-import/:candidateIdentifier/merge/:registrationIdentifier',
+  BasicDataCentralImportCandidateMergeBeta = '/basic-data/central-import/:candidateIdentifier/merge/:registrationIdentifier/beta',
   BasicDataInstitutions = '/basic-data/institutions',
   BasicDataNvi = '/basic-data/nvi',
   BasicDataNviNew = '/basic-data/nvi/new',
@@ -134,6 +135,13 @@ export const getImportCandidateWizardPath = (identifier: string) =>
 
 export const getImportCandidateMergePath = (candidateIdentifier: string, registrationIdentifier: string) =>
   UrlPathTemplate.BasicDataCentralImportCandidateMerge.replace(
+    ':candidateIdentifier',
+    encodeURIComponent(candidateIdentifier)
+  ).replace(':registrationIdentifier', encodeURIComponent(registrationIdentifier));
+
+// TODO: Remove this when new merging is out of beta
+export const getImportCandidateMergeBetaPath = (candidateIdentifier: string, registrationIdentifier: string) =>
+  UrlPathTemplate.BasicDataCentralImportCandidateMergeBeta.replace(
     ':candidateIdentifier',
     encodeURIComponent(candidateIdentifier)
   ).replace(':registrationIdentifier', encodeURIComponent(registrationIdentifier));


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-49449

Endrer på at man må bruke betafunksjonalitet ved merging til at man kan velge om man vil bruke gammel eller beta-versjon. Beta-knapp er bare synlig om man har satt beta-flagg

<img width="280" height="427" alt="bilde" src="https://github.com/user-attachments/assets/03ea438e-6c1a-48bd-a03e-bd450e5a3704" />


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
