### PR TITLE
Remove redundant padding for env banner

### DIFF
--- a/src/components/ServiceBanner.tsx
+++ b/src/components/ServiceBanner.tsx
@@ -49,7 +49,7 @@ export const ServiceBanner = () => {
       }>
       <Box sx={{ mx: 'auto', maxWidth: '50rem', textAlign: 'center' }}>
         {isTestEnvironment && (!minimizeBanner || showMaintenanceInfo) && (
-          <Typography gutterBottom>
+          <Typography>
             {t('common.test_environment')} ({hostname})
           </Typography>
         )}


### PR DESCRIPTION
Før:
<img width="242" height="93" alt="bilde" src="https://github.com/user-attachments/assets/9ac20ae7-610c-4707-bc51-6e5ac421454a" />

Etter:
<img width="397" height="107" alt="bilde" src="https://github.com/user-attachments/assets/206b2d3a-c351-4c51-b5aa-6b0bace88823" />

