### PR TITLE
NP-49913 Avoid infinite loading for contact point

### DIFF
--- a/src/pages/public_registration/details/DetailsPanel.tsx
+++ b/src/pages/public_registration/details/DetailsPanel.tsx
@@ -56,6 +56,7 @@ export const DetailsPanel = ({ contributors }: DetailsPanelProps) => {
   const topLevelOrgs = affiliationQueries
     .map((affiliationQuery) => (affiliationQuery.data ? getTopLevelOrganization(affiliationQuery.data) : null))
     .filter(Boolean) as Organization[];
+  const uniqueInstitutions = getUniqueOrganizations(topLevelOrgs);
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', p: '1rem', bgcolor: 'background.neutral97', gap: '0.5rem' }}>
@@ -89,7 +90,7 @@ export const DetailsPanel = ({ contributors }: DetailsPanelProps) => {
         </IconButton>
 
         <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-          <InstitutionsServiceCenterOverview institutions={getUniqueOrganizations(topLevelOrgs)} />
+          {uniqueInstitutions.length > 0 && <InstitutionsServiceCenterOverview institutions={uniqueInstitutions} />}
 
           {contactPersons.length > 0 && (
             <div>

--- a/src/pages/public_registration/details/InstitutionsServiceCenterOverview.tsx
+++ b/src/pages/public_registration/details/InstitutionsServiceCenterOverview.tsx
@@ -19,12 +19,12 @@ export const InstitutionsServiceCenterOverview = ({ institutions }: Institutions
     customers.some((customer) => customer.cristinId === institution.id && customer.serviceCenterUri)
   );
 
-  if (customersData.isPending) {
-    return <PageSpinner aria-label={t('institutions_service_support')} />;
+  if (institutions.length === 0 || institutionsWithServiceCenter.length === 0) {
+    return null;
   }
 
-  if (institutionsWithServiceCenter.length === 0) {
-    return null;
+  if (customersData.isEnabled && customersData.isPending) {
+    return <PageSpinner aria-label={t('institutions_service_support')} />;
   }
 
   return (


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-49913

Unngå evig loading når bruker skal se kontaktinformasjon for et resultat.

# How to test

Affected part of the application: https://dev.nva.sikt.no/registration/0199956ab0ae-a2009854-e384-4a23-bbe4-fa7787d7d714

1. Åpne landing page for et resultat hvor ingen bidragsytere har noen tilknytninger
2. Velg "Se kontaktinformasjon" under "Detaljer" oppe til høyre
3. Dialogen får nå en evig loading spinner før denne PRen trer i kraft

Før:
<img width="1323" height="477" alt="bilde" src="https://github.com/user-attachments/assets/7756c403-10e0-4ce1-89a1-56f472873d5a" />

Etter:
<img width="1322" height="383" alt="bilde" src="https://github.com/user-attachments/assets/086c6435-15da-4e67-a726-b9238fda5521" />


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
