### PR TITLE
Fix links in ResearchProfile component to use updated URL paths

### DIFF
--- a/src/pages/research_profile/ResearchProfile.tsx
+++ b/src/pages/research_profile/ResearchProfile.tsx
@@ -1,7 +1,7 @@
 import LinkIcon from '@mui/icons-material/Link';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import PhoneEnabledIcon from '@mui/icons-material/PhoneEnabled';
-import { Box, Chip, Divider, Grid, IconButton, List, Link as MuiLink, Typography } from '@mui/material';
+import { Box, Chip, Divider, Grid, IconButton, Link as MuiLink, List, Typography } from '@mui/material';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
@@ -285,7 +285,10 @@ const ResearchProfile = () => {
         {registrationsQuery.data?.totalHits && registrationsQuery.data.totalHits > 0 ? (
           <Typography>
             <Trans i18nKey="my_page.my_profile.link_to_results_search">
-              <MuiLink component={Link} to={`/?${ResultParam.Contributor}=${encodeURIComponent(personIdentifier)}`} />
+              <MuiLink
+                component={Link}
+                to={`${UrlPathTemplate.Filter}?${ResultParam.Contributor}=${encodeURIComponent(personIdentifier)}`}
+              />
             </Trans>
           </Typography>
         ) : null}
@@ -330,7 +333,7 @@ const ResearchProfile = () => {
             <Trans t={t} i18nKey="my_page.my_profile.link_to_projects_search">
               <MuiLink
                 component={Link}
-                to={`/?${SearchParam.Type}=${SearchTypeValue.Project}&${ProjectSearchParameter.ParticipantFacet}=${encodeURIComponent(
+                to={`${UrlPathTemplate.Filter}?${SearchParam.Type}=${SearchTypeValue.Project}&${ProjectSearchParameter.ParticipantFacet}=${encodeURIComponent(
                   getIdentifierFromId(personId)
                 )}`}
               />


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-49909](https://sikt.atlassian.net/browse/NP-49909)

Two links in profile page was not updated after we re-routed the app and moved search to '/filter' and frontpage to '/'. In this PR the two links were fixed so that now they point to the search page and not the front page.

# How to test

Affected part of the application: Profile page

1) Fra startsiden, gjør et søk på person:

<img width="1447" height="388" alt="image" src="https://github.com/user-attachments/assets/74840845-50d3-4382-a76f-b8843abf7a6f" />

2) Gå inn på en av personene i søkeresultatet, men pass på å velge en som har både resultater og prosjekter knyttet til seg. Følg linkene som er markert med rødt på bildet under. Før fixen førte disse til forsiden, men nå fører de til søkesiden, som de skal:

<img width="681" height="848" alt="image" src="https://github.com/user-attachments/assets/dedb2299-cc78-4dd5-8b60-fdde874c25d2" />

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [ ] The changes are working as expected
- [ ] The changes are tested OK for different screen sizes
- [ ] The changes are tested OK for a11y
- [ ] Interactive elements have data-testids
- [ ] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
