### PR TITLE
NP-49917 Avoid error message when use cancells login

### DIFF
--- a/src/utils/hooks/useAuthErrorListener.ts
+++ b/src/utils/hooks/useAuthErrorListener.ts
@@ -5,6 +5,7 @@ import { useDispatch } from 'react-redux';
 import { setNotification } from '../../redux/notificationSlice';
 
 enum AuthErrorCode {
+  Cancelled = 'User cancelled OAuth flow',
   MissingNin = 'IdentityService-1003',
 }
 
@@ -15,7 +16,9 @@ export const useAuthErrorListener = () => {
   useEffect(() => {
     const unsubscribeAuthErrorListener = Hub.listen('auth', ({ payload }) => {
       if (payload.event === 'signInWithRedirect_failure') {
-        if (payload.data.error?.message.includes(AuthErrorCode.MissingNin)) {
+        if (payload.data.error?.message.includes(AuthErrorCode.Cancelled)) {
+          return;
+        } else if (payload.data.error?.message.includes(AuthErrorCode.MissingNin)) {
           dispatch(setNotification({ message: t('feedback.error.login_failed_try_bankid'), variant: 'error' }));
         } else {
           dispatch(setNotification({ message: t('feedback.error.login_failed'), variant: 'error' }));


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-49917

Unngå at bruker får feilmelding når om man avbryter ett innloggingsforsøk.


# How to test

1. Trykk på "logg inn"
2. Trykk tilbake i nettleseren uten å gjøre noe mer
3. Se at man da får feilmelding om at "Innlogging feilet", selv om man ikke har prøvd å logge inn

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
