### PR TITLE
NP-49806 Update header links according to new front page

### DIFF
--- a/src/layout/header/Header.tsx
+++ b/src/layout/header/Header.tsx
@@ -101,8 +101,8 @@ export const Header = () => {
             <MenuIconButton
               color="inherit"
               title={t('common.search')}
-              isSelected={location.pathname === UrlPathTemplate.Root || currentPath === UrlPathTemplate.Root}
-              to={UrlPathTemplate.Root}>
+              isSelected={currentPath === UrlPathTemplate.Filter || currentPath === UrlPathTemplate.Search}
+              to={currentPath === UrlPathTemplate.Search ? UrlPathTemplate.Search : UrlPathTemplate.Filter}>
               <SearchIcon fontSize="large" />
             </MenuIconButton>
           )}


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-49806

La "<Siktlogo> Nasjonalt Vitenarkiv" lenke til ny forside, mens Søkeikonet lenker til nye "/filter". Om man allerede står på avansert søk lar jeg søkeikon fortsatt peke til avansert søk.

# How to test
Sjekk lenker i header.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
