### PR TITLE
Correct default value for publishing workflow

### DIFF
--- a/src/types/customerInstitution.types.ts
+++ b/src/types/customerInstitution.types.ts
@@ -109,7 +109,7 @@ export const emptyCustomerInstitution: Omit<CustomerInstitution, 'doiAgent'> = {
   identifier: '',
   name: '',
   vocabularies: [],
-  publicationWorkflow: 'RegistratorPublishesMetadataAndFiles',
+  publicationWorkflow: 'RegistratorPublishesMetadataOnly',
   rorId: '',
   sector: Sector.Uhi,
   nviInstitution: false,


### PR DESCRIPTION
Sett `RegistratorPublishesMetadataOnly` som default arbeidsflyt når man oppretter ny kundeinstitusjon