### PR TITLE
Fix responsiveness of NVI search filters

### DIFF
--- a/src/pages/messages/components/NviStatusPage.tsx
+++ b/src/pages/messages/components/NviStatusPage.tsx
@@ -37,7 +37,7 @@ export const NviStatusPage = () => {
       <Typography variant="h1">{t('tasks.nvi.institution_nvi_status')}</Typography>
 
       <Box sx={{ width: '100%', display: 'flex', justifyContent: 'space-between', gap: '1rem' }}>
-        <NviYearSelector />
+        <NviYearSelector sx={{ minWidth: '10rem' }} />
         <ExportNviStatusButton />
       </Box>
 

--- a/src/pages/messages/components/NviYearSelector.tsx
+++ b/src/pages/messages/components/NviYearSelector.tsx
@@ -33,7 +33,6 @@ export const NviYearSelector = (props: Pick<TextFieldProps, 'fullWidth'>) => {
         }
         navigate({ search: syncedParams.toString() });
       }}
-      sx={{ minWidth: '10rem' }}
       {...props}>
       {nviYearFilterValues.map((year) => (
         <MenuItem key={year} value={year}>

--- a/src/pages/messages/components/NviYearSelector.tsx
+++ b/src/pages/messages/components/NviYearSelector.tsx
@@ -9,7 +9,7 @@ import { syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 
 const nviYearFilterValues = getNviYearFilterValues(new Date().getFullYear() + 1);
 
-export const NviYearSelector = (props: Pick<TextFieldProps, 'fullWidth'>) => {
+export const NviYearSelector = (props: Partial<TextFieldProps>) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();


### PR DESCRIPTION
# Description

Fikser responsiviteten på NVI-søk, da noen filter nå kan strekke seg ut av skjermen ved noen oppløsninger

# How to test

Affected part of the application: http://localhost:3000/tasks/nvi

Før:
<img width="1472" height="196" alt="bilde" src="https://github.com/user-attachments/assets/f3f46594-f82d-4a92-ba43-cb314a6cd4e2" />

Etter:
<img width="1472" height="192" alt="bilde" src="https://github.com/user-attachments/assets/0b7a8c74-b22a-46d0-b662-bed4644faa76" />


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
