### PR TITLE
Extended language choice handling

### DIFF
--- a/src/layout/header/LanguageSelector.tsx
+++ b/src/layout/header/LanguageSelector.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, Divider } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { selectDisplayLanguage } from '../../translations/i18n';
 
 export type LanguageCode = 'nob' | 'eng' | 'nno';
 
@@ -10,6 +11,8 @@ export const LanguageSelector = () => {
     i18n.changeLanguage(languageCode);
   };
 
+  const displayLanguage = selectDisplayLanguage(i18n.language);
+
   return (
     <Box
       sx={{
@@ -19,7 +22,7 @@ export const LanguageSelector = () => {
         gap: '0.25rem',
       }}>
       <Button
-        sx={{ borderBottom: i18n.language === 'nob' ? '4px solid' : 'none', borderRadius: '0' }}
+        sx={{ borderBottom: displayLanguage === 'nob' ? '4px solid' : 'none', borderRadius: '0' }}
         color="white"
         size="small"
         onClick={() => setLanguage('nob')}
@@ -28,7 +31,7 @@ export const LanguageSelector = () => {
       </Button>
       <Divider orientation="vertical" flexItem sx={{ bgcolor: 'white', height: '1rem', alignSelf: 'center' }} />
       <Button
-        sx={{ borderBottom: i18n.language === 'nno' ? '4px solid' : 'none', borderRadius: '0' }}
+        sx={{ borderBottom: displayLanguage === 'nno' ? '4px solid' : 'none', borderRadius: '0' }}
         color="white"
         size="small"
         onClick={() => setLanguage('nno')}
@@ -38,7 +41,7 @@ export const LanguageSelector = () => {
       <Divider orientation="vertical" flexItem sx={{ bgcolor: 'white', height: '1rem', alignSelf: 'center' }} />
 
       <Button
-        sx={{ borderBottom: i18n.language === 'eng' ? '4px solid' : 'none', borderRadius: '0' }}
+        sx={{ borderBottom: displayLanguage === 'eng' ? '4px solid' : 'none', borderRadius: '0' }}
         color="white"
         size="small"
         onClick={() => setLanguage('eng')}

--- a/src/translations/i18n.ts
+++ b/src/translations/i18n.ts
@@ -4,17 +4,42 @@ import enTranslations from './enTranslations.json';
 import nbTranslations from './nbTranslations.json';
 import nnTranslations from './nnTranslations.json';
 
-const supportedLanguages = ['nob', 'eng', 'nno', 'sme', 'sma', 'smj', 'smn', 'sms', 'sje', 'sju', 'sjd', 'sjt'];
+const supportedLanguages = [
+  'nob', // Norwegian Bokmål,
+  'nb', // Norwegian Bokmål, other language code
+  'nn', // Norwegian Nynorsk
+  'eng', // English
+  'en', // English, other language code
+  'nno', // Norwegian Nynorsk, other language code
+  'sme', // All below arw different sami languages
+  'sma',
+  'smj',
+  'smn',
+  'sms',
+  'sje',
+  'sju',
+  'sjd',
+  'sjt',
+];
 
 i18n.use(LanguageDetector).init({
   resources: {
     eng: {
       translation: enTranslations,
     },
+    en: {
+      translation: enTranslations,
+    },
     nob: {
       translation: nbTranslations,
     },
     nno: {
+      translation: nnTranslations,
+    },
+    nb: {
+      translation: nbTranslations,
+    },
+    nn: {
       translation: nnTranslations,
     },
     sme: {
@@ -68,7 +93,6 @@ i18n.use(LanguageDetector).init({
     return [langCode];
   },
   returnEmptyString: false,
-  supportedLngs: supportedLanguages,
   debug: false,
 });
 

--- a/src/translations/i18n.ts
+++ b/src/translations/i18n.ts
@@ -4,6 +4,8 @@ import enTranslations from './enTranslations.json';
 import nbTranslations from './nbTranslations.json';
 import nnTranslations from './nnTranslations.json';
 
+const supportedLanguages = ['nob', 'eng', 'nno', 'sme', 'sma', 'smj', 'smn', 'sms', 'sje', 'sju', 'sjd', 'sjt'];
+
 i18n.use(LanguageDetector).init({
   resources: {
     eng: {
@@ -15,11 +17,58 @@ i18n.use(LanguageDetector).init({
     nno: {
       translation: nnTranslations,
     },
+    sme: {
+      // When the user's browser language is a Sami variant, then the service should display in Bokmål
+      translation: nbTranslations,
+    },
+    sma: {
+      // Southern Sami
+      translation: nbTranslations,
+    },
+    smj: {
+      // Lule Sami
+      translation: nbTranslations,
+    },
+    smn: {
+      // Inari Sami
+      translation: nbTranslations,
+    },
+    sms: {
+      // Skolt Sami
+      translation: nbTranslations,
+    },
+    sje: {
+      // Pite Sami
+      translation: nbTranslations,
+    },
+    sju: {
+      // Ume Sami
+      translation: nbTranslations,
+    },
+    sjd: {
+      // Kildin Sami
+      translation: nbTranslations,
+    },
+    sjt: {
+      // Ter Sami
+      translation: nbTranslations,
+    },
   },
   contextSeparator: '__',
-  fallbackLng: 'nob',
+  fallbackLng: (langCode) => {
+    if (!langCode) {
+      // When the user's browser language is not specified, then the service should display in Bokmål
+      return ['nob'];
+    }
+    if (!supportedLanguages.includes(langCode)) {
+      // When the user's browser language is not Norwegian (Bokmål, Nynorsk, or any Sami variant), then the service should display in English by default
+      return ['eng'];
+    }
+    // Supported language
+    return [langCode];
+  },
   returnEmptyString: false,
-  supportedLngs: ['nob', 'eng', 'nno'],
+  supportedLngs: supportedLanguages,
   debug: false,
 });
 

--- a/src/translations/i18n.ts
+++ b/src/translations/i18n.ts
@@ -59,9 +59,9 @@ i18n.use(LanguageDetector).init({
 });
 
 const getLanguageTagValue = (language: string) => {
-  if (language === 'eng') {
+  if (language === 'eng' || language === 'en') {
     return 'en';
-  } else if (language === 'nn') {
+  } else if (language === 'nn' || language === 'nno') {
     return 'nn';
   }
   return 'no';

--- a/src/translations/i18n.ts
+++ b/src/translations/i18n.ts
@@ -4,30 +4,27 @@ import enTranslations from './enTranslations.json';
 import nbTranslations from './nbTranslations.json';
 import nnTranslations from './nnTranslations.json';
 
-const supportedLanguages = [
+const handledLanguages = [
   'nob', // Norwegian Bokmål,
-  'nb', // Norwegian Bokmål, other language code
-  'nn', // Norwegian Nynorsk
+  'nb', // Norwegian Bokmål
   'eng', // English
-  'en', // English, other language code
-  'nno', // Norwegian Nynorsk, other language code
-  'sme', // All below arw different sami languages
-  'sma',
-  'smj',
-  'smn',
-  'sms',
-  'sje',
-  'sju',
-  'sjd',
-  'sjt',
+  'en', // English
+  'nn', // Norwegian Nynorsk
+  'nno', // Norwegian Nynorsk
+  'sme', // Northern Sami
+  'sma', // Southern Sami
+  'smj', // Lule Sami
+  'smn', // Inari Sami
+  'sms', // Skolt Sami
+  'sje', // Pite Sami
+  'sju', // Ume Sami
+  'sjd', // Kildin Sami
+  'sjt', // Ter Sami
 ];
 
 i18n.use(LanguageDetector).init({
   resources: {
     eng: {
-      translation: enTranslations,
-    },
-    en: {
       translation: enTranslations,
     },
     nob: {
@@ -36,61 +33,16 @@ i18n.use(LanguageDetector).init({
     nno: {
       translation: nnTranslations,
     },
-    nb: {
-      translation: nbTranslations,
-    },
-    nn: {
-      translation: nnTranslations,
-    },
-    sme: {
-      // When the user's browser language is a Sami variant, then the service should display in Bokmål
-      translation: nbTranslations,
-    },
-    sma: {
-      // Southern Sami
-      translation: nbTranslations,
-    },
-    smj: {
-      // Lule Sami
-      translation: nbTranslations,
-    },
-    smn: {
-      // Inari Sami
-      translation: nbTranslations,
-    },
-    sms: {
-      // Skolt Sami
-      translation: nbTranslations,
-    },
-    sje: {
-      // Pite Sami
-      translation: nbTranslations,
-    },
-    sju: {
-      // Ume Sami
-      translation: nbTranslations,
-    },
-    sjd: {
-      // Kildin Sami
-      translation: nbTranslations,
-    },
-    sjt: {
-      // Ter Sami
-      translation: nbTranslations,
-    },
   },
   contextSeparator: '__',
   fallbackLng: (langCode) => {
-    if (!langCode) {
-      // When the user's browser language is not specified, then the service should display in Bokmål
-      return ['nob'];
-    }
-    if (!supportedLanguages.includes(langCode)) {
+    if (!handledLanguages.includes(langCode) || langCode === 'en' || langCode === 'eng') {
       // When the user's browser language is not Norwegian (Bokmål, Nynorsk, or any Sami variant), then the service should display in English by default
       return ['eng'];
+    } else if (langCode === 'nn' || langCode === 'nno') {
+      return ['nno'];
     }
-    // Supported language
-    return [langCode];
+    return ['nob']; // When the user's browser language is not specified, and when Bokmål is selected, then the service should display in Bokmål
   },
   returnEmptyString: false,
   debug: false,

--- a/src/translations/i18n.ts
+++ b/src/translations/i18n.ts
@@ -4,13 +4,9 @@ import enTranslations from './enTranslations.json';
 import nbTranslations from './nbTranslations.json';
 import nnTranslations from './nnTranslations.json';
 
-const handledLanguages = [
-  'nob', // Norwegian Bokmål,
-  'nb', // Norwegian Bokmål
-  'eng', // English
-  'en', // English
-  'nn', // Norwegian Nynorsk
-  'nno', // Norwegian Nynorsk
+export const samiLanguageCodes = [
+  'smi', // General for all sami languages
+  'se', // Northern Sami
   'sme', // Northern Sami
   'sma', // Southern Sami
   'smj', // Lule Sami
@@ -19,8 +15,30 @@ const handledLanguages = [
   'sje', // Pite Sami
   'sju', // Ume Sami
   'sjd', // Kildin Sami
-  'sjt', // Ter Sami
+  'sjt', // Ter Sami];
 ];
+
+const handledLanguages = [
+  'nob', // Norwegian Bokmål,
+  'nb', // Norwegian Bokmål
+  'eng', // English
+  'en', // English
+  'nn', // Norwegian Nynorsk
+  'nno', // Norwegian Nynorsk
+  ...samiLanguageCodes,
+];
+
+export const selectDisplayLanguage = (langCode: string) => {
+  if (langCode === 'undefined' || langCode === 'null' || langCode === undefined || langCode === null) {
+    return 'nob'; // When the user's language is not specified, then the service should display in Bokmål
+  } else if (langCode === 'en' || langCode === 'eng' || !handledLanguages.includes(langCode)) {
+    // When the selected language is not Norwegian (Bokmål, Nynorsk, or any Sami variant), then the service should display in English by default
+    return 'eng';
+  } else if (langCode === 'nn' || langCode === 'nno') {
+    return 'nno';
+  }
+  return 'nob';
+};
 
 i18n.use(LanguageDetector).init({
   resources: {
@@ -35,15 +53,7 @@ i18n.use(LanguageDetector).init({
     },
   },
   contextSeparator: '__',
-  fallbackLng: (langCode) => {
-    if (!handledLanguages.includes(langCode) || langCode === 'en' || langCode === 'eng') {
-      // When the user's browser language is not Norwegian (Bokmål, Nynorsk, or any Sami variant), then the service should display in English by default
-      return ['eng'];
-    } else if (langCode === 'nn' || langCode === 'nno') {
-      return ['nno'];
-    }
-    return ['nob']; // When the user's browser language is not specified, and when Bokmål is selected, then the service should display in Bokmål
-  },
+  fallbackLng: (langCode) => [selectDisplayLanguage(langCode)],
   returnEmptyString: false,
   debug: false,
 });
@@ -51,12 +61,14 @@ i18n.use(LanguageDetector).init({
 const getLanguageTagValue = (language: string) => {
   if (language === 'eng') {
     return 'en';
+  } else if (language === 'nn') {
+    return 'nn';
   }
   return 'no';
 };
 
 if (typeof document !== 'undefined') {
-  document.documentElement.lang = getLanguageTagValue(i18n.language);
+  document.documentElement.lang = getLanguageTagValue(selectDisplayLanguage(i18n.language));
   i18n.on('languageChanged', (newLanguage) => {
     document.documentElement.lang = getLanguageTagValue(newLanguage);
   });


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-49983](https://sikt.atlassian.net/browse/NP-49983)

Implement user stories from the task:

1) As a user with a non-Norwegian language setting, when the user's browser language is not Norwegian (Bokmål, Nynorsk, or any Sami variant), then the service should display in English by default

2) As a user with Nynorsk language setting, when the user's browser language is Nynorsk, then the service should display in Nynorsk

3) As a user with a Sami language setting, when the user's browser language is a Sami variant, then the service should display in Bokmål

4) As a user with Bokmål setting or no specific language setting, when the user's browser language is Bokmål or not specified, then the service should display in Bokmål

# How to test

1) Set a non-norwegian language as prefered language in your browser and delete the i18n cookie. Refresh and verify that the page is in english, regardless of language. Also remember to verify that the selected language is highlighted in the footer.
2) Set nynorsk as prefered language, delete cookie and refresh to verify that the page is in nynorsk. Also remember to verify that the selected language is highlighted in the footer.
3) Sami languages cannot be selected in the browser, but you can at least verify that if you set ?lng=sme (a sami language) cookie is set to sme, but the page is still displayed in bokmål. Also remember to verify that the selected language is highlighted in the footer.
4) This is also difficult to test, since the browser forces us to have a selected language. At least you can verify that when bokmål is selected it displays bokmål. You can set the cookie to undefined and verify that bokmål is displayed. Also remember to verify that the selected language is highlighted in the footer.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-49983]: https://sikt.atlassian.net/browse/NP-49983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Sami language variants and unified display-language mapping for consistent language handling.
  * Dynamic fallback and detection now use the mapped display language for more consistent initial selection.

* **Bug Fixes**
  * Language selector styling reliably highlights the active language using the mapped display language.
  * Page language and document attributes update correctly when switching, improving accessibility and SEO.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->