### PR TITLE
Number of hits for each of the main search sections on front page

### DIFF
--- a/src/api/hooks/useFetchProjects.tsx
+++ b/src/api/hooks/useFetchProjects.tsx
@@ -1,19 +1,21 @@
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { PersonSearchParams, searchForProjects } from '../cristinApi';
+import { ProjectsSearchParams, searchForProjects } from '../cristinApi';
 
-interface FetchProjectsOptions extends PersonSearchParams {
+interface FetchProjectsOptions extends ProjectsSearchParams {
   searchTerm?: string;
   enabled?: boolean;
+  results?: number;
+  page?: number;
 }
 
-export const useFetchProjects = ({ searchTerm = '', enabled = true }: FetchProjectsOptions) => {
+export const useFetchProjects = ({ searchTerm = '', enabled = true, results = 10, page = 1 }: FetchProjectsOptions) => {
   const { t } = useTranslation();
 
   return useQuery({
     enabled: enabled,
-    queryKey: ['projects', 10, 1, searchTerm],
-    queryFn: () => searchForProjects(10, 1, { query: searchTerm }),
+    queryKey: ['projects', results, page, searchTerm],
+    queryFn: () => searchForProjects(results, page, { query: searchTerm }),
     meta: { errorMessage: t('feedback.error.project_search') },
   });
 };

--- a/src/api/hooks/useFetchProjects.tsx
+++ b/src/api/hooks/useFetchProjects.tsx
@@ -2,11 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { searchForProjects } from '../cristinApi';
 
-export const useFetchProjects = (searchTerm: string) => {
+export const useFetchProjects = (searchTerm: string, searchEmpty?: boolean) => {
   const { t } = useTranslation();
 
   return useQuery({
-    enabled: searchTerm.length > 0,
+    enabled: searchTerm.length > 0 || searchEmpty,
     queryKey: ['projects', 10, 1, searchTerm],
     queryFn: () => searchForProjects(10, 1, { query: searchTerm }),
     meta: { errorMessage: t('feedback.error.project_search') },

--- a/src/api/hooks/useFetchProjects.tsx
+++ b/src/api/hooks/useFetchProjects.tsx
@@ -1,8 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { ProjectsSearchParams, searchForProjects } from '../cristinApi';
+import { searchForProjects } from '../cristinApi';
 
-interface FetchProjectsOptions extends ProjectsSearchParams {
+interface FetchProjectsOptions {
   searchTerm?: string;
   enabled?: boolean;
   results?: number;
@@ -13,7 +13,7 @@ export const useFetchProjects = ({ searchTerm = '', enabled = true, results = 10
   const { t } = useTranslation();
 
   return useQuery({
-    enabled: enabled,
+    enabled,
     queryKey: ['projects', results, page, searchTerm],
     queryFn: () => searchForProjects(results, page, { query: searchTerm }),
     meta: { errorMessage: t('feedback.error.project_search') },

--- a/src/api/hooks/useFetchProjects.tsx
+++ b/src/api/hooks/useFetchProjects.tsx
@@ -1,12 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { searchForProjects } from '../cristinApi';
+import { PersonSearchParams, searchForProjects } from '../cristinApi';
 
-export const useFetchProjects = (searchTerm: string, searchEmpty?: boolean) => {
+interface FetchProjectsOptions extends PersonSearchParams {
+  searchTerm?: string;
+  enabled?: boolean;
+}
+
+export const useFetchProjects = ({ searchTerm = '', enabled = true }: FetchProjectsOptions) => {
   const { t } = useTranslation();
 
   return useQuery({
-    enabled: searchTerm.length > 0 || searchEmpty,
+    enabled: enabled,
     queryKey: ['projects', 10, 1, searchTerm],
     queryFn: () => searchForProjects(10, 1, { query: searchTerm }),
     meta: { errorMessage: t('feedback.error.project_search') },

--- a/src/pages/frontpage/CategorySection.tsx
+++ b/src/pages/frontpage/CategorySection.tsx
@@ -14,7 +14,7 @@ export const CategorySection = () => {
   const { t } = useTranslation();
 
   return (
-    <FrontPageBox sx={{ bgcolor: 'white', alignItems: 'center' }}>
+    <FrontPageBox sx={{ bgcolor: 'white', alignItems: 'center', gap: '0.75rem' }}>
       <Trans
         t={t}
         i18nKey="science_categories_front_page"

--- a/src/pages/frontpage/FrontPage.tsx
+++ b/src/pages/frontpage/FrontPage.tsx
@@ -2,25 +2,15 @@ import { FrontPageHeading } from './FrontPageHeading';
 import { StyledPageContent } from '../../components/styled/Wrappers';
 import { SearchSection } from './SearchSection';
 import { NvaDescriptionSection } from './NvaDescriptionSection';
-import { Box } from '@mui/material';
 import { CategorySection } from './CategorySection';
 
 const FrontPage = () => (
-  <Box
-    sx={{
-      bgcolor: '#EFEFEF',
-      width: '100%',
-      height: '100%',
-      display: 'flex',
-      justifyContent: 'center',
-    }}>
-    <StyledPageContent sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '2rem' }}>
-      <FrontPageHeading />
-      <SearchSection />
-      <NvaDescriptionSection />
-      <CategorySection />
-    </StyledPageContent>
-  </Box>
+  <StyledPageContent sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '2rem' }}>
+    <FrontPageHeading />
+    <SearchSection />
+    <NvaDescriptionSection />
+    <CategorySection />
+  </StyledPageContent>
 );
 
 export default FrontPage;

--- a/src/pages/frontpage/FrontPage.tsx
+++ b/src/pages/frontpage/FrontPage.tsx
@@ -2,15 +2,25 @@ import { FrontPageHeading } from './FrontPageHeading';
 import { StyledPageContent } from '../../components/styled/Wrappers';
 import { SearchSection } from './SearchSection';
 import { NvaDescriptionSection } from './NvaDescriptionSection';
+import { Box } from '@mui/material';
 import { CategorySection } from './CategorySection';
 
 const FrontPage = () => (
-  <StyledPageContent sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '2rem' }}>
-    <FrontPageHeading />
-    <SearchSection />
-    <NvaDescriptionSection />
-    <CategorySection />
-  </StyledPageContent>
+  <Box
+    sx={{
+      bgcolor: '#EFEFEF',
+      width: '100%',
+      height: '100%',
+      display: 'flex',
+      justifyContent: 'center',
+    }}>
+    <StyledPageContent sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '2rem' }}>
+      <FrontPageHeading />
+      <SearchSection />
+      <NvaDescriptionSection />
+      <CategorySection />
+    </StyledPageContent>
+  </Box>
 );
 
 export default FrontPage;

--- a/src/pages/frontpage/NvaDescriptionSection.tsx
+++ b/src/pages/frontpage/NvaDescriptionSection.tsx
@@ -45,6 +45,7 @@ export const NvaDescriptionSection = () => {
           text={t('projects')}
           icon={<ProjectIcon sx={iconStyle} />}
           number={projectsQuery.data?.size}
+          hasNumber={true}
           dataTestId={dataTestId.frontPage.projectsLink}
           to={{ pathname: UrlPathTemplate.Root, search: getUrlParams(SearchParam.Type, SearchTypeValue.Project) }}
         />
@@ -52,6 +53,7 @@ export const NvaDescriptionSection = () => {
           text={t('results')}
           icon={<RegistrationIcon sx={iconStyle} />}
           number={registrationQuery.data?.totalHits}
+          hasNumber={true}
           dataTestId={dataTestId.frontPage.registrationsLink}
           to={{ pathname: UrlPathTemplate.Root }}
         />
@@ -59,6 +61,7 @@ export const NvaDescriptionSection = () => {
           text={t('person_profiles')}
           icon={<PersonIcon sx={iconStyle} />}
           number={personQuery.data?.size}
+          hasNumber={true}
           dataTestId={dataTestId.frontPage.personsLink}
           to={{ pathname: UrlPathTemplate.Root, search: getUrlParams(SearchParam.Type, SearchTypeValue.Person) }}
         />

--- a/src/pages/frontpage/NvaDescriptionSection.tsx
+++ b/src/pages/frontpage/NvaDescriptionSection.tsx
@@ -19,13 +19,9 @@ const iconStyle = { height: '2rem', width: '2rem' };
 export const NvaDescriptionSection = () => {
   const { t } = useTranslation();
 
-  const registrationQuery = useRegistrationSearch({
-    params: { aggregation: 'all' },
-  });
-
-  const personQuery = useSearchForPerson({});
-
-  const projectsQuery = useFetchProjects('', true);
+  const registrationQuery = useRegistrationSearch({ params: { aggregation: 'all', results: 0 } });
+  const personQuery = useSearchForPerson({ results: 1 });
+  const projectsQuery = useFetchProjects({});
 
   return (
     <FrontPageBox sx={{ bgcolor: 'white', alignItems: 'center', gap: '0.75rem' }}>

--- a/src/pages/frontpage/NvaDescriptionSection.tsx
+++ b/src/pages/frontpage/NvaDescriptionSection.tsx
@@ -21,7 +21,7 @@ export const NvaDescriptionSection = () => {
 
   const registrationQuery = useRegistrationSearch({ params: { aggregation: 'all', results: 0 } });
   const personQuery = useSearchForPerson({ results: 1 });
-  const projectsQuery = useFetchProjects({});
+  const projectsQuery = useFetchProjects({ results: 1 });
 
   return (
     <FrontPageBox sx={{ bgcolor: 'white', alignItems: 'center', gap: '0.75rem' }}>

--- a/src/pages/frontpage/NvaDescriptionSection.tsx
+++ b/src/pages/frontpage/NvaDescriptionSection.tsx
@@ -8,6 +8,9 @@ import { PersonIcon } from '../../components/atoms/PersonIcon';
 import { dataTestId } from '../../utils/dataTestIds';
 import { ProjectIcon } from '../../components/atoms/ProjectIcon';
 import { RegistrationIcon } from '../../components/atoms/RegistrationIcon';
+import { useRegistrationSearch } from '../../api/hooks/useRegistrationSearch';
+import { useSearchForPerson } from '../../api/hooks/useSearchForPerson';
+import { useFetchProjects } from '../../api/hooks/useFetchProjects';
 import { getUrlParams } from './utils';
 import { SearchParam } from '../../utils/searchHelpers';
 
@@ -16,8 +19,16 @@ const iconStyle = { height: '2rem', width: '2rem' };
 export const NvaDescriptionSection = () => {
   const { t } = useTranslation();
 
+  const registrationQuery = useRegistrationSearch({
+    params: { aggregation: 'all' },
+  });
+
+  const personQuery = useSearchForPerson({});
+
+  const projectsQuery = useFetchProjects('', true);
+
   return (
-    <FrontPageBox sx={{ bgcolor: 'white', alignItems: 'center' }}>
+    <FrontPageBox sx={{ bgcolor: 'white', alignItems: 'center', gap: '0.75rem' }}>
       <Trans
         t={t}
         i18nKey="what_you_find_in_nva_description"
@@ -37,18 +48,21 @@ export const NvaDescriptionSection = () => {
         <TypeCard
           text={t('projects')}
           icon={<ProjectIcon sx={iconStyle} />}
+          number={projectsQuery.data?.size}
           dataTestId={dataTestId.frontPage.projectsLink}
           to={{ pathname: UrlPathTemplate.Root, search: getUrlParams(SearchParam.Type, SearchTypeValue.Project) }}
         />
         <TypeCard
           text={t('results')}
           icon={<RegistrationIcon sx={iconStyle} />}
+          number={registrationQuery.data?.totalHits}
           dataTestId={dataTestId.frontPage.registrationsLink}
           to={{ pathname: UrlPathTemplate.Root }}
         />
         <TypeCard
           text={t('person_profiles')}
           icon={<PersonIcon sx={iconStyle} />}
+          number={personQuery.data?.size}
           dataTestId={dataTestId.frontPage.personsLink}
           to={{ pathname: UrlPathTemplate.Root, search: getUrlParams(SearchParam.Type, SearchTypeValue.Person) }}
         />

--- a/src/pages/frontpage/NvaDescriptionSection.tsx
+++ b/src/pages/frontpage/NvaDescriptionSection.tsx
@@ -45,7 +45,7 @@ export const NvaDescriptionSection = () => {
           text={t('projects')}
           icon={<ProjectIcon sx={iconStyle} />}
           number={projectsQuery.data?.size}
-          hasNumber={true}
+          isLoadingNumber={projectsQuery.isPending}
           dataTestId={dataTestId.frontPage.projectsLink}
           to={{ pathname: UrlPathTemplate.Root, search: getUrlParams(SearchParam.Type, SearchTypeValue.Project) }}
         />
@@ -53,7 +53,7 @@ export const NvaDescriptionSection = () => {
           text={t('results')}
           icon={<RegistrationIcon sx={iconStyle} />}
           number={registrationQuery.data?.totalHits}
-          hasNumber={true}
+          isLoadingNumber={registrationQuery.isPending}
           dataTestId={dataTestId.frontPage.registrationsLink}
           to={{ pathname: UrlPathTemplate.Root }}
         />
@@ -61,7 +61,7 @@ export const NvaDescriptionSection = () => {
           text={t('person_profiles')}
           icon={<PersonIcon sx={iconStyle} />}
           number={personQuery.data?.size}
-          hasNumber={true}
+          isLoadingNumber={personQuery.isPending}
           dataTestId={dataTestId.frontPage.personsLink}
           to={{ pathname: UrlPathTemplate.Root, search: getUrlParams(SearchParam.Type, SearchTypeValue.Person) }}
         />

--- a/src/pages/frontpage/SearchSection.tsx
+++ b/src/pages/frontpage/SearchSection.tsx
@@ -58,7 +58,7 @@ export const SearchSection = () => {
   };
 
   return (
-    <FrontPageBox component="search" sx={{ bgcolor: '#D9D9D9' }}>
+    <FrontPageBox component="search" sx={{ bgcolor: '#D9D9D9', gap: '0.75rem' }}>
       <Box
         sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, gap: '0.75rem' }}
         component="form"

--- a/src/pages/frontpage/TypeCard.tsx
+++ b/src/pages/frontpage/TypeCard.tsx
@@ -1,28 +1,38 @@
-import { Box, Link, LinkProps, Typography } from '@mui/material';
+import { Link, LinkProps, Typography } from '@mui/material';
 import { FrontPageBox } from './styles';
 import { Link as RouterLink, To } from 'react-router';
+import { VerticalBox } from '../../components/styled/Wrappers';
 
 interface TypeCardProps extends Pick<LinkProps, 'sx'> {
   text: string;
   icon: React.ReactNode;
   dataTestId: string;
   to: To;
+  number?: number;
 }
 
-export const TypeCard = ({ sx = {}, text, icon, dataTestId, to }: TypeCardProps) => {
+export const TypeCard = ({ sx, text, icon, dataTestId, to, number }: TypeCardProps) => {
   return (
-    <Link component={RouterLink} data-testid={dataTestId} to={to} sx={{ width: '100%', ...sx }}>
+    <Link component={RouterLink} data-testid={dataTestId} to={to} sx={{ width: '100%', textDecoration: 'none', ...sx }}>
       <FrontPageBox
         sx={{
           flex: '1',
           bgcolor: '#EFEFEF',
           alignItems: 'center',
           p: '1.5rem',
-          height: '8rem',
+          height: '9rem',
+          gap: '0.25rem',
           borderRadius: '0.5rem',
         }}>
-        <Box sx={{ flexGrow: 1, alignContent: 'center' }}>{icon}</Box>
-        <Typography sx={{ fontSize: '0.8rem', color: '#120732' }}>{text}</Typography>
+        <VerticalBox sx={{ flexGrow: 1, alignItems: 'center', justifyContent: 'center', gap: '0.5rem' }}>
+          {icon}
+          {number && (
+            <Typography sx={{ fontSize: '1.25rem', fontWeight: '900', color: '#120732' }}>
+              {number.toLocaleString('nb-NO')}
+            </Typography>
+          )}
+        </VerticalBox>
+        <Typography sx={{ fontSize: '0.8rem', textDecoration: 'underline', color: '#120732' }}>{text}</Typography>
       </FrontPageBox>
     </Link>
   );

--- a/src/pages/frontpage/TypeCard.tsx
+++ b/src/pages/frontpage/TypeCard.tsx
@@ -1,4 +1,4 @@
-import { Link, LinkProps, Typography } from '@mui/material';
+import { Link, LinkProps, Skeleton, Typography } from '@mui/material';
 import { FrontPageBox } from './styles';
 import { Link as RouterLink, To } from 'react-router';
 import { VerticalBox } from '../../components/styled/Wrappers';
@@ -9,9 +9,10 @@ interface TypeCardProps extends Pick<LinkProps, 'sx'> {
   dataTestId: string;
   to: To;
   number?: number;
+  hasNumber?: boolean;
 }
 
-export const TypeCard = ({ sx, text, icon, dataTestId, to, number }: TypeCardProps) => {
+export const TypeCard = ({ sx, text, icon, dataTestId, to, number, hasNumber }: TypeCardProps) => {
   return (
     <Link component={RouterLink} data-testid={dataTestId} to={to} sx={{ width: '100%', textDecoration: 'none', ...sx }}>
       <FrontPageBox
@@ -31,6 +32,7 @@ export const TypeCard = ({ sx, text, icon, dataTestId, to, number }: TypeCardPro
               {number.toLocaleString('nb-NO')}
             </Typography>
           )}
+          {!number && hasNumber && <Skeleton width={70} height={30} />}
         </VerticalBox>
         <Typography sx={{ fontSize: '0.8rem', textDecoration: 'underline', color: '#120732' }}>{text}</Typography>
       </FrontPageBox>

--- a/src/pages/frontpage/TypeCard.tsx
+++ b/src/pages/frontpage/TypeCard.tsx
@@ -9,10 +9,10 @@ interface TypeCardProps extends Pick<LinkProps, 'sx'> {
   dataTestId: string;
   to: To;
   number?: number;
-  hasNumber?: boolean;
+  isLoadingNumber?: boolean;
 }
 
-export const TypeCard = ({ sx, text, icon, dataTestId, to, number, hasNumber }: TypeCardProps) => {
+export const TypeCard = ({ sx, text, icon, dataTestId, to, number, isLoadingNumber }: TypeCardProps) => {
   return (
     <Link component={RouterLink} data-testid={dataTestId} to={to} sx={{ width: '100%', textDecoration: 'none', ...sx }}>
       <FrontPageBox
@@ -27,12 +27,13 @@ export const TypeCard = ({ sx, text, icon, dataTestId, to, number, hasNumber }: 
         }}>
         <VerticalBox sx={{ flexGrow: 1, alignItems: 'center', justifyContent: 'center', gap: '0.5rem' }}>
           {icon}
-          {number && (
+          {number ? (
             <Typography sx={{ fontSize: '1.25rem', fontWeight: '900', color: '#120732' }}>
               {number.toLocaleString('nb-NO')}
             </Typography>
-          )}
-          {!number && hasNumber && <Skeleton width={70} height={30} />}
+          ) : isLoadingNumber ? (
+            <Skeleton width={70} height={30} />
+          ) : null}
         </VerticalBox>
         <Typography sx={{ fontSize: '0.8rem', textDecoration: 'underline', color: '#120732' }}>{text}</Typography>
       </FrontPageBox>

--- a/src/pages/frontpage/styles.ts
+++ b/src/pages/frontpage/styles.ts
@@ -2,7 +2,6 @@ import { BoxProps, styled } from '@mui/material';
 import { VerticalBox } from '../../components/styled/Wrappers';
 
 export const FrontPageBox = styled(VerticalBox)<BoxProps>({
-  gap: '0.75rem',
   width: '100%',
   borderRadius: '1rem',
   padding: '2rem 3rem',

--- a/src/pages/project/project_wizard/RelatedProjectsField.tsx
+++ b/src/pages/project/project_wizard/RelatedProjectsField.tsx
@@ -18,7 +18,7 @@ export const RelatedProjectsField = () => {
   const [rowsPerPage, setRowsPerPage] = useState(ROWS_PER_PAGE_OPTIONS[0]);
   const [searchTerm, setSearchTerm] = useState('');
   const debouncedSearchTerm = useDebounce(searchTerm);
-  const projectsQuery = useFetchProjects(debouncedSearchTerm);
+  const projectsQuery = useFetchProjects({ searchTerm: debouncedSearchTerm, enabled: debouncedSearchTerm.length > 0 });
   const projects = projectsQuery.data?.hits ?? [];
   const paginatedProjects = values.relatedProjects.slice(rowsPerPage * (page - 1), rowsPerPage * page);
 


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-49842](https://sikt.atlassian.net/browse/NP-49842)

Insert numbers in the main search categories on the front page:

<img width="681" height="761" alt="image" src="https://github.com/user-attachments/assets/83578fd4-469b-46cc-8d65-000933a93c9c" />

# How to test

Affected part of the application: [Front page](http://localhost:3000/new-front-page)

This PR performs one search for each of the areas projects, results and persons and displays number of hits in the respective box.

Have added skeleton for when numbers load.

Also I think I takes way too long after we click a box before the page even reacts and re-routes to the search. Don't know if this is something to fix in this PR or if it is an app-issue?

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-49842]: https://sikt.atlassian.net/browse/NP-49842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ