### PR TITLE
Np 49823 show ticket type icons

### DIFF
--- a/src/components/TicketTypeFilterButton.tsx
+++ b/src/components/TicketTypeFilterButton.tsx
@@ -22,6 +22,6 @@ export const TicketTypeFilterButton = ({ isSelected, children, ...rest }: Ticket
         mr: '0.5rem',
       },
     }}>
-    <Box sx={{ display: 'flex', gap: '0.1rem', alignItems: 'center' }}>{children}</Box>
+    <Box sx={{ display: 'flex', gap: '0.25rem', alignItems: 'center' }}>{children}</Box>
   </Button>
 );

--- a/src/components/TicketTypeFilterButton.tsx
+++ b/src/components/TicketTypeFilterButton.tsx
@@ -4,19 +4,12 @@ import { Box, Button, ButtonProps } from '@mui/material';
 
 interface TicketTypeFilterButtonProps extends ButtonProps {
   isSelected: boolean;
-  showCheckbox?: boolean;
 }
 
-export const TicketTypeFilterButton = ({
-  isSelected,
-  showCheckbox = false,
-  children,
-  startIcon,
-  ...rest
-}: TicketTypeFilterButtonProps) => (
+export const TicketTypeFilterButton = ({ isSelected, children, ...rest }: TicketTypeFilterButtonProps) => (
   <Button
     {...rest}
-    startIcon={showCheckbox ? isSelected ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon /> : startIcon}
+    startIcon={isSelected ? <CheckBoxIcon /> : <CheckBoxOutlineBlankIcon />}
     variant={isSelected ? 'contained' : 'outlined'}
     sx={{
       justifyContent: 'start',

--- a/src/components/TicketTypeFilterButton.tsx
+++ b/src/components/TicketTypeFilterButton.tsx
@@ -1,6 +1,6 @@
 import CheckBoxIcon from '@mui/icons-material/CheckBox';
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
-import { Button, ButtonProps } from '@mui/material';
+import { Box, Button, ButtonProps } from '@mui/material';
 
 interface TicketTypeFilterButtonProps extends ButtonProps {
   isSelected: boolean;
@@ -29,6 +29,6 @@ export const TicketTypeFilterButton = ({
         mr: '0.5rem',
       },
     }}>
-    {children}
+    <Box sx={{ display: 'flex', gap: '0.1rem', alignItems: 'center' }}>{children}</Box>
   </Button>
 );

--- a/src/pages/messages/TasksPage.tsx
+++ b/src/pages/messages/TasksPage.tsx
@@ -167,7 +167,6 @@ const TasksPage = () => {
                 <TicketTypeFilterButton
                   data-testid={dataTestId.tasksPage.typeSearch.publishingButton}
                   endIcon={<Badge badgeContent={publishingNotificationsCount} />}
-                  showCheckbox
                   isSelected={!!ticketTypes.publishingRequest}
                   color="publishingRequest"
                   onClick={() => {
@@ -185,7 +184,6 @@ const TasksPage = () => {
                 <TicketTypeFilterButton
                   data-testid={dataTestId.tasksPage.typeSearch.thesisPublishingRequestsButton}
                   endIcon={<Badge badgeContent={thesisPublishingNotificationsCount} />}
-                  showCheckbox
                   isSelected={!!ticketTypes.filesApprovalThesis}
                   color="publishingRequest"
                   onClick={() => {
@@ -203,7 +201,6 @@ const TasksPage = () => {
                 <TicketTypeFilterButton
                   data-testid={dataTestId.tasksPage.typeSearch.doiButton}
                   endIcon={<Badge badgeContent={doiNotificationsCount} />}
-                  showCheckbox
                   isSelected={!!ticketTypes.doiRequest}
                   color="doiRequest"
                   onClick={() => {
@@ -221,7 +218,6 @@ const TasksPage = () => {
                 <TicketTypeFilterButton
                   data-testid={dataTestId.tasksPage.typeSearch.supportButton}
                   endIcon={<Badge badgeContent={supportNotificationsCount} />}
-                  showCheckbox
                   isSelected={!!ticketTypes.generalSupportCase}
                   color="generalSupportCase"
                   onClick={() => {

--- a/src/pages/messages/TasksPage.tsx
+++ b/src/pages/messages/TasksPage.tsx
@@ -1,4 +1,8 @@
+import AddLinkOutlinedIcon from '@mui/icons-material/AddLinkOutlined';
 import AssignmentIcon from '@mui/icons-material/AssignmentOutlined';
+import ChatBubbleOutlineOutlinedIcon from '@mui/icons-material/ChatBubbleOutlineOutlined';
+import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutlined';
+import SchoolOutlinedIcon from '@mui/icons-material/SchoolOutlined';
 import { Badge } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
@@ -170,6 +174,7 @@ const TasksPage = () => {
                     setTicketTypes({ ...ticketTypes, publishingRequest: !ticketTypes.publishingRequest });
                     resetPaginationAndNavigate(searchParams, navigate);
                   }}>
+                  <InsertDriveFileOutlinedIcon fontSize="small" />
                   {ticketTypes.publishingRequest && publishingRequestCount
                     ? `${t('my_page.messages.types.PublishingRequest')} (${publishingRequestCount})`
                     : t('my_page.messages.types.PublishingRequest')}
@@ -187,6 +192,7 @@ const TasksPage = () => {
                     setTicketTypes({ ...ticketTypes, filesApprovalThesis: !ticketTypes.filesApprovalThesis });
                     resetPaginationAndNavigate(searchParams, navigate);
                   }}>
+                  <SchoolOutlinedIcon fontSize="small" />
                   {ticketTypes.filesApprovalThesis && thesisPublishingRequestCount
                     ? `${t('my_page.messages.types.FilesApprovalThesis')} (${thesisPublishingRequestCount})`
                     : t('my_page.messages.types.FilesApprovalThesis')}
@@ -204,6 +210,7 @@ const TasksPage = () => {
                     setTicketTypes({ ...ticketTypes, doiRequest: !ticketTypes.doiRequest });
                     resetPaginationAndNavigate(searchParams, navigate);
                   }}>
+                  <AddLinkOutlinedIcon fontSize="small" />
                   {ticketTypes.doiRequest && doiRequestCount
                     ? `${t('my_page.messages.types.DoiRequest')} (${doiRequestCount})`
                     : t('my_page.messages.types.DoiRequest')}
@@ -221,6 +228,7 @@ const TasksPage = () => {
                     setTicketTypes({ ...ticketTypes, generalSupportCase: !ticketTypes.generalSupportCase });
                     resetPaginationAndNavigate(searchParams, navigate);
                   }}>
+                  <ChatBubbleOutlineOutlinedIcon fontSize="small" />
                   {ticketTypes.generalSupportCase && generalSupportCaseCount
                     ? `${t('my_page.messages.types.GeneralSupportCase')} (${generalSupportCaseCount})`
                     : t('my_page.messages.types.GeneralSupportCase')}

--- a/src/pages/messages/components/DoiRequestMessagesColumn.tsx
+++ b/src/pages/messages/components/DoiRequestMessagesColumn.tsx
@@ -1,3 +1,4 @@
+import AddLinkOutlinedIcon from '@mui/icons-material/AddLinkOutlined';
 import BlockIcon from '@mui/icons-material/Block';
 import CheckIcon from '@mui/icons-material/Check';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
@@ -14,14 +15,23 @@ import {
 
 interface DoiRequestMessagesColumnProps {
   ticket: ExpandedTicket | Ticket;
-  showLastMessage?: boolean;
+  showDetails?: boolean;
 }
 
-export const DoiRequestMessagesColumn = ({ ticket, showLastMessage }: DoiRequestMessagesColumnProps) => {
+export const DoiRequestMessagesColumn = ({ ticket, showDetails }: DoiRequestMessagesColumnProps) => {
   const { t } = useTranslation();
 
   return (
     <StyledMessagesContainer>
+      {showDetails && (
+        <StyledStatusMessageBox sx={{ bgcolor: 'doiRequest.main' }}>
+          <StyledIconAndTextWrapper>
+            <AddLinkOutlinedIcon fontSize="small" />
+            <Typography>{t('my_page.messages.types.DoiRequest')}</Typography>
+          </StyledIconAndTextWrapper>
+        </StyledStatusMessageBox>
+      )}
+
       {ticket.status === 'New' || ticket.status === 'Pending' ? (
         <StyledStatusMessageBox sx={{ bgcolor: 'secondary.dark' }}>
           <StyledIconAndTextWrapper>
@@ -47,7 +57,7 @@ export const DoiRequestMessagesColumn = ({ ticket, showLastMessage }: DoiRequest
         </StyledStatusMessageBox>
       ) : null}
 
-      {showLastMessage && <LastMessageBox ticket={ticket as ExpandedTicket} />}
+      {showDetails && <LastMessageBox ticket={ticket as ExpandedTicket} />}
     </StyledMessagesContainer>
   );
 };

--- a/src/pages/messages/components/PublishingRequestMessagesColumn.tsx
+++ b/src/pages/messages/components/PublishingRequestMessagesColumn.tsx
@@ -1,6 +1,7 @@
 import BlockIcon from '@mui/icons-material/Block';
 import CheckIcon from '@mui/icons-material/Check';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
+import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutlined';
 import { Box, styled, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { ExpandedPublishingTicket, PublishingTicket } from '../../../types/publication_types/ticket.types';
@@ -36,6 +37,13 @@ export const PublishingRequestMessagesColumn = ({ ticket }: PublishingRequestMes
 
   return (
     <StyledMessagesContainer>
+      <StyledStatusMessageBox sx={{ bgcolor: 'publishingRequest.main' }}>
+        <StyledIconAndTextWrapper>
+          <InsertDriveFileOutlinedIcon fontSize="small" />
+          <Typography>{t('my_page.messages.types.PublishingRequest')}</Typography>
+        </StyledIconAndTextWrapper>
+      </StyledStatusMessageBox>
+
       {ticket.status === 'Pending' || ticket.status === 'New' ? (
         <>
           {ticket.filesForApproval.length > 0 && (

--- a/src/pages/messages/components/SupportMessagesColumn.tsx
+++ b/src/pages/messages/components/SupportMessagesColumn.tsx
@@ -1,3 +1,4 @@
+import ChatBubbleOutlineOutlinedIcon from '@mui/icons-material/ChatBubbleOutlineOutlined';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 import { Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
@@ -18,6 +19,13 @@ export const SupportMessagesColumn = ({ ticket }: SupportMessagesColumnProps) =>
 
   return (
     <StyledMessagesContainer>
+      <StyledStatusMessageBox sx={{ bgcolor: 'generalSupportCase.main' }}>
+        <StyledIconAndTextWrapper>
+          <ChatBubbleOutlineOutlinedIcon fontSize="small" />
+          <Typography>{t('my_page.messages.types.GeneralSupportCase')}</Typography>
+        </StyledIconAndTextWrapper>
+      </StyledStatusMessageBox>
+
       {(ticket.status === 'New' || ticket.status === 'Pending') && (
         <StyledStatusMessageBox sx={{ bgcolor: 'secondary.dark' }}>
           <StyledIconAndTextWrapper>

--- a/src/pages/messages/components/TicketListItem.tsx
+++ b/src/pages/messages/components/TicketListItem.tsx
@@ -79,7 +79,6 @@ export const TicketListItem = ({ ticket }: TicketListItemProps) => {
 
   return (
     <SearchListItem
-      key={ticket.id}
       sx={{
         borderLeftColor: ticketColor[ticket.type],
         p: 0,
@@ -124,7 +123,7 @@ export const TicketListItem = ({ ticket }: TicketListItemProps) => {
           {isFileApprovalTicket(ticket) ? (
             <PublishingRequestMessagesColumn ticket={ticket as ExpandedPublishingTicket} />
           ) : ticket.type === 'DoiRequest' ? (
-            <DoiRequestMessagesColumn ticket={ticket} showLastMessage />
+            <DoiRequestMessagesColumn ticket={ticket} showDetails />
           ) : ticket.type === 'GeneralSupportCase' ? (
             <SupportMessagesColumn ticket={ticket} />
           ) : (

--- a/src/pages/my_page/MyPagePage.tsx
+++ b/src/pages/my_page/MyPagePage.tsx
@@ -217,7 +217,6 @@ const MyPagePage = () => {
               <TicketTypeFilterButton
                 data-testid={dataTestId.tasksPage.typeSearch.publishingButton}
                 endIcon={<Badge badgeContent={allUnreadPublishingCount} />}
-                showCheckbox
                 isSelected={!!selectedTypes.publishingRequest}
                 color="publishingRequest"
                 onClick={() => {
@@ -233,7 +232,6 @@ const MyPagePage = () => {
               <TicketTypeFilterButton
                 data-testid={dataTestId.tasksPage.typeSearch.doiButton}
                 endIcon={<Badge badgeContent={unreadDoiCount} />}
-                showCheckbox
                 isSelected={!!selectedTypes.doiRequest}
                 color="doiRequest"
                 onClick={() => {
@@ -249,7 +247,6 @@ const MyPagePage = () => {
               <TicketTypeFilterButton
                 data-testid={dataTestId.tasksPage.typeSearch.supportButton}
                 endIcon={<Badge badgeContent={unreadGeneralSupportCount} />}
-                showCheckbox
                 isSelected={!!selectedTypes.generalSupportCase}
                 color="generalSupportCase"
                 onClick={() => {

--- a/src/pages/my_page/MyPagePage.tsx
+++ b/src/pages/my_page/MyPagePage.tsx
@@ -1,5 +1,8 @@
+import AddLinkOutlinedIcon from '@mui/icons-material/AddLinkOutlined';
 import ChatBubbleIcon from '@mui/icons-material/ChatBubble';
+import ChatBubbleOutlineOutlinedIcon from '@mui/icons-material/ChatBubbleOutlineOutlined';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutlined';
 import NotesIcon from '@mui/icons-material/Notes';
 import ShowChartIcon from '@mui/icons-material/ShowChart';
 import { Badge, Divider, Typography } from '@mui/material';
@@ -221,6 +224,7 @@ const MyPagePage = () => {
                   setSelectedTypes({ ...selectedTypes, publishingRequest: !selectedTypes.publishingRequest });
                   resetPaginationAndNavigate(searchParams, navigate);
                 }}>
+                <InsertDriveFileOutlinedIcon fontSize="small" />
                 {selectedTypes.publishingRequest && allPublishingRequestCount
                   ? `${t('my_page.messages.types.PublishingRequest')} (${allPublishingRequestCount})`
                   : t('my_page.messages.types.PublishingRequest')}
@@ -236,6 +240,7 @@ const MyPagePage = () => {
                   setSelectedTypes({ ...selectedTypes, doiRequest: !selectedTypes.doiRequest });
                   resetPaginationAndNavigate(searchParams, navigate);
                 }}>
+                <AddLinkOutlinedIcon fontSize="small" />
                 {selectedTypes.doiRequest && doiRequestCount
                   ? `${t('my_page.messages.types.DoiRequest')} (${doiRequestCount})`
                   : t('my_page.messages.types.DoiRequest')}
@@ -251,6 +256,7 @@ const MyPagePage = () => {
                   setSelectedTypes({ ...selectedTypes, generalSupportCase: !selectedTypes.generalSupportCase });
                   resetPaginationAndNavigate(searchParams, navigate);
                 }}>
+                <ChatBubbleOutlineOutlinedIcon fontSize="small" />
                 {selectedTypes.generalSupportCase && generalSupportCaseCount
                   ? `${t('my_page.messages.types.GeneralSupportCase')} (${generalSupportCaseCount})`
                   : t('my_page.messages.types.GeneralSupportCase')}


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-49823

Legger til ikoner for å vise hvilken type ticket det er snakk om.
Fører til et litt rart fargespill noen steder, men tenker dette egentlig er bra nok for første iterasjon, så blir det å jobbe videre med fargene

Synlig på:
- Oppgaveliste: http://localhost:3000/tasks
- Mine brukerdialoger: http://localhost:3000/my-page/messages/my-messages

<img width="1247" height="562" alt="bilde" src="https://github.com/user-attachments/assets/4e265248-6717-4295-995b-12f9b7001112" />


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
