### PR TITLE
Add max length validation and character count for project summary fields

### DIFF
--- a/src/pages/project/project_wizard/DescriptionInput.tsx
+++ b/src/pages/project/project_wizard/DescriptionInput.tsx
@@ -1,0 +1,27 @@
+import { TextField } from '@mui/material';
+
+interface DescriptionInputProps {
+  field: FieldInputProps<string>;
+  dataTestId: string;
+  label: string;
+}
+
+const MAX_SUMMARY_LENGTH = 4000;
+
+export const DescriptionInput = ({ field, dataTestId, label }: DescriptionInputProps) => (
+  <TextField
+    {...field}
+    value={field.value ?? ''}
+    variant="filled"
+    fullWidth
+    multiline
+    rows="3"
+    data-testid={dataTestId}
+    label={label}
+    slotProps={{
+      htmlInput: { maxLength: MAX_SUMMARY_LENGTH },
+      formHelperText: { sx: { textAlign: 'end' } },
+    }}
+    helperText={`${field.value?.length ?? 0}/${MAX_SUMMARY_LENGTH}`}
+  />
+);

--- a/src/pages/project/project_wizard/DescriptionInput.tsx
+++ b/src/pages/project/project_wizard/DescriptionInput.tsx
@@ -1,4 +1,5 @@
 import { TextField } from '@mui/material';
+import { FieldInputProps } from 'formik';
 
 interface DescriptionInputProps {
   field: FieldInputProps<string>;

--- a/src/pages/project/project_wizard/ProjectDescriptionForm.tsx
+++ b/src/pages/project/project_wizard/ProjectDescriptionForm.tsx
@@ -13,12 +13,11 @@ import { getLanguageString } from '../../../utils/translation-helpers';
 import { getProjectPath } from '../../../utils/urlPaths';
 import { DuplicateWarning } from '../../registration/DuplicateWarning';
 import { FormBox } from './styles';
+import { DescriptionInput } from './DescriptionInput';
 
 interface ProjectDescriptionFormProps {
   thisIsRekProject: boolean;
 }
-
-const MAX_SUMMARY_LENGTH = 4000;
 
 export const ProjectDescriptionForm = ({ thisIsRekProject }: ProjectDescriptionFormProps) => {
   const { t } = useTranslation();
@@ -66,77 +65,37 @@ export const ProjectDescriptionForm = ({ thisIsRekProject }: ProjectDescriptionF
           )}
           <Field name={ProjectFieldName.AcademicSummaryNo}>
             {({ field }: FieldProps<string>) => (
-              <TextField
-                {...field}
-                value={field.value ?? ''}
-                variant="filled"
-                fullWidth
-                multiline
-                rows="4"
-                data-testid={dataTestId.projectWizard.descriptionPanel.scientificSummaryNorwegianField}
+              <DescriptionInput
+                field={field}
+                dataTestId={dataTestId.projectWizard.descriptionPanel.scientificSummaryNorwegianField}
                 label={t('project.scientific_summary_norwegian')}
-                slotProps={{
-                  htmlInput: { maxLength: MAX_SUMMARY_LENGTH },
-                  formHelperText: { sx: { textAlign: 'end' } },
-                }}
-                helperText={`${field.value?.length ?? 0}/${MAX_SUMMARY_LENGTH}`}
               />
             )}
           </Field>
           <Field name={ProjectFieldName.AcademicSummaryEn}>
             {({ field }: FieldProps<string>) => (
-              <TextField
-                {...field}
-                value={field.value ?? ''}
-                variant="filled"
-                fullWidth
-                multiline
-                rows="4"
-                data-testid={dataTestId.projectWizard.descriptionPanel.scientificSummaryEnglishField}
+              <DescriptionInput
+                field={field}
+                dataTestId={dataTestId.projectWizard.descriptionPanel.scientificSummaryEnglishField}
                 label={t('project.scientific_summary_english')}
-                slotProps={{
-                  htmlInput: { maxLength: MAX_SUMMARY_LENGTH },
-                  formHelperText: { sx: { textAlign: 'end' } },
-                }}
-                helperText={`${field.value?.length ?? 0}/${MAX_SUMMARY_LENGTH}`}
               />
             )}
           </Field>
           <Field name={ProjectFieldName.PopularScientificSummaryNo}>
             {({ field }: FieldProps<string>) => (
-              <TextField
-                {...field}
-                value={field.value ?? ''}
-                variant="filled"
-                fullWidth
-                multiline
-                rows="3"
-                data-testid={dataTestId.projectWizard.descriptionPanel.popularScienceSummaryNorwegianField}
+              <DescriptionInput
+                field={field}
+                dataTestId={dataTestId.projectWizard.descriptionPanel.popularScienceSummaryNorwegianField}
                 label={t('project.popular_science_summary_norwegian')}
-                slotProps={{
-                  htmlInput: { maxLength: MAX_SUMMARY_LENGTH },
-                  formHelperText: { sx: { textAlign: 'end' } },
-                }}
-                helperText={`${field.value?.length ?? 0}/${MAX_SUMMARY_LENGTH}`}
               />
             )}
           </Field>
           <Field name={ProjectFieldName.PopularScientificSummaryEn}>
             {({ field }: FieldProps<string>) => (
-              <TextField
-                {...field}
-                value={field.value ?? ''}
-                variant="filled"
-                fullWidth
-                multiline
-                rows="3"
-                data-testid={dataTestId.projectWizard.descriptionPanel.popularScienceSummaryEnglishField}
+              <DescriptionInput
+                field={field}
+                dataTestId={dataTestId.projectWizard.descriptionPanel.popularScienceSummaryEnglishField}
                 label={t('project.popular_science_summary_english')}
-                slotProps={{
-                  htmlInput: { maxLength: MAX_SUMMARY_LENGTH },
-                  formHelperText: { sx: { textAlign: 'end' } },
-                }}
-                helperText={`${field.value?.length ?? 0}/${MAX_SUMMARY_LENGTH}`}
               />
             )}
           </Field>

--- a/src/pages/project/project_wizard/ProjectDescriptionForm.tsx
+++ b/src/pages/project/project_wizard/ProjectDescriptionForm.tsx
@@ -18,6 +18,8 @@ interface ProjectDescriptionFormProps {
   thisIsRekProject: boolean;
 }
 
+const MAX_SUMMARY_LENGTH = 4000;
+
 export const ProjectDescriptionForm = ({ thisIsRekProject }: ProjectDescriptionFormProps) => {
   const { t } = useTranslation();
   const { values, setFieldValue, setFieldTouched } = useFormikContext<CristinProject>();
@@ -73,6 +75,11 @@ export const ProjectDescriptionForm = ({ thisIsRekProject }: ProjectDescriptionF
                 rows="4"
                 data-testid={dataTestId.projectWizard.descriptionPanel.scientificSummaryNorwegianField}
                 label={t('project.scientific_summary_norwegian')}
+                slotProps={{
+                  htmlInput: { maxLength: MAX_SUMMARY_LENGTH },
+                  formHelperText: { sx: { textAlign: 'end' } },
+                }}
+                helperText={`${field.value?.length ?? 0}/${MAX_SUMMARY_LENGTH}`}
               />
             )}
           </Field>
@@ -87,6 +94,11 @@ export const ProjectDescriptionForm = ({ thisIsRekProject }: ProjectDescriptionF
                 rows="4"
                 data-testid={dataTestId.projectWizard.descriptionPanel.scientificSummaryEnglishField}
                 label={t('project.scientific_summary_english')}
+                slotProps={{
+                  htmlInput: { maxLength: MAX_SUMMARY_LENGTH },
+                  formHelperText: { sx: { textAlign: 'end' } },
+                }}
+                helperText={`${field.value?.length ?? 0}/${MAX_SUMMARY_LENGTH}`}
               />
             )}
           </Field>
@@ -101,6 +113,11 @@ export const ProjectDescriptionForm = ({ thisIsRekProject }: ProjectDescriptionF
                 rows="3"
                 data-testid={dataTestId.projectWizard.descriptionPanel.popularScienceSummaryNorwegianField}
                 label={t('project.popular_science_summary_norwegian')}
+                slotProps={{
+                  htmlInput: { maxLength: MAX_SUMMARY_LENGTH },
+                  formHelperText: { sx: { textAlign: 'end' } },
+                }}
+                helperText={`${field.value?.length ?? 0}/${MAX_SUMMARY_LENGTH}`}
               />
             )}
           </Field>
@@ -115,6 +132,11 @@ export const ProjectDescriptionForm = ({ thisIsRekProject }: ProjectDescriptionF
                 rows="3"
                 data-testid={dataTestId.projectWizard.descriptionPanel.popularScienceSummaryEnglishField}
                 label={t('project.popular_science_summary_english')}
+                slotProps={{
+                  htmlInput: { maxLength: MAX_SUMMARY_LENGTH },
+                  formHelperText: { sx: { textAlign: 'end' } },
+                }}
+                helperText={`${field.value?.length ?? 0}/${MAX_SUMMARY_LENGTH}`}
               />
             )}
           </Field>

--- a/src/pages/project/project_wizard/ProjectForm.tsx
+++ b/src/pages/project/project_wizard/ProjectForm.tsx
@@ -83,7 +83,7 @@ export const ProjectForm = ({ project, suggestedProjectManager, toggleModal, onP
           })
         );
       }
-    } catch (err) {
+    } catch {
       dispatch(
         setNotification({
           message: projectWithId ? t('feedback.error.update_project') : t('feedback.error.create_project'),

--- a/src/pages/project/project_wizard/ProjectForm.tsx
+++ b/src/pages/project/project_wizard/ProjectForm.tsx
@@ -53,28 +53,37 @@ export const ProjectForm = ({ project, suggestedProjectManager, toggleModal, onP
       data: values,
     };
 
-    const updateProjectResponse = await authenticatedApiRequest2<CristinProject>(config);
+    try {
+      const updateProjectResponse = await authenticatedApiRequest2<CristinProject>(config);
 
-    if (isSuccessStatus(updateProjectResponse.status)) {
-      dispatch(
-        setNotification({
-          message: projectWithId ? t('feedback.success.update_project') : t('feedback.success.create_project'),
-          variant: 'success',
-        })
-      );
+      if (isSuccessStatus(updateProjectResponse.status)) {
+        dispatch(
+          setNotification({
+            message: projectWithId ? t('feedback.success.update_project') : t('feedback.success.create_project'),
+            variant: 'success',
+          })
+        );
 
-      const id = projectWithId ? projectWithId.id : updateProjectResponse.data.id;
+        const id = projectWithId ? projectWithId.id : updateProjectResponse.data.id;
 
-      if (toggleModal) {
-        if (onProjectCreated) {
-          if (projectWithId) onProjectCreated(projectWithId);
-          else onProjectCreated(updateProjectResponse.data);
+        if (toggleModal) {
+          if (onProjectCreated) {
+            if (projectWithId) onProjectCreated(projectWithId);
+            else onProjectCreated(updateProjectResponse.data);
+          }
+          toggleModal();
+        } else if (id) {
+          goToLandingPage(id);
         }
-        toggleModal();
-      } else if (id) {
-        goToLandingPage(id);
+      } else if (isErrorStatus(updateProjectResponse.status)) {
+        dispatch(
+          setNotification({
+            message: projectWithId ? t('feedback.error.update_project') : t('feedback.error.create_project'),
+            variant: 'error',
+          })
+        );
       }
-    } else if (isErrorStatus(updateProjectResponse.status)) {
+    } catch (err) {
       dispatch(
         setNotification({
           message: projectWithId ? t('feedback.error.update_project') : t('feedback.error.create_project'),


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-49960](https://sikt.atlassian.net/browse/NP-49960)

Add length validation to all summary fields, because the API does not allow summaries that are more than 4000 characters long.

Also discovered that there is a discrepancy between how we handle errors in the axios-function and in the components, so that we don't actually catch the errors returned from the API. This results in no error message shown to the user when save results in error. Fixed this in the project form, but we should look into if this happens several places in the app and consider if we want to change the axios-function or each view that posts a form.

# How to test

Affected part of the application: [New project view](http://localhost:3000/projects/new)

**Before this PR:**
Start creating a new project and type a very long description (more than 4000 characters). When you click save, the button will spin for a while and then stop spinning without anything happening. No error, no confirmation, no form errors shown. If you go into the console or the networks tab you will see that the form could not be saved.

There are two problems with this:
1) The form cannot be saved when the description is too long, but there is no way you can know that, because the form does not validate for summary length.
2) The save is unsuccessful but you are not notified about this.

**After this PR:**
1) Added a length validation to all summary fields so that it's not possible to make them too long
2) Fixed error notifications so that if you for some reason were able to send in an invalid form you now get an error message.

<img width="1300" height="497" alt="image" src="https://github.com/user-attachments/assets/fa441edd-c08c-442f-b30e-f54dd8816f74" />

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-49960]: https://sikt.atlassian.net/browse/NP-49960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ