### PR TITLE
NP-49665 Set last modified to default sorting for result search

### DIFF
--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -582,7 +582,7 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
 
   searchParams.set(ResultParam.From, typeof params.from === 'number' ? params.from.toString() : '0');
   searchParams.set(ResultParam.Results, typeof params.results === 'number' ? params.results.toString() : '10');
-  searchParams.set(ResultParam.Order, params.order ?? ResultSearchOrder.Relevance);
+  searchParams.set(ResultParam.Order, params.order ?? ResultSearchOrder.ModifiedDate);
   searchParams.set(ResultParam.Sort, params.sort ?? 'desc');
 
   const getResults = await apiRequest2<RegistrationSearchResponse>({

--- a/src/pages/search/registration_search/RegistrationSortSelector.tsx
+++ b/src/pages/search/registration_search/RegistrationSortSelector.tsx
@@ -10,11 +10,15 @@ interface RegistrationSortOption {
 }
 
 export const registrationSortOptions: RegistrationSortOption[] = [
-  { orderBy: ResultSearchOrder.Relevance, sortOrder: 'desc', i18nKey: 'search.sort_by_relevance' },
   {
     orderBy: ResultSearchOrder.ModifiedDate,
     sortOrder: 'desc',
     i18nKey: 'search.sort_by_modified_date',
+  },
+  {
+    orderBy: ResultSearchOrder.Relevance,
+    sortOrder: 'desc',
+    i18nKey: 'search.sort_by_relevance',
   },
   {
     orderBy: ResultSearchOrder.PublicationDate,


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-49665

Sorterer resultatsøk på "Sist endret" som standard i stedet for "Relevans". Dette vil da gjelde overalt, som kan være uheldig da vi noen plasser ønsker å sortere på "Relevans" for å få resultater som er markert som favoritter øverst. Noen stikkprøver viser at det ikke virker i dev heller atm da.. Men det var tanken tidligere hvertfall

<img width="1087" height="670" alt="bilde" src="https://github.com/user-attachments/assets/c986f6ab-a954-4af9-a1ef-343d26a2809c" />


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
