### PR TITLE
Added MenuItem to allow selecting all NVI candidates

### DIFF
--- a/src/pages/messages/components/NviStatusFilter.tsx
+++ b/src/pages/messages/components/NviStatusFilter.tsx
@@ -62,7 +62,7 @@ export const NviStatusFilter = () => {
       <MenuItem value={'approved' satisfies NviCandidateStatus}>{t('tasks.nvi.status.Approved')}</MenuItem>
       <MenuItem value={'rejected' satisfies NviCandidateStatus}>{t('tasks.nvi.status.Rejected')}</MenuItem>
       <MenuItem value={'dispute' satisfies NviCandidateGlobalStatus}>{t('tasks.nvi.status.Dispute')}</MenuItem>
-      <MenuItem value={'all'}>{t('tasks.nvi.status.all')}</MenuItem>
+      <MenuItem value={'all'}>{t('common.show_all')}</MenuItem>
     </TextField>
   );
 };

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1967,8 +1967,7 @@
         "Dispute": "Tvist",
         "New": "Kandidat",
         "Pending": "Kontrolleres",
-        "Rejected": "Avvist",
-        "all": "Vis alle"
+        "Rejected": "Avvist"
       },
       "unidentified_person_with_nvi_institution": "Uidentifisert person med tilknytning til NVI-institusjon"
     },


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-49540](https://sikt.atlassian.net/browse/NP-49540)

When the user performs a search without selecting a status the system now returns all NVI candidates regardless of status

# How to test
Go into Oppgaver -> NVI-kontroll -> NVI kandidatsøk (/tasks/nvi)

Test out using the "Velg alle"-selection in the status-dropdown

<img width="501" height="242" alt="image" src="https://github.com/user-attachments/assets/c1456956-2fa8-49b4-b518-27f0d307eaca" />

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

[NP-49540]: https://sikt.atlassian.net/browse/NP-49540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ