### PR TITLE
NP-49668 Add fallback text to vocabulary

### DIFF
--- a/src/pages/editor/VocabularyOverview.tsx
+++ b/src/pages/editor/VocabularyOverview.tsx
@@ -7,6 +7,7 @@ import { fetchVocabulary } from '../../api/customerInstitutionsApi';
 import { HeadTitle } from '../../components/HeadTitle';
 import { RootState } from '../../redux/store';
 import {
+  CustomerVocabulary,
   defaultHrcsActivity,
   defaultHrcsCategory,
   visibleVocabularyStatuses,
@@ -30,6 +31,10 @@ export const VocabularyOverview = () => {
     meta: { errorMessage: t('feedback.error.get_vocabularies') },
   });
 
+  const visibleVocabularies =
+    vocabularyQuery.data?.vocabularies.filter((vocabulary) => visibleVocabularyStatuses.includes(vocabulary.status)) ??
+    [];
+
   return (
     <>
       <HeadTitle>{t('editor.vocabulary')}</HeadTitle>
@@ -37,28 +42,37 @@ export const VocabularyOverview = () => {
         {t('editor.vocabulary')}
       </Typography>
 
-      <Typography>{t('editor.vocabulary_description')}</Typography>
-
       {vocabularyQuery.isPending ? (
         <CircularProgress aria-labelledby="vocabulary-label" />
+      ) : visibleVocabularies.length > 0 ? (
+        <>
+          <Typography>{t('editor.vocabulary_description')}</Typography>
+          {visibleVocabularies.map((vocabulary) => (
+            <VocabularyCard vocabulary={vocabulary} key={vocabulary.id} />
+          ))}
+        </>
       ) : (
-        vocabularyQuery.data?.vocabularies
-          .filter((vocabulary) => visibleVocabularyStatuses.includes(vocabulary.status))
-          .map((vocabulary) => {
-            return (
-              <Card
-                key={vocabulary.id}
-                sx={{
-                  bgcolor: 'white',
-                  maxWidth: '450px',
-                  mt: '1rem',
-                  p: '1.5rem',
-                }}>
-                <Typography fontWeight="600">{getTranslatedVocabularyName(t, vocabulary.id)}</Typography>
-              </Card>
-            );
-          })
+        <Typography>{t('vocabulary_missing')}</Typography>
       )}
     </>
+  );
+};
+
+interface VocabularyCardProps {
+  vocabulary: CustomerVocabulary;
+}
+
+const VocabularyCard = ({ vocabulary }: VocabularyCardProps) => {
+  const { t } = useTranslation();
+  return (
+    <Card
+      sx={{
+        bgcolor: 'white',
+        maxWidth: '450px',
+        mt: '1rem',
+        p: '1.5rem',
+      }}>
+      <Typography fontWeight="600">{getTranslatedVocabularyName(t, vocabulary.id)}</Typography>
+    </Card>
   );
 };

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -2273,5 +2273,6 @@
     "unpublish_registration_duplicate_question": "Finnes det en annen publisert versjon av samme forskningsresultat?",
     "unpublish_registration_reason": "Legg inn en kort begrunnelse for at dette forskningsresultatet ikke lenger skal være publisert. Begrunnelsen vil vises på forskningsresultatet ved oppslag av referanse til forskningsresultet."
   },
-  "view_contact_info": "Se kontaktinformasjon"
+  "view_contact_info": "Se kontaktinformasjon",
+  "vocabulary_missing": "Institusjonen har ikke lagt til vokabular."
 }


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-49668](https://sikt.atlassian.net/browse/NP-49668)

Legger til en standardtekst derson institusjonen ikke har valgt vokabular.

Før:
<img width="1029" height="407" alt="image" src="https://github.com/user-attachments/assets/65f26044-a06a-42bb-83b6-1fe4c77bdee7" />

Etter:
<img width="866" height="419" alt="image" src="https://github.com/user-attachments/assets/2aa8cf8b-379d-4707-adc7-c8da6fdfcc09" />

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-49668]: https://sikt.atlassian.net/browse/NP-49668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ