### PR TITLE
NP-49928 Show importSource for all log entries

### DIFF
--- a/src/pages/public_registration/log/LogEntryItem.tsx
+++ b/src/pages/public_registration/log/LogEntryItem.tsx
@@ -56,7 +56,7 @@ export const LogEntryItem = ({ logEntry, messages }: LogEntryItemProps) => {
         <LogEntryOganizationInfo performedBy={logEntry.performedBy} />
       ) : null}
 
-      {logEntry.type === 'FileLogEntry' ? (
+      {logEntry.type === 'FileLogEntry' && (
         <>
           <Divider />
           <StyledLogRow>
@@ -65,14 +65,15 @@ export const LogEntryItem = ({ logEntry, messages }: LogEntryItemProps) => {
               {logEntry.filename || t('log.unknown_filename')}
             </Typography>
           </StyledLogRow>
-          {logEntry.topic === 'FileImported' && <LogEntryImportSourceInfo importSource={logEntry.importSource} />}
         </>
-      ) : logEntry.topic === 'PublicationImported' || logEntry.topic === 'PublicationMerged' ? (
+      )}
+
+      {logEntry.importSource && (
         <>
           <Divider />
           <LogEntryImportSourceInfo importSource={logEntry.importSource} />
         </>
-      ) : null}
+      )}
 
       {messages && messages.length > 0 && <LogMessageAccordion messages={messages} topic={logEntry.topic} />}
     </Box>

--- a/src/types/log.types.ts
+++ b/src/types/log.types.ts
@@ -16,6 +16,7 @@ export interface LogEntryPerson {
 
 interface BaseLogEntry {
   timestamp: string;
+  importSource?: ImportSourceLogData;
 }
 
 interface PublicationLogEntry extends BaseLogEntry {
@@ -42,7 +43,6 @@ export interface ImportSourceLogData {
 interface PublicationImportLogEntry extends Omit<PublicationLogEntry, 'topic' | 'performedBy'> {
   topic: 'PublicationImported' | 'PublicationMerged';
   performedBy: LogEntryOrganization;
-  importSource: ImportSourceLogData;
 }
 
 export interface FileLogEntry extends BaseLogEntry {

--- a/src/types/log.types.ts
+++ b/src/types/log.types.ts
@@ -64,7 +64,6 @@ export interface FileLogEntry extends BaseLogEntry {
 
 interface FileImportLogEntry extends Omit<FileLogEntry, 'topic'> {
   topic: 'FileImported';
-  importSource: ImportSourceLogData;
 }
 
 export type LogEntry = PublicationLogEntry | FileLogEntry | PublicationImportLogEntry | FileImportLogEntry;


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-49928

Tillat alle loggmeldinger å ha importkilde, og vis dem for alle. Backend vil legge til `importSource` for flere logg-typer fremover i [denne oppgaven](https://sikt.atlassian.net/browse/NP-49929).

# How to test

Affected part of the application: http://localhost:3000/registration/01999d25deff-7bb3eb43-6bb8-40e3-8b42-a05da3d8beda

Siden det bare er testmiljøet som har data for dette er det litt ekstra knot å verifisere:
1. Endre `.env` til å peke mot test-miljøet
2. Siden test-miljøet ikke er satt opp til å fungere mot localhost må man ha en CORS-plugin i nettleser for at API-kall skal virke, feks [CORS Everywhere](https://addons.mozilla.org/nb-NO/firefox/addon/cors-everywhere/?utm_content=addons-manager-reviews-link&utm_medium=firefox-browser&utm_source=firefox-browser)
3. Åpne [samme lenke](http://localhost:3000/registration/01999d25deff-7bb3eb43-6bb8-40e3-8b42-a05da3d8beda) som over lokalt og se forskjell

Før:
<img width="287" height="321" alt="bilde" src="https://github.com/user-attachments/assets/4f4e9163-4be5-44b7-84ad-572701d6c58d" />


Etter:
<img width="291" height="347" alt="bilde" src="https://github.com/user-attachments/assets/494ce926-906a-4ffd-b89a-93c7da8fd7c0" />


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
