### PR TITLE
Remove initialData from user fetch query in UserFormDialog

### DIFF
--- a/src/pages/basic_data/institution_admin/edit_user/UserFormDialog.tsx
+++ b/src/pages/basic_data/institution_admin/edit_user/UserFormDialog.tsx
@@ -75,7 +75,6 @@ export const UserFormDialog = ({ open, onClose, existingUser, existingPerson }: 
     queryFn: () => fetchUser(username),
     meta: { errorMessage: false }, // No error message, since a Cristin Person will lack User if they have not logged in yet
     retry: false,
-    initialData: existingUser,
   });
 
   const personMutation = useMutation({


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-49231](https://sikt.atlassian.net/browse/NP-49231)

Fixed bug where tasks that didn't have a curator in some cases appeared to have a specific curator in some cases.

# How to test

**Before this PR:**
1) Go into your tasks-page and click on a registration.
2) Verify that it doesn't have a selected curator:
<img width="1468" height="217" alt="image" src="https://github.com/user-attachments/assets/67c0c458-1c23-45db-96d6-f4f6ce98f084" />

3) Go into the tab for your organization
<img width="1472" height="77" alt="image" src="https://github.com/user-attachments/assets/26a56f2a-4aaa-4a73-9ef4-3f288e0d49a4" />

4) Click on "Kuratorer" in the side panel and wait until the page is fully loaded:
<img width="718" height="250" alt="image" src="https://github.com/user-attachments/assets/68609769-f861-4120-a7c1-d005f3e985c6" />

5) Go back to your tasks page and select the same task

6) Verify that a curator is now selected:

<img width="1471" height="203" alt="image" src="https://github.com/user-attachments/assets/ba312d3b-2ec9-43cb-a944-0668726b0363" />

**The bug is that it should not appear as if a curator is selected.**

After this PR:
Perform all the steps above and see how no curator is selected.

# The solution
I found out that when on the curator page (step 4 above) we iterate through a list of curators and set the first one as the default user when using react query to perform a user search. Even if the search is not performed because the userId is empty, react query will store the default curator on the empty string in the cache, so that every time we are considering to do a lookup and think we are gatekeeping on userId, the cache will return the user we have stored on the empty id.

Thus, I removed this default user, but I am not sure if this has any consequenses in the rest of the app. 


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [ ] The changes are working as expected
- [ ] The changes are tested OK for different screen sizes
- [ ] The changes are tested OK for a11y
- [ ] Interactive elements have data-testids
- [ ] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
