### PR TITLE
Np 49823 use correct role icons

### DIFF
--- a/src/pages/editor/curators/OrganizationCuratorRow.tsx
+++ b/src/pages/editor/curators/OrganizationCuratorRow.tsx
@@ -1,10 +1,9 @@
-import AddLinkIcon from '@mui/icons-material/AddLink';
-import AdjustIcon from '@mui/icons-material/Adjust';
+import AddLinkOutlinedIcon from '@mui/icons-material/AddLinkOutlined';
+import AdjustOutlinedIcon from '@mui/icons-material/AdjustOutlined';
+import ChatBubbleOutlineOutlinedIcon from '@mui/icons-material/ChatBubbleOutlineOutlined';
 import EditIcon from '@mui/icons-material/Edit';
-import EventIcon from '@mui/icons-material/Event';
-import MarkEmailReadIcon from '@mui/icons-material/MarkEmailRead';
-import SchoolIcon from '@mui/icons-material/School';
-import TaskIcon from '@mui/icons-material/Task';
+import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutlined';
+import SchoolOutlinedIcon from '@mui/icons-material/SchoolOutlined';
 import { Box, IconButton, Typography } from '@mui/material';
 import { ComponentType, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -20,12 +19,12 @@ interface OrganizationCuratorRowProps extends Pick<OrganizationCuratorsProps, 'c
 }
 
 const curatorRolesConfig = [
-  { rolename: RoleName.SupportCurator, SelectedIcon: MarkEmailReadIcon },
-  { rolename: RoleName.PublishingCurator, SelectedIcon: TaskIcon },
-  { rolename: RoleName.CuratorThesis, SelectedIcon: SchoolIcon },
-  { rolename: RoleName.CuratorThesisEmbargo, SelectedIcon: EventIcon },
-  { rolename: RoleName.DoiCurator, SelectedIcon: AddLinkIcon },
-  { rolename: RoleName.NviCurator, SelectedIcon: AdjustIcon },
+  { rolename: RoleName.SupportCurator, SelectedIcon: ChatBubbleOutlineOutlinedIcon },
+  { rolename: RoleName.PublishingCurator, SelectedIcon: InsertDriveFileOutlinedIcon },
+  { rolename: RoleName.CuratorThesis, SelectedIcon: SchoolOutlinedIcon },
+  { rolename: RoleName.CuratorThesisEmbargo, SelectedIcon: SchoolOutlinedIcon },
+  { rolename: RoleName.DoiCurator, SelectedIcon: AddLinkOutlinedIcon },
+  { rolename: RoleName.NviCurator, SelectedIcon: AdjustOutlinedIcon },
 ] satisfies {
   rolename:
     | RoleName.SupportCurator

--- a/src/pages/messages/components/PublishingRequestMessagesColumn.tsx
+++ b/src/pages/messages/components/PublishingRequestMessagesColumn.tsx
@@ -2,6 +2,7 @@ import BlockIcon from '@mui/icons-material/Block';
 import CheckIcon from '@mui/icons-material/Check';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutlined';
+import SchoolOutlinedIcon from '@mui/icons-material/SchoolOutlined';
 import { Box, styled, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { ExpandedPublishingTicket, PublishingTicket } from '../../../types/publication_types/ticket.types';
@@ -41,8 +42,17 @@ export const PublishingRequestMessagesColumn = ({ ticket }: PublishingRequestMes
     <StyledMessagesContainer>
       <StyledStatusMessageBox sx={{ bgcolor: ticketStatusColor[ticket.status], width: 'fit-content' }}>
         <StyledIconAndTextWrapper>
-          <InsertDriveFileOutlinedIcon fontSize="small" />
-          <Typography color="white">{t('my_page.messages.types.PublishingRequest')}</Typography>
+          {ticket.type === 'FilesApprovalThesis' ? (
+            <>
+              <SchoolOutlinedIcon fontSize="small" />
+              <Typography color="white">{t('my_page.messages.types.FilesApprovalThesis')}</Typography>
+            </>
+          ) : (
+            <>
+              <InsertDriveFileOutlinedIcon fontSize="small" />
+              <Typography color="white">{t('my_page.messages.types.PublishingRequest')}</Typography>
+            </>
+          )}
         </StyledIconAndTextWrapper>
       </StyledStatusMessageBox>
 


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-49823

Sørg for at rikitge ikoner blir brukt for ulike roller, og at de samsvarer på ulike sider.

# How to test

https://dev.nva.sikt.no/institution/overview/curators

Før:
<img width="627" height="66" alt="bilde" src="https://github.com/user-attachments/assets/8ba6e163-7d11-47a3-8638-d4da0f06b47f" />

Etter:
<img width="622" height="62" alt="bilde" src="https://github.com/user-attachments/assets/f1e21f1c-a2c5-4f18-a90f-b363623f1b00" />

https://dev.nva.sikt.no/tasks/dialogue

Før:
<img width="1040" height="390" alt="bilde" src="https://github.com/user-attachments/assets/f2b8e2fc-d7a2-4762-a124-619760d39559" />

Etter:
<img width="1042" height="385" alt="bilde" src="https://github.com/user-attachments/assets/38ad7797-29cc-4e5c-b7fc-73b01c3a3589" />


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [ ] The changes are working as expected
- [ ] The changes are tested OK for different screen sizes
- [ ] The changes are tested OK for a11y
- [ ] Interactive elements have data-testids
- [ ] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
