### PR TITLE
Add NVA description section to front page and update translations

### DIFF
--- a/src/components/atoms/PersonIcon.tsx
+++ b/src/components/atoms/PersonIcon.tsx
@@ -1,0 +1,5 @@
+import PersonIconMui from '@mui/icons-material/Person';
+
+export const PersonIcon = () => {
+  return <PersonIconMui sx={{ bgcolor: 'person.main', borderRadius: '0.4rem', color: 'black' }} />;
+};

--- a/src/components/atoms/RegistrationIcon.tsx
+++ b/src/components/atoms/RegistrationIcon.tsx
@@ -1,0 +1,5 @@
+import NotesIcon from '@mui/icons-material/Notes';
+
+export const RegistrationIcon = () => {
+  return <NotesIcon sx={{ bgcolor: 'registration.main', borderRadius: '0.4rem', color: 'black' }} />;
+};

--- a/src/components/styled/Wrappers.tsx
+++ b/src/components/styled/Wrappers.tsx
@@ -1,4 +1,4 @@
-import { Box, FormGroup, ListItem, ListItemProps, styled, Typography, TypographyProps } from '@mui/material';
+import { Box, BoxProps, FormGroup, ListItem, ListItemProps, styled, Typography, TypographyProps } from '@mui/material';
 
 export const StyledRightAlignedFooter = styled(Box)({
   display: 'flex',
@@ -138,4 +138,9 @@ export const StyledContributorModalActions = styled(Box)(({ theme }) => ({
   justifyContent: 'space-between',
   marginTop: '2rem',
   gap: '1rem',
+}));
+
+export const VerticalBox = styled(Box)<BoxProps>(() => ({
+  display: 'flex',
+  flexDirection: 'column',
 }));

--- a/src/pages/frontpage/FrontPage.tsx
+++ b/src/pages/frontpage/FrontPage.tsx
@@ -1,11 +1,13 @@
 import { FrontPageHeading } from './FrontPageHeading';
 import { StyledPageContent } from '../../components/styled/Wrappers';
 import { SearchSection } from './SearchSection';
+import { NVADescriptionSection } from './NVADescriptionSection';
 
 const FrontPage = () => (
   <StyledPageContent sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '2rem' }}>
     <FrontPageHeading />
     <SearchSection />
+    <NVADescriptionSection />
   </StyledPageContent>
 );
 

--- a/src/pages/frontpage/FrontPageHeading.tsx
+++ b/src/pages/frontpage/FrontPageHeading.tsx
@@ -1,15 +1,16 @@
-import { Box, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { VerticalBox } from '../../components/styled/Wrappers';
 
 export const FrontPageHeading = () => {
   const { t } = useTranslation();
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1.5rem', mt: '3rem' }}>
-      <Typography variant="h1" sx={{ fontSize: '3rem', color: '#120732' }}>
+    <VerticalBox sx={{ gap: '1.5rem', mt: '3rem', mb: '1rem' }}>
+      <Typography component="h1" variant="h1" sx={{ fontSize: '3rem', color: '#120732' }}>
         {t('common.page_title')}
       </Typography>
       <Typography sx={{ fontSize: '1rem' }}>{t('search_in_national_research_publication')}</Typography>
-    </Box>
+    </VerticalBox>
   );
 };

--- a/src/pages/frontpage/NVADescriptionSection.tsx
+++ b/src/pages/frontpage/NVADescriptionSection.tsx
@@ -1,0 +1,29 @@
+import { Box, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { TypeCard } from './TypeCard';
+import { FrontPageBox } from './styles';
+import { SearchTypeValue } from '../search/SearchTypeDropdown';
+
+export const NVADescriptionSection = () => {
+  const { t } = useTranslation();
+  return (
+    <FrontPageBox sx={{ bgcolor: 'white', alignItems: 'center' }}>
+      <Typography component="h2" variant="h2" sx={{ fontSize: '1.5rem', color: '#120732' }}>
+        {t('frontpage_box_what_is_in_NVA')}
+      </Typography>
+      <Typography sx={{ color: '#120732' }}>{t('frontpage_box_NVA_collects_norwegian_science')}</Typography>
+      <Typography sx={{ color: '#120732' }}>{t('frontpage_box_NVA_explore_publications')}</Typography>
+      <Box
+        sx={{
+          display: 'flex',
+          width: '100%',
+          gap: { xs: '1rem', sm: '0.5rem', md: '2rem' },
+          flexDirection: { xs: 'column', sm: 'row' },
+        }}>
+        <TypeCard type={SearchTypeValue.Project}></TypeCard>
+        <TypeCard type={SearchTypeValue.Result}></TypeCard>
+        <TypeCard type={SearchTypeValue.Person}></TypeCard>
+      </Box>
+    </FrontPageBox>
+  );
+};

--- a/src/pages/frontpage/SearchSection.tsx
+++ b/src/pages/frontpage/SearchSection.tsx
@@ -12,6 +12,7 @@ import { SearchTypeDropdown, SearchTypeValue } from '../search/SearchTypeDropdow
 import { ResultParam } from '../../api/searchApi';
 import { PersonSearchParameter, ProjectSearchParameter } from '../../api/cristinApi';
 import { SearchParam } from '../../utils/searchHelpers';
+import { FrontPageBox } from './styles';
 
 const getSearchParams = (inputValue: string, searchType: SearchTypeValue) => {
   const searchParams = new URLSearchParams();
@@ -57,17 +58,7 @@ export const SearchSection = () => {
   };
 
   return (
-    <Box
-      component="search"
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '0.75rem',
-        width: '100%',
-        bgcolor: '#D9D9D9',
-        borderRadius: '1rem',
-        p: '2rem 3rem',
-      }}>
+    <FrontPageBox component="search" sx={{ bgcolor: '#D9D9D9' }}>
       <Box
         sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, gap: '0.75rem' }}
         component="form"
@@ -104,6 +95,6 @@ export const SearchSection = () => {
           <EastIcon />
         </Link>
       )}
-    </Box>
+    </FrontPageBox>
   );
 };

--- a/src/pages/frontpage/TypeCard.tsx
+++ b/src/pages/frontpage/TypeCard.tsx
@@ -1,0 +1,45 @@
+import { useTranslation } from 'react-i18next';
+import { Typography } from '@mui/material';
+import { FrontPageBox } from './styles';
+import { SearchTypeValue } from '../search/SearchTypeDropdown';
+import { ProjectIcon } from '../../components/atoms/ProjectIcon';
+import { RegistrationIcon } from '../../components/atoms/RegistrationIcon';
+import { PersonIcon } from '../../components/atoms/PersonIcon';
+import { TFunction } from 'i18next';
+
+const renderText = (type: SearchTypeValue, t: TFunction<'translation'>) => {
+  switch (type) {
+    case SearchTypeValue.Person:
+      return t('person_profiles');
+    case SearchTypeValue.Project:
+      return t('projects');
+    case SearchTypeValue.Result:
+      return t('results');
+    default:
+      return t('results');
+  }
+};
+
+interface TypeCardProps {
+  type: SearchTypeValue;
+}
+
+export const TypeCard = ({ type }: TypeCardProps) => {
+  const { t } = useTranslation();
+  const icon =
+    type === SearchTypeValue.Person ? (
+      <PersonIcon />
+    ) : type === SearchTypeValue.Project ? (
+      <ProjectIcon />
+    ) : (
+      <RegistrationIcon />
+    );
+
+  return (
+    <FrontPageBox sx={{ flex: '1', bgcolor: '#EFEFEF', alignItems: 'center', p: '1.5rem' }}>
+      {icon}
+      <Typography sx={{ fontSize: '1rem', fontWeight: 'bold' }}>{(47783).toLocaleString('nb-NO')}</Typography>
+      <Typography sx={{ fontSize: '0.8rem', textDecoration: 'underline' }}>{renderText(type, t)}</Typography>
+    </FrontPageBox>
+  );
+};

--- a/src/pages/frontpage/styles.ts
+++ b/src/pages/frontpage/styles.ts
@@ -1,0 +1,9 @@
+import { BoxProps, styled } from '@mui/material';
+import { VerticalBox } from '../../components/styled/Wrappers';
+
+export const FrontPageBox = styled(VerticalBox)<BoxProps>(() => ({
+  gap: '0.75rem',
+  width: '100%',
+  borderRadius: '1rem',
+  padding: '2rem 3rem',
+}));

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -2288,5 +2288,11 @@
   "vocabulary_missing": "Institusjonen har ikke lagt til vokabular.",
   "you_cannot_upload_files_to_this_result": "Du har ikke tilgang til å laste opp filer for dette resultatet.",
   "you_do_not_have_permission_to_edit_this_registration": "Du har ikke tilgang til å endre denne registreringen.",
-  "go_to_advanced_search": "Gå til avansert resultatsøk"
+  "go_to_advanced_search": "Gå til avansert resultatsøk",
+  "frontpage_box_what_is_in_NVA": "Hva finner du i NVA?",
+  "frontpage_box_NVA_collects_norwegian_science": "Nasjonalt Vitenarkiv (NVA) samler og gjør tilgjengelig informasjon om norsk forskning.",
+  "frontpage_box_NVA_explore_publications": "Her kan du utforske publikasjoner, forskningsprosjekt og forskere på tvers av universiteter, høyskoler og forskningsinstitusjoner.",
+  "projects": "Prosjekter",
+  "results": "Forskningsresultater",
+  "person_profiles": "Personprofiler"
 }


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-49803](https://sikt.atlassian.net/browse/NP-49803)

Legger til en "Hva finner du i NVA?"-boks til den nye forsiden:

<img width="914" height="843" alt="image" src="https://github.com/user-attachments/assets/2762a1dd-2893-4115-8a6a-839253e83c16" />

# How to test

Affected part of the application: [New front page](http://localhost:3000/new-front-page)

Den nye seksjonen er midt på forsiden. Den er implementert slik at hver av de tre typene har sitt eget kort, og disse henter tallet sitt gjennom et async kall som bruker useEffect for å hindre at kallet blir gjort hver gang den rendres. Er dette beste måte?

I smalere view blir mellomrommet mellom kortene mindre, og i mobilvire blir det kolonne istedet for rad.

# Checklist

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [] The changes are tested OK for a11y
- [] Interactive elements have data-testids
- [x] I have done a QA of my own changes
