### PR TITLE
NP-49914 Validate series only for categories where it is relevant

### DIFF
--- a/src/utils/validation/registration/referenceValidation.ts
+++ b/src/utils/validation/registration/referenceValidation.ts
@@ -54,8 +54,8 @@ import {
   ReportType,
   ResearchDataType,
 } from '../../../types/publicationFieldNames';
-import { ContextPublisher, PublicationChannelType } from '../../../types/registration.types';
-import { isPeriodicalMediaContribution } from '../../registration-helpers';
+import { ContextPublisher, PublicationChannelType, PublicationInstanceType } from '../../../types/registration.types';
+import { isBook, isPeriodicalMediaContribution, isReport } from '../../registration-helpers';
 import { YupShape } from '../validationHelpers';
 
 const resourceErrorMessage = {
@@ -219,11 +219,18 @@ const publisherField: Yup.ObjectSchema<ContextPublisher> = Yup.object({
   ),
 });
 
+const categoryHasSeries = (category: PublicationInstanceType) =>
+  isBook(category) || isReport(category) || category === DegreeType.Licentiate || category === DegreeType.Phd;
+
 const seriesField = Yup.object().shape({
-  id: Yup.string().test(
-    'series-test',
-    resourceErrorMessage.seriesNotSelected,
-    (idValue, context) => !context.parent.title || !!idValue
+  id: Yup.string().when('$publicationInstanceType', ([publicationInstanceType], schema) =>
+    categoryHasSeries(publicationInstanceType)
+      ? schema.test(
+          'series-test',
+          resourceErrorMessage.seriesNotSelected,
+          (idValue, context) => !context.parent.title || !!idValue
+        )
+      : schema
   ),
 });
 


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-49914

Unngå å gi valideringsfeil på at man har en uidentifisert serie når kategorien ikke skal ha serie. Dette kan skje om importert data har andre regler enn vi har i NVA.

# How to test

Før: https://dev.nva.sikt.no/registration/0199956ab0ae-a2009854-e384-4a23-bbe4-fa7787d7d714/edit
Etter: http://localhost:3000/registration/0199956ab0ae-a2009854-e384-4a23-bbe4-fa7787d7d714/edit

Validering skal virke som før for kategorier som skal kunne ha serie

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
