### PR TITLE
Np 49851 sync channel id with selected year

### DIFF
--- a/src/pages/registration/description_tab/DatePickerField.tsx
+++ b/src/pages/registration/description_tab/DatePickerField.tsx
@@ -34,7 +34,10 @@ export const DatePickerField = () => {
   const disabled = disableNviCriticalFields || disableChannelClaimsFields;
 
   const syncChannelIdsWithYear = (newYear: string) => {
-    const publicationContext = entityDescription?.reference?.publicationContext ?? {};
+    const publicationContext = entityDescription?.reference?.publicationContext;
+    if (!publicationContext) {
+      return;
+    }
 
     const journalId = 'id' in publicationContext ? publicationContext.id : null;
     if (journalId && !journalId.endsWith(newYear)) {

--- a/src/pages/registration/description_tab/DatePickerField.tsx
+++ b/src/pages/registration/description_tab/DatePickerField.tsx
@@ -5,7 +5,7 @@ import { useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StyledInfoBanner } from '../../../components/styled/Wrappers';
 import { RegistrationFormContext } from '../../../context/RegistrationFormContext';
-import { DescriptionFieldNames } from '../../../types/publicationFieldNames';
+import { DescriptionFieldNames, ResourceFieldNames } from '../../../types/publicationFieldNames';
 import { EntityDescription, Registration, RegistrationDate } from '../../../types/registration.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { getRegistrationDate } from '../../../utils/date-helpers';
@@ -36,6 +36,30 @@ export const DatePickerField = () => {
       month: !isYearOnly && newDate ? (newDate.getMonth() + 1).toString() : '',
       day: !isYearOnly && newDate ? newDate.getDate().toString() : '',
     };
+
+    const yearIsChanged = updatedDate.year !== dateData?.year;
+    if (yearIsChanged) {
+      const publicationContext = entityDescription?.reference?.publicationContext ?? {};
+
+      const journalId = 'id' in publicationContext ? publicationContext.id : null;
+      if (journalId && !journalId.endsWith(updatedDate.year)) {
+        const updatedJournalId = journalId.replace(/\d{4}$/, updatedDate.year);
+        setFieldValue(ResourceFieldNames.PublicationContextId, updatedJournalId);
+      }
+
+      const publisherId = 'publisher' in publicationContext ? publicationContext.publisher?.id : null;
+      if (publisherId && !publisherId.endsWith(updatedDate.year)) {
+        const updatedPublisherId = publisherId.replace(/\d{4}$/, updatedDate.year);
+        setFieldValue(ResourceFieldNames.PublicationContextPublisherId, updatedPublisherId);
+      }
+
+      const seriesId = 'series' in publicationContext ? publicationContext.series?.id : null;
+      if (seriesId && !seriesId.endsWith(updatedDate.year)) {
+        const updatedSeriesId = seriesId.replace(/\d{4}$/, updatedDate.year);
+        setFieldValue(ResourceFieldNames.SeriesId, updatedSeriesId);
+      }
+    }
+
     setFieldValue(DescriptionFieldNames.PublicationDate, updatedDate);
   };
 

--- a/src/pages/registration/description_tab/DatePickerField.tsx
+++ b/src/pages/registration/description_tab/DatePickerField.tsx
@@ -11,6 +11,10 @@ import { dataTestId } from '../../../utils/dataTestIds';
 import { getRegistrationDate } from '../../../utils/date-helpers';
 import { LockedNviFieldDescription } from '../LockedNviFieldDescription';
 
+const replaceYearInId = (id: string, newYear: string) => {
+  return id.replace(/\d{4}$/, newYear);
+};
+
 export const DatePickerField = () => {
   const { t } = useTranslation();
   const {
@@ -43,19 +47,19 @@ export const DatePickerField = () => {
 
       const journalId = 'id' in publicationContext ? publicationContext.id : null;
       if (journalId && !journalId.endsWith(updatedDate.year)) {
-        const updatedJournalId = journalId.replace(/\d{4}$/, updatedDate.year);
+        const updatedJournalId = replaceYearInId(journalId, updatedDate.year);
         setFieldValue(ResourceFieldNames.PublicationContextId, updatedJournalId);
       }
 
       const publisherId = 'publisher' in publicationContext ? publicationContext.publisher?.id : null;
       if (publisherId && !publisherId.endsWith(updatedDate.year)) {
-        const updatedPublisherId = publisherId.replace(/\d{4}$/, updatedDate.year);
+        const updatedPublisherId = replaceYearInId(publisherId, updatedDate.year);
         setFieldValue(ResourceFieldNames.PublicationContextPublisherId, updatedPublisherId);
       }
 
       const seriesId = 'series' in publicationContext ? publicationContext.series?.id : null;
       if (seriesId && !seriesId.endsWith(updatedDate.year)) {
-        const updatedSeriesId = seriesId.replace(/\d{4}$/, updatedDate.year);
+        const updatedSeriesId = replaceYearInId(seriesId, updatedDate.year);
         setFieldValue(ResourceFieldNames.SeriesId, updatedSeriesId);
       }
     }

--- a/src/pages/registration/description_tab/DatePickerField.tsx
+++ b/src/pages/registration/description_tab/DatePickerField.tsx
@@ -33,6 +33,28 @@ export const DatePickerField = () => {
   const { disableNviCriticalFields, disableChannelClaimsFields } = useContext(RegistrationFormContext);
   const disabled = disableNviCriticalFields || disableChannelClaimsFields;
 
+  const syncChannelIdsWithYear = (newYear: string) => {
+    const publicationContext = entityDescription?.reference?.publicationContext ?? {};
+
+    const journalId = 'id' in publicationContext ? publicationContext.id : null;
+    if (journalId && !journalId.endsWith(newYear)) {
+      const updatedJournalId = replaceYearInId(journalId, newYear);
+      setFieldValue(ResourceFieldNames.PublicationContextId, updatedJournalId);
+    }
+
+    const publisherId = 'publisher' in publicationContext ? publicationContext.publisher?.id : null;
+    if (publisherId && !publisherId.endsWith(newYear)) {
+      const updatedPublisherId = replaceYearInId(publisherId, newYear);
+      setFieldValue(ResourceFieldNames.PublicationContextPublisherId, updatedPublisherId);
+    }
+
+    const seriesId = 'series' in publicationContext ? publicationContext.series?.id : null;
+    if (seriesId && !seriesId.endsWith(newYear)) {
+      const updatedSeriesId = replaceYearInId(seriesId, newYear);
+      setFieldValue(ResourceFieldNames.SeriesId, updatedSeriesId);
+    }
+  };
+
   const updateDateValues = (newDate: Date | null, isYearOnly: boolean) => {
     const updatedDate: RegistrationDate = {
       type: 'PublicationDate',
@@ -43,25 +65,7 @@ export const DatePickerField = () => {
 
     const yearIsChanged = updatedDate.year !== dateData?.year;
     if (yearIsChanged) {
-      const publicationContext = entityDescription?.reference?.publicationContext ?? {};
-
-      const journalId = 'id' in publicationContext ? publicationContext.id : null;
-      if (journalId && !journalId.endsWith(updatedDate.year)) {
-        const updatedJournalId = replaceYearInId(journalId, updatedDate.year);
-        setFieldValue(ResourceFieldNames.PublicationContextId, updatedJournalId);
-      }
-
-      const publisherId = 'publisher' in publicationContext ? publicationContext.publisher?.id : null;
-      if (publisherId && !publisherId.endsWith(updatedDate.year)) {
-        const updatedPublisherId = replaceYearInId(publisherId, updatedDate.year);
-        setFieldValue(ResourceFieldNames.PublicationContextPublisherId, updatedPublisherId);
-      }
-
-      const seriesId = 'series' in publicationContext ? publicationContext.series?.id : null;
-      if (seriesId && !seriesId.endsWith(updatedDate.year)) {
-        const updatedSeriesId = replaceYearInId(seriesId, updatedDate.year);
-        setFieldValue(ResourceFieldNames.SeriesId, updatedSeriesId);
-      }
+      syncChannelIdsWithYear(updatedDate.year);
     }
 
     setFieldValue(DescriptionFieldNames.PublicationDate, updatedDate);


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-49851

Unngå feil hvor et resultat har koblinger til kanaler med andre år enn året resultatet er publisert.

# How to test

1. Åpne nytt resultat i wizard
2. Gå til kategori-fanen og sett en kanal (tidsskrift, utgiver, eller serie)
3. Gå til beskrivelse-fanen og sett et vilkårlig årstall som publiseringsdato
4. Lagre og sjekk oppdatert resultat i nettverksloggen
5. `entityDescription.publicationDate.year` må samsvare med siste del av kanal-ID for at NVI-rapportering skal bli riktig. 
Kanal-ID kan være `publicationContext.id` (tidsskrift), `publicationContext.publisher.id` (utgiver), eller `publicationContext.series.id` (serie) avhengig av hvilken type det er
 

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
