### PR TITLE
Np 49802 merge search type onclicks

### DIFF
--- a/src/pages/frontpage/SearchSection.tsx
+++ b/src/pages/frontpage/SearchSection.tsx
@@ -1,13 +1,13 @@
-import { useTranslation } from 'react-i18next';
-import { useState } from 'react';
-import { Link as RouterLink, useNavigate } from 'react-router';
-import { SearchTypeDropdown, SearchTypeValue } from '../search/SearchTypeDropdown';
-import { Box, Button, Link, Typography } from '@mui/material';
-import SearchIcon from '@mui/icons-material/Search';
-import { dataTestId } from '../../utils/dataTestIds';
-import { SearchTextField } from '../search/SearchTextField';
 import EastIcon from '@mui/icons-material/East';
+import SearchIcon from '@mui/icons-material/Search';
+import { Box, Button, Link, Typography } from '@mui/material';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link as RouterLink, useNavigate } from 'react-router';
+import { dataTestId } from '../../utils/dataTestIds';
 import { UrlPathTemplate } from '../../utils/urlPaths';
+import { SearchTextField } from '../search/SearchTextField';
+import { SearchTypeDropdown, SearchTypeValue } from '../search/SearchTypeDropdown';
 
 const getCorrectParameters = (inputValue: string, searchType: SearchTypeValue) => {
   switch (searchType) {
@@ -62,12 +62,7 @@ export const SearchSection = () => {
         sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, gap: '0.75rem' }}
         component="form"
         onSubmit={onSubmit}>
-        <SearchTypeDropdown
-          selectedValue={selectedSearchType}
-          onSelectResult={() => setSelectedSearchType(SearchTypeValue.Result)}
-          onSelectPerson={() => setSelectedSearchType(SearchTypeValue.Person)}
-          onSelectProject={() => setSelectedSearchType(SearchTypeValue.Project)}
-        />
+        <SearchTypeDropdown selectedValue={selectedSearchType} setSelectedSearchType={setSelectedSearchType} />
         <SearchTextField
           dataTestId={dataTestId.frontPage.searchInputField}
           aria-label={t(getCorrectPlaceholderKey(selectedSearchType))}

--- a/src/pages/frontpage/SearchSection.tsx
+++ b/src/pages/frontpage/SearchSection.tsx
@@ -62,7 +62,7 @@ export const SearchSection = () => {
         sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, gap: '0.75rem' }}
         component="form"
         onSubmit={onSubmit}>
-        <SearchTypeDropdown selectedValue={selectedSearchType} setSelectedSearchType={setSelectedSearchType} />
+        <SearchTypeDropdown selectedValue={selectedSearchType} onSearchTypeChanged={setSelectedSearchType} />
         <SearchTextField
           dataTestId={dataTestId.frontPage.searchInputField}
           aria-label={t(getCorrectPlaceholderKey(selectedSearchType))}

--- a/src/pages/frontpage/SearchSection.tsx
+++ b/src/pages/frontpage/SearchSection.tsx
@@ -1,8 +1,8 @@
 import { useTranslation } from 'react-i18next';
 import { useState } from 'react';
-import { useNavigate } from 'react-router';
+import { Link as RouterLink, useNavigate } from 'react-router';
 import { SearchTypeDropdown, SearchTypeValue } from '../search/SearchTypeDropdown';
-import { Box, Button, Typography } from '@mui/material';
+import { Box, Button, Link, Typography } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import { dataTestId } from '../../utils/dataTestIds';
 import { SearchTextField } from '../search/SearchTextField';
@@ -19,6 +19,19 @@ const getCorrectParameters = (inputValue: string, searchType: SearchTypeValue) =
       return `type=project${inputValue ? `&multiple=${inputValue}` : ''}`;
     default:
       return '';
+  }
+};
+
+const getCorrectPlaceholderKey = (searchType: SearchTypeValue) => {
+  switch (searchType) {
+    case SearchTypeValue.Result:
+      return 'search.search_placeholder';
+    case SearchTypeValue.Person:
+      return 'search.person_search_placeholder';
+    case SearchTypeValue.Project:
+      return 'search.search_project_placeholder';
+    default:
+      return 'search.search_placeholder';
   }
 };
 
@@ -57,7 +70,8 @@ export const SearchSection = () => {
         />
         <SearchTextField
           dataTestId={dataTestId.frontPage.searchInputField}
-          placeholder={t('search.search_placeholder')}
+          aria-label={t(getCorrectPlaceholderKey(selectedSearchType))}
+          placeholder={t(getCorrectPlaceholderKey(selectedSearchType))}
           value={inputValue}
           onChange={(event) => setInputValue(event.target.value)}
           sx={{ flex: 1, bgcolor: 'white' }}
@@ -73,20 +87,20 @@ export const SearchSection = () => {
           data-testid={dataTestId.frontPage.searchButton}
           startIcon={<SearchIcon />}
           aria-label={t('common.search')}>
-          {t('common.search').toUpperCase()}
+          {t('common.search')}
         </Button>
       </Box>
-      <Button
-        variant="text"
-        data-testid={dataTestId.frontPage.advancedSearchButton}
-        sx={{ display: 'flex', gap: '0.25rem', alignSelf: 'flex-end' }}
-        onClick={() => {
-          navigate({ pathname: UrlPathTemplate.Search });
-        }}
-        aria-label={t('go_to_advanced_search')}>
-        <Typography sx={{ color: '#120732', textDecoration: 'underline' }}>{t('go_to_advanced_search')}</Typography>
-        <EastIcon sx={{ fontSize: '1.25rem' }} />
-      </Button>
+      {selectedSearchType === SearchTypeValue.Result && (
+        <Link
+          component={RouterLink}
+          data-testid={dataTestId.frontPage.advancedSearchLink}
+          to={UrlPathTemplate.Search}
+          aria-label={t('go_to_advanced_search')}
+          sx={{ display: 'flex', gap: '0.25rem', alignSelf: 'flex-end' }}>
+          <Typography sx={{ color: '#120732', textDecoration: 'underline' }}>{t('go_to_advanced_search')}</Typography>
+          <EastIcon />
+        </Link>
+      )}
     </Box>
   );
 };

--- a/src/pages/search/SearchTypeDropdown.tsx
+++ b/src/pages/search/SearchTypeDropdown.tsx
@@ -19,10 +19,10 @@ export enum SearchTypeValue {
 
 interface SearchTypeDropdownProps extends Pick<TextFieldProps, 'sx'> {
   selectedValue: SearchTypeValue;
-  setSelectedSearchType: (searchType: SearchTypeValue) => void;
+  onSearchTypeChanged: (searchType: SearchTypeValue) => void;
 }
 
-export const SearchTypeDropdown = ({ sx = {}, selectedValue, setSelectedSearchType }: SearchTypeDropdownProps) => {
+export const SearchTypeDropdown = ({ sx = {}, selectedValue, onSearchTypeChanged }: SearchTypeDropdownProps) => {
   const { t } = useTranslation();
   return (
     <TextField
@@ -41,7 +41,7 @@ export const SearchTypeDropdown = ({ sx = {}, selectedValue, setSelectedSearchTy
         ...sx,
       }}
       slotProps={{ htmlInput: { 'aria-label': t('common.type') } }}
-      onChange={(event) => setSelectedSearchType(event.target.value as SearchTypeValue)}>
+      onChange={(event) => onSearchTypeChanged(event.target.value as SearchTypeValue)}>
       <StyledMenuItem value={SearchTypeValue.Result}>
         <NotesIcon fontSize="small" />
         {t('search.result')}

--- a/src/pages/search/SearchTypeDropdown.tsx
+++ b/src/pages/search/SearchTypeDropdown.tsx
@@ -1,9 +1,15 @@
 import NotesIcon from '@mui/icons-material/Notes';
 import PersonIcon from '@mui/icons-material/Person';
 import ShowChartIcon from '@mui/icons-material/ShowChart';
-import { MenuItem, TextField, TextFieldProps } from '@mui/material';
+import { MenuItem, styled, TextField, TextFieldProps } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { dataTestId } from '../../utils/dataTestIds';
+
+const StyledMenuItem = styled(MenuItem)({
+  display: 'flex',
+  gap: '0.5rem',
+  alignItems: 'center',
+});
 
 export enum SearchTypeValue {
   Result = 'registration',
@@ -44,24 +50,15 @@ export const SearchTypeDropdown = ({
         ...sx,
       }}
       slotProps={{ htmlInput: { 'aria-label': t('common.type') } }}>
-      <MenuItem
-        sx={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}
-        value={SearchTypeValue.Result}
-        onClick={onSelectResult}>
+      <StyledMenuItem value={SearchTypeValue.Result} onClick={onSelectResult}>
         <NotesIcon fontSize="small" />
         {t('search.result')}
-      </MenuItem>
-      <MenuItem
-        sx={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}
-        value={SearchTypeValue.Person}
-        onClick={onSelectPerson}>
+      </StyledMenuItem>
+      <MenuItem value={SearchTypeValue.Person} onClick={onSelectPerson}>
         <PersonIcon fontSize="small" />
         {t('search.persons')}
       </MenuItem>
-      <MenuItem
-        sx={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}
-        value={SearchTypeValue.Project}
-        onClick={onSelectProject}>
+      <MenuItem value={SearchTypeValue.Project} onClick={onSelectProject}>
         <ShowChartIcon fontSize="small" />
         {t('project.project')}
       </MenuItem>

--- a/src/pages/search/SearchTypeDropdown.tsx
+++ b/src/pages/search/SearchTypeDropdown.tsx
@@ -19,20 +19,11 @@ export enum SearchTypeValue {
 
 interface SearchTypeDropdownProps extends Pick<TextFieldProps, 'sx'> {
   selectedValue: SearchTypeValue;
-  onSelectResult: () => void;
-  onSelectPerson: () => void;
-  onSelectProject: () => void;
+  setSelectedSearchType: (searchType: SearchTypeValue) => void;
 }
 
-export const SearchTypeDropdown = ({
-  sx = {},
-  selectedValue,
-  onSelectResult,
-  onSelectPerson,
-  onSelectProject,
-}: SearchTypeDropdownProps) => {
+export const SearchTypeDropdown = ({ sx = {}, selectedValue, setSelectedSearchType }: SearchTypeDropdownProps) => {
   const { t } = useTranslation();
-
   return (
     <TextField
       select
@@ -49,16 +40,17 @@ export const SearchTypeDropdown = ({
         },
         ...sx,
       }}
-      slotProps={{ htmlInput: { 'aria-label': t('common.type') } }}>
-      <StyledMenuItem value={SearchTypeValue.Result} onClick={onSelectResult}>
+      slotProps={{ htmlInput: { 'aria-label': t('common.type') } }}
+      onChange={(event) => setSelectedSearchType(event.target.value as SearchTypeValue)}>
+      <StyledMenuItem value={SearchTypeValue.Result}>
         <NotesIcon fontSize="small" />
         {t('search.result')}
       </StyledMenuItem>
-      <MenuItem value={SearchTypeValue.Person} onClick={onSelectPerson}>
+      <MenuItem value={SearchTypeValue.Person}>
         <PersonIcon fontSize="small" />
         {t('search.persons')}
       </MenuItem>
-      <MenuItem value={SearchTypeValue.Project} onClick={onSelectProject}>
+      <MenuItem value={SearchTypeValue.Project}>
         <ShowChartIcon fontSize="small" />
         {t('project.project')}
       </MenuItem>

--- a/src/pages/search/SearchTypeField.tsx
+++ b/src/pages/search/SearchTypeField.tsx
@@ -40,28 +40,26 @@ export const SearchTypeField = ({ sx = {} }: Pick<TextFieldProps, 'sx'>) => {
       sx={sx}
       selectedValue={paramsSearchType}
       setSelectedSearchType={(searchType) => {
+        const searchParams = new URLSearchParams();
         if (searchType === SearchTypeValue.Result && !resultIsSelected) {
-          const resultParams = new URLSearchParams();
           const searchTerm = getSyncedSearchTerm(params, paramsSearchType);
           if (searchTerm) {
-            resultParams.set(ResultParam.Query, searchTerm);
+            searchParams.set(ResultParam.Query, searchTerm);
           }
-          navigate({ search: resultParams.toString() });
         } else if (searchType === SearchTypeValue.Person && !personIsSelected) {
-          const personParams = new URLSearchParams({ [SearchParam.Type]: SearchTypeValue.Person });
+          searchParams.set(SearchParam.Type, SearchTypeValue.Person);
           const searchTerm = getSyncedSearchTerm(params, paramsSearchType);
           if (searchTerm) {
-            personParams.set(PersonSearchParameter.Name, searchTerm);
+            searchParams.set(PersonSearchParameter.Name, searchTerm);
           }
-          navigate({ search: personParams.toString() });
         } else if (searchType === SearchTypeValue.Project && !projectIsSelected) {
-          const projectParams = new URLSearchParams({ [SearchParam.Type]: SearchTypeValue.Project });
+          searchParams.set(SearchParam.Type, SearchTypeValue.Project);
           const searchTerm = getSyncedSearchTerm(params, paramsSearchType);
           if (searchTerm) {
-            projectParams.set(ProjectSearchParameter.Query, searchTerm);
+            searchParams.set(ProjectSearchParameter.Query, searchTerm);
           }
-          navigate({ search: projectParams.toString() });
         }
+        navigate({ search: searchParams.toString() });
       }}
     />
   );

--- a/src/pages/search/SearchTypeField.tsx
+++ b/src/pages/search/SearchTypeField.tsx
@@ -35,46 +35,34 @@ export const SearchTypeField = ({ sx = {} }: Pick<TextFieldProps, 'sx'>) => {
   const personIsSelected = paramsSearchType === SearchTypeValue.Person;
   const projectIsSelected = paramsSearchType === SearchTypeValue.Project;
 
-  const onSelectResult = () => {
-    if (!resultIsSelected) {
-      const resultParams = new URLSearchParams();
-      const searchTerm = getSyncedSearchTerm(params, paramsSearchType);
-      if (searchTerm) {
-        resultParams.set(ResultParam.Query, searchTerm);
-      }
-      navigate({ search: resultParams.toString() });
-    }
-  };
-
-  const onSelectPerson = () => {
-    if (!personIsSelected) {
-      const personParams = new URLSearchParams({ [SearchParam.Type]: SearchTypeValue.Person });
-      const searchTerm = getSyncedSearchTerm(params, paramsSearchType);
-      if (searchTerm) {
-        personParams.set(PersonSearchParameter.Name, searchTerm);
-      }
-      navigate({ search: personParams.toString() });
-    }
-  };
-
-  const onSelectProject = () => {
-    if (!projectIsSelected) {
-      const projectParams = new URLSearchParams({ [SearchParam.Type]: SearchTypeValue.Project });
-      const searchTerm = getSyncedSearchTerm(params, paramsSearchType);
-      if (searchTerm) {
-        projectParams.set(ProjectSearchParameter.Query, searchTerm);
-      }
-      navigate({ search: projectParams.toString() });
-    }
-  };
-
   return (
     <SearchTypeDropdown
       sx={sx}
       selectedValue={paramsSearchType}
-      onSelectResult={onSelectResult}
-      onSelectPerson={onSelectPerson}
-      onSelectProject={onSelectProject}
+      setSelectedSearchType={(searchType) => {
+        if (searchType === SearchTypeValue.Result && !resultIsSelected) {
+          const resultParams = new URLSearchParams();
+          const searchTerm = getSyncedSearchTerm(params, paramsSearchType);
+          if (searchTerm) {
+            resultParams.set(ResultParam.Query, searchTerm);
+          }
+          navigate({ search: resultParams.toString() });
+        } else if (searchType === SearchTypeValue.Person && !personIsSelected) {
+          const personParams = new URLSearchParams({ [SearchParam.Type]: SearchTypeValue.Person });
+          const searchTerm = getSyncedSearchTerm(params, paramsSearchType);
+          if (searchTerm) {
+            personParams.set(PersonSearchParameter.Name, searchTerm);
+          }
+          navigate({ search: personParams.toString() });
+        } else if (searchType === SearchTypeValue.Project && !projectIsSelected) {
+          const projectParams = new URLSearchParams({ [SearchParam.Type]: SearchTypeValue.Project });
+          const searchTerm = getSyncedSearchTerm(params, paramsSearchType);
+          if (searchTerm) {
+            projectParams.set(ProjectSearchParameter.Query, searchTerm);
+          }
+          navigate({ search: projectParams.toString() });
+        }
+      }}
     />
   );
 };

--- a/src/pages/search/SearchTypeField.tsx
+++ b/src/pages/search/SearchTypeField.tsx
@@ -39,7 +39,7 @@ export const SearchTypeField = ({ sx = {} }: Pick<TextFieldProps, 'sx'>) => {
     <SearchTypeDropdown
       sx={sx}
       selectedValue={paramsSearchType}
-      setSelectedSearchType={(searchType) => {
+      onSearchTypeChanged={(searchType) => {
         const searchParams = new URLSearchParams();
         if (searchType === SearchTypeValue.Result && !resultIsSelected) {
           const searchTerm = getSyncedSearchTerm(params, paramsSearchType);

--- a/src/utils/dataTestIds.ts
+++ b/src/utils/dataTestIds.ts
@@ -814,7 +814,7 @@ export const dataTestId = {
     unpublishJustificationTextField: 'unpublish-registration-justification-textfield',
   },
   frontPage: {
-    advancedSearchButton: 'front-page-advanced-search-button',
+    advancedSearchLink: 'front-page-advanced-search-link',
     searchButton: 'front-page-search-button',
     searchInputField: 'front-page-search-input-field',
   },


### PR DESCRIPTION
Forslag til endring i https://github.com/BIBSYSDEV/NVA-Frontend/pull/7751

Slår sammen separate `onClick`s for hvert menu item til at det håndteres on `onChange` i selve `TextField`. Vil begrense hvor mange ganger vi oppretter nye funksjoner på hver render