### PR TITLE
Add quick search for candidates in the NVI status report view

### DIFF
--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -253,8 +253,23 @@ export enum NviCandidatesSearchParam {
 export type NviCandidateOrderBy = 'createdDate';
 
 export type NviCandidateFilter = 'rejectedByOthers' | 'approvedByOthers' | 'collaboration';
-export type NviCandidateStatus = 'pending' | 'approved' | 'rejected';
-export type NviCandidateGlobalStatus = NviCandidateStatus | 'dispute';
+
+export enum NviCandidateStatusEnum {
+  Pending = 'pending',
+  Approved = 'approved',
+  Rejected = 'rejected',
+}
+
+export type NviCandidateStatus = keyof typeof NviCandidateStatusEnum;
+
+export enum NviCandidateGlobalStatusEnum {
+  Pending = 'pending',
+  Approved = 'approved',
+  Rejected = 'rejected',
+  Dispute = 'dispute',
+}
+
+export type NviCandidateGlobalStatus = keyof typeof NviCandidateGlobalStatusEnum;
 
 export interface FetchNviCandidatesParams {
   [NviCandidatesSearchParam.Affiliations]?: string[] | null;

--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -260,7 +260,7 @@ export enum NviCandidateStatusEnum {
   Rejected = 'rejected',
 }
 
-export type NviCandidateStatus = keyof typeof NviCandidateStatusEnum;
+export type NviCandidateStatus = `${NviCandidateStatusEnum}`;
 
 export enum NviCandidateGlobalStatusEnum {
   Pending = 'pending',
@@ -269,7 +269,7 @@ export enum NviCandidateGlobalStatusEnum {
   Dispute = 'dispute',
 }
 
-export type NviCandidateGlobalStatus = keyof typeof NviCandidateGlobalStatusEnum;
+export type NviCandidateGlobalStatus = `${NviCandidateGlobalStatusEnum}`;
 
 export interface FetchNviCandidatesParams {
   [NviCandidatesSearchParam.Affiliations]?: string[] | null;

--- a/src/pages/messages/TasksPage.tsx
+++ b/src/pages/messages/TasksPage.tsx
@@ -9,6 +9,8 @@ import { useFetchUserQuery } from '../../api/hooks/useFetchUserQuery';
 import {
   fetchCustomerTickets,
   FetchTicketsParams,
+  NviCandidateGlobalStatusEnum,
+  NviCandidateStatusEnum,
   SortOrder,
   TicketOrderBy,
   TicketSearchParam,
@@ -256,7 +258,14 @@ const TasksPage = () => {
                   isTicketCurator ? (
                     <Navigate to={UrlPathTemplate.TasksDialogue} replace />
                   ) : (
-                    <Navigate to={getNviCandidatesSearchPath(user?.nvaUsername)} replace />
+                    <Navigate
+                      to={getNviCandidatesSearchPath({
+                        username: user?.nvaUsername,
+                        status: NviCandidateStatusEnum.Pending,
+                        globalStatus: NviCandidateGlobalStatusEnum.Pending,
+                      })}
+                      replace
+                    />
                   )
                 }
               />

--- a/src/pages/messages/components/NviCandidatesNavigationAccordion.tsx
+++ b/src/pages/messages/components/NviCandidatesNavigationAccordion.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
 import { useFetchNviCandidates } from '../../../api/hooks/useFetchNviCandidates';
-import { NviCandidatesSearchParam } from '../../../api/searchApi';
+import { NviCandidateGlobalStatusEnum, NviCandidatesSearchParam, NviCandidateStatusEnum } from '../../../api/searchApi';
 import { NavigationListAccordion } from '../../../components/NavigationListAccordion';
 import { SelectableButton } from '../../../components/SelectableButton';
 import { StyledTicketSearchFormGroup } from '../../../components/styled/Wrappers';
@@ -62,7 +62,11 @@ export const NviCandidatesNavigationAccordion = () => {
       title={t('tasks.nvi.nvi_control')}
       startIcon={<AdjustIcon />}
       accordionPath={UrlPathTemplate.TasksNvi}
-      defaultPath={getNviCandidatesSearchPath(user?.nvaUsername)}
+      defaultPath={getNviCandidatesSearchPath({
+        username: user?.nvaUsername,
+        status: NviCandidateStatusEnum.Pending,
+        globalStatus: NviCandidateGlobalStatusEnum.Pending,
+      })}
       dataTestId={dataTestId.tasksPage.nviAccordion}>
       <StyledTicketSearchFormGroup>
         <StyledNviStatusBox>
@@ -103,7 +107,12 @@ export const NviCandidatesNavigationAccordion = () => {
               data-testid={dataTestId.tasksPage.nvi.showCandidateSearchButton}
               sx={{ justifyContent: 'center' }}
               isSelected={isOnNviCandidatesPage}
-              to={getNviCandidatesSearchPath(user?.nvaUsername, nviParams.year)}>
+              to={getNviCandidatesSearchPath({
+                username: user?.nvaUsername,
+                status: NviCandidateStatusEnum.Pending,
+                globalStatus: NviCandidateGlobalStatusEnum.Pending,
+                year: nviParams.year,
+              })}>
               {t('tasks.nvi.show_candidate_search')}
             </SelectableButton>
             <SelectableButton

--- a/src/pages/messages/components/NviStatusPage.tsx
+++ b/src/pages/messages/components/NviStatusPage.tsx
@@ -66,7 +66,14 @@ export const NviStatusPage = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {institution && <NviStatusTableRow organization={institution} aggregations={nviStatusQuery.data} />}
+            {institution && (
+              <NviStatusTableRow
+                organization={institution}
+                aggregations={nviStatusQuery.data}
+                user={user}
+                year={year}
+              />
+            )}
           </TableBody>
         </Table>
       </TableContainer>

--- a/src/pages/messages/components/NviStatusTableRow.tsx
+++ b/src/pages/messages/components/NviStatusTableRow.tsx
@@ -54,7 +54,22 @@ export const NviStatusTableRow = ({ organization, aggregations, level = 0, user,
           )}
         </TableCell>
         <TableCell align="center">
-          {aggregations ? (orgAggregations?.status.Pending?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
+          {aggregations ? (
+            <Link
+              component={RouterLink}
+              data-testid={dataTestId.nviStatusTableRow.candidateLink}
+              to={getNviCandidatesSearchPath({
+                year: year,
+                orgNumber: getIdentifierFromId(organization.id),
+                status: NviCandidateStatusEnum.Pending,
+                globalStatus: NviCandidateGlobalStatusEnum.Pending,
+                excludeUnassigned: true,
+              })}>
+              {orgAggregations?.status.Pending?.docCount.toLocaleString() ?? 0}
+            </Link>
+          ) : (
+            <StyledSkeleton />
+          )}
         </TableCell>
         <TableCell align="center">
           {aggregations ? (
@@ -62,11 +77,14 @@ export const NviStatusTableRow = ({ organization, aggregations, level = 0, user,
               component={RouterLink}
               data-testid={dataTestId.nviStatusTableRow.approvedLink}
               to={getNviCandidatesSearchPath({
-                username: user?.nvaUsername,
                 year: year,
                 orgNumber: getIdentifierFromId(organization.id),
                 status: NviCandidateStatusEnum.Approved,
-                globalStatus: NviCandidateGlobalStatusEnum.Approved,
+                globalStatus: [
+                  NviCandidateGlobalStatusEnum.Approved,
+                  NviCandidateGlobalStatusEnum.Pending,
+                  NviCandidateGlobalStatusEnum.Dispute,
+                ],
               })}>
               {orgAggregations?.status.Approved?.docCount.toLocaleString() ?? 0}
             </Link>
@@ -80,7 +98,6 @@ export const NviStatusTableRow = ({ organization, aggregations, level = 0, user,
               component={RouterLink}
               data-testid={dataTestId.nviStatusTableRow.rejectedLink}
               to={getNviCandidatesSearchPath({
-                username: user?.nvaUsername,
                 year: year,
                 orgNumber: getIdentifierFromId(organization.id),
                 status: NviCandidateStatusEnum.Rejected,
@@ -98,7 +115,6 @@ export const NviStatusTableRow = ({ organization, aggregations, level = 0, user,
               component={RouterLink}
               data-testid={dataTestId.nviStatusTableRow.totalAmountLink}
               to={getNviCandidatesSearchPath({
-                username: user?.nvaUsername,
                 year: year,
                 orgNumber: getIdentifierFromId(organization.id),
               })}>
@@ -121,7 +137,6 @@ export const NviStatusTableRow = ({ organization, aggregations, level = 0, user,
               component={RouterLink}
               data-testid={dataTestId.nviStatusTableRow.disputeLink}
               to={getNviCandidatesSearchPath({
-                username: user?.nvaUsername,
                 year: year,
                 orgNumber: getIdentifierFromId(organization.id),
                 globalStatus: NviCandidateGlobalStatusEnum.Dispute,

--- a/src/pages/messages/components/NviStatusTableRow.tsx
+++ b/src/pages/messages/components/NviStatusTableRow.tsx
@@ -36,61 +36,77 @@ export const NviStatusTableRow = ({ organization, aggregations, level = 0, user,
       <TableRow sx={{ bgcolor: level % 2 === 0 ? undefined : 'white' }}>
         <TableCell sx={{ pl: `${1 + level * 1.5}rem`, py: '1rem' }}>{getLanguageString(organization.labels)}</TableCell>
         <TableCell align="center">
-          <Link
-            component={RouterLink}
-            data-testid={dataTestId.nviStatusTableRow.candidateLink}
-            to={getNviCandidatesSearchPath({
-              username: user?.nvaUsername,
-              year: year,
-              orgNumber: getIdentifierFromId(organization.id),
-              status: NviCandidateStatusEnum.Pending,
-              globalStatus: NviCandidateGlobalStatusEnum.Pending,
-            })}>
-            {aggregations ? (orgAggregations?.status.New?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
-          </Link>
+          {aggregations ? (
+            <Link
+              component={RouterLink}
+              data-testid={dataTestId.nviStatusTableRow.candidateLink}
+              to={getNviCandidatesSearchPath({
+                username: user?.nvaUsername,
+                year: year,
+                orgNumber: getIdentifierFromId(organization.id),
+                status: NviCandidateStatusEnum.Pending,
+                globalStatus: NviCandidateGlobalStatusEnum.Pending,
+              })}>
+              {orgAggregations?.status.New?.docCount.toLocaleString() ?? 0}
+            </Link>
+          ) : (
+            <StyledSkeleton />
+          )}
         </TableCell>
         <TableCell align="center">
           {aggregations ? (orgAggregations?.status.Pending?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
         </TableCell>
         <TableCell align="center">
-          <Link
-            component={RouterLink}
-            data-testid={dataTestId.nviStatusTableRow.approvedLink}
-            to={getNviCandidatesSearchPath({
-              username: user?.nvaUsername,
-              year: year,
-              orgNumber: getIdentifierFromId(organization.id),
-              status: NviCandidateStatusEnum.Approved,
-              globalStatus: NviCandidateGlobalStatusEnum.Approved,
-            })}>
-            {aggregations ? (orgAggregations?.status.Approved?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
-          </Link>
+          {aggregations ? (
+            <Link
+              component={RouterLink}
+              data-testid={dataTestId.nviStatusTableRow.approvedLink}
+              to={getNviCandidatesSearchPath({
+                username: user?.nvaUsername,
+                year: year,
+                orgNumber: getIdentifierFromId(organization.id),
+                status: NviCandidateStatusEnum.Approved,
+                globalStatus: NviCandidateGlobalStatusEnum.Approved,
+              })}>
+              {orgAggregations?.status.Approved?.docCount.toLocaleString() ?? 0}
+            </Link>
+          ) : (
+            <StyledSkeleton />
+          )}
         </TableCell>
         <TableCell align="center">
-          <Link
-            component={RouterLink}
-            data-testid={dataTestId.nviStatusTableRow.rejectedLink}
-            to={getNviCandidatesSearchPath({
-              username: user?.nvaUsername,
-              year: year,
-              orgNumber: getIdentifierFromId(organization.id),
-              status: NviCandidateStatusEnum.Rejected,
-              globalStatus: NviCandidateGlobalStatusEnum.Rejected,
-            })}>
-            {aggregations ? (orgAggregations?.status.Rejected?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
-          </Link>
+          {aggregations ? (
+            <Link
+              component={RouterLink}
+              data-testid={dataTestId.nviStatusTableRow.rejectedLink}
+              to={getNviCandidatesSearchPath({
+                username: user?.nvaUsername,
+                year: year,
+                orgNumber: getIdentifierFromId(organization.id),
+                status: NviCandidateStatusEnum.Rejected,
+                globalStatus: NviCandidateGlobalStatusEnum.Rejected,
+              })}>
+              {orgAggregations?.status.Rejected?.docCount.toLocaleString() ?? 0}
+            </Link>
+          ) : (
+            <StyledSkeleton />
+          )}
         </TableCell>
         <TableCell align="center">
-          <Link
-            component={RouterLink}
-            data-testid={dataTestId.nviStatusTableRow.totalAmountLink}
-            to={getNviCandidatesSearchPath({
-              username: user?.nvaUsername,
-              year: year,
-              orgNumber: getIdentifierFromId(organization.id),
-            })}>
-            {aggregations ? (orgAggregations?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
-          </Link>
+          {aggregations ? (
+            <Link
+              component={RouterLink}
+              data-testid={dataTestId.nviStatusTableRow.totalAmountLink}
+              to={getNviCandidatesSearchPath({
+                username: user?.nvaUsername,
+                year: year,
+                orgNumber: getIdentifierFromId(organization.id),
+              })}>
+              {orgAggregations?.docCount.toLocaleString() ?? 0}
+            </Link>
+          ) : (
+            <StyledSkeleton />
+          )}
         </TableCell>
         <TableCell align="center">
           {aggregations ? (
@@ -100,17 +116,21 @@ export const NviStatusTableRow = ({ organization, aggregations, level = 0, user,
           )}
         </TableCell>
         <TableCell align="center">
-          <Link
-            component={RouterLink}
-            data-testid={dataTestId.nviStatusTableRow.disputeLink}
-            to={getNviCandidatesSearchPath({
-              username: user?.nvaUsername,
-              year: year,
-              orgNumber: getIdentifierFromId(organization.id),
-              globalStatus: NviCandidateGlobalStatusEnum.Dispute,
-            })}>
-            {aggregations ? (orgAggregations?.dispute?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
-          </Link>
+          {aggregations ? (
+            <Link
+              component={RouterLink}
+              data-testid={dataTestId.nviStatusTableRow.disputeLink}
+              to={getNviCandidatesSearchPath({
+                username: user?.nvaUsername,
+                year: year,
+                orgNumber: getIdentifierFromId(organization.id),
+                globalStatus: NviCandidateGlobalStatusEnum.Dispute,
+              })}>
+              {orgAggregations?.dispute?.docCount.toLocaleString() ?? 0}
+            </Link>
+          ) : (
+            <StyledSkeleton />
+          )}
         </TableCell>
         <TableCell>
           {level !== 0 && organization.hasPart && organization.hasPart.length > 0 && (

--- a/src/pages/messages/components/NviStatusTableRow.tsx
+++ b/src/pages/messages/components/NviStatusTableRow.tsx
@@ -1,16 +1,24 @@
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { IconButton, Skeleton, styled, TableCell, TableRow } from '@mui/material';
+import { IconButton, Skeleton, styled, TableCell, TableRow, Link } from '@mui/material';
+import { Link as RouterLink } from 'react-router';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NviInstitutionStatusResponse } from '../../../types/nvi.types';
 import { Organization } from '../../../types/organization.types';
 import { getLanguageString } from '../../../utils/translation-helpers';
+import { dataTestId } from '../../../utils/dataTestIds';
+import { getNviCandidatesSearchPath } from '../../../utils/urlPaths';
+import { User } from '../../../types/user.types';
+import { getIdentifierFromId } from '../../../utils/general-helpers';
+import { NviCandidateGlobalStatusEnum, NviCandidateStatusEnum } from '../../../api/searchApi';
 
 interface NviStatusTableRowProps {
   organization: Organization;
   aggregations?: NviInstitutionStatusResponse;
   level?: number;
+  user?: User | null;
+  year?: number;
 }
 
 const StyledSkeleton = styled(Skeleton)({
@@ -18,7 +26,7 @@ const StyledSkeleton = styled(Skeleton)({
   margin: 'auto',
 });
 
-export const NviStatusTableRow = ({ organization, aggregations, level = 0 }: NviStatusTableRowProps) => {
+export const NviStatusTableRow = ({ organization, aggregations, level = 0, user, year }: NviStatusTableRowProps) => {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(level === 0);
   const orgAggregations = aggregations?.[organization.id];
@@ -28,19 +36,61 @@ export const NviStatusTableRow = ({ organization, aggregations, level = 0 }: Nvi
       <TableRow sx={{ bgcolor: level % 2 === 0 ? undefined : 'white' }}>
         <TableCell sx={{ pl: `${1 + level * 1.5}rem`, py: '1rem' }}>{getLanguageString(organization.labels)}</TableCell>
         <TableCell align="center">
-          {aggregations ? (orgAggregations?.status.New?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
+          <Link
+            component={RouterLink}
+            data-testid={dataTestId.nviStatusTableRow.candidateLink}
+            to={getNviCandidatesSearchPath({
+              username: user?.nvaUsername,
+              year: year,
+              orgNumber: getIdentifierFromId(organization.id),
+              status: NviCandidateStatusEnum.Pending,
+              globalStatus: NviCandidateGlobalStatusEnum.Pending,
+            })}>
+            {aggregations ? (orgAggregations?.status.New?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
+          </Link>
         </TableCell>
         <TableCell align="center">
           {aggregations ? (orgAggregations?.status.Pending?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
         </TableCell>
         <TableCell align="center">
-          {aggregations ? (orgAggregations?.status.Approved?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
+          <Link
+            component={RouterLink}
+            data-testid={dataTestId.nviStatusTableRow.approvedLink}
+            to={getNviCandidatesSearchPath({
+              username: user?.nvaUsername,
+              year: year,
+              orgNumber: getIdentifierFromId(organization.id),
+              status: NviCandidateStatusEnum.Approved,
+              globalStatus: NviCandidateGlobalStatusEnum.Approved,
+            })}>
+            {aggregations ? (orgAggregations?.status.Approved?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
+          </Link>
         </TableCell>
         <TableCell align="center">
-          {aggregations ? (orgAggregations?.status.Rejected?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
+          <Link
+            component={RouterLink}
+            data-testid={dataTestId.nviStatusTableRow.rejectedLink}
+            to={getNviCandidatesSearchPath({
+              username: user?.nvaUsername,
+              year: year,
+              orgNumber: getIdentifierFromId(organization.id),
+              status: NviCandidateStatusEnum.Rejected,
+              globalStatus: NviCandidateGlobalStatusEnum.Rejected,
+            })}>
+            {aggregations ? (orgAggregations?.status.Rejected?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
+          </Link>
         </TableCell>
         <TableCell align="center">
-          {aggregations ? (orgAggregations?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
+          <Link
+            component={RouterLink}
+            data-testid={dataTestId.nviStatusTableRow.totalAmountLink}
+            to={getNviCandidatesSearchPath({
+              username: user?.nvaUsername,
+              year: year,
+              orgNumber: getIdentifierFromId(organization.id),
+            })}>
+            {aggregations ? (orgAggregations?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
+          </Link>
         </TableCell>
         <TableCell align="center">
           {aggregations ? (
@@ -50,7 +100,17 @@ export const NviStatusTableRow = ({ organization, aggregations, level = 0 }: Nvi
           )}
         </TableCell>
         <TableCell align="center">
-          {aggregations ? (orgAggregations?.dispute?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
+          <Link
+            component={RouterLink}
+            data-testid={dataTestId.nviStatusTableRow.disputeLink}
+            to={getNviCandidatesSearchPath({
+              username: user?.nvaUsername,
+              year: year,
+              orgNumber: getIdentifierFromId(organization.id),
+              globalStatus: NviCandidateGlobalStatusEnum.Dispute,
+            })}>
+            {aggregations ? (orgAggregations?.dispute?.docCount.toLocaleString() ?? 0) : <StyledSkeleton />}
+          </Link>
         </TableCell>
         <TableCell>
           {level !== 0 && organization.hasPart && organization.hasPart.length > 0 && (
@@ -63,7 +123,14 @@ export const NviStatusTableRow = ({ organization, aggregations, level = 0 }: Nvi
 
       {expanded &&
         organization.hasPart?.map((subUnit) => (
-          <NviStatusTableRow key={subUnit.id} organization={subUnit} aggregations={aggregations} level={level + 1} />
+          <NviStatusTableRow
+            key={subUnit.id}
+            organization={subUnit}
+            aggregations={aggregations}
+            level={level + 1}
+            user={user}
+            year={year}
+          />
         ))}
     </>
   );

--- a/src/utils/dataTestIds.ts
+++ b/src/utils/dataTestIds.ts
@@ -840,4 +840,12 @@ export const dataTestId = {
       GeographicalContent: 'frontpage-category-GeographicalContent',
     },
   },
+  nviStatusTableRow: {
+    candidateLink: 'nvi-aggregations-candidate-link',
+    controlLink: 'nvi-aggregations-control-link',
+    approvedLink: 'nvi-aggregations-approved-link',
+    rejectedLink: 'nvi-aggregations-rejected-link',
+    totalAmountLink: 'nvi-aggregations-total-amount-link',
+    disputeLink: 'nvi-aggregations-dispute-link',
+  },
 };

--- a/src/utils/urlPaths.ts
+++ b/src/utils/urlPaths.ts
@@ -1,5 +1,5 @@
 import { To } from 'react-router';
-import { NviCandidateGlobalStatus, NviCandidateStatus } from '../api/searchApi';
+import { NviCandidateGlobalStatusEnum, NviCandidatesSearchParam, NviCandidateStatusEnum } from '../api/searchApi';
 import { Registration, RegistrationStatus } from '../types/registration.types';
 import { getIdentifierFromId } from './general-helpers';
 
@@ -159,16 +159,39 @@ export const getMyMessagesRegistrationPath = (identifier: string) =>
 export const getNviCandidatePath = (identifier: string) =>
   UrlPathTemplate.TasksNviCandidate.replace(':identifier', encodeURIComponent(identifier));
 
-export const getNviCandidatesSearchPath = (currentUsername = '', year?: number) => {
-  const searchParams = new URLSearchParams({
-    status: 'pending' satisfies NviCandidateStatus,
-    globalStatus: 'pending' satisfies NviCandidateGlobalStatus,
-  });
-  if (currentUsername) {
-    searchParams.set('assignee', currentUsername); // NviCandidatesSearchParam.Assignee
+export interface NviCandidatesSearchParams {
+  username?: string;
+  year?: number;
+  orgNumber?: string;
+  status?: NviCandidateStatusEnum;
+  globalStatus?: NviCandidateGlobalStatusEnum;
+}
+
+export const getNviCandidatesSearchPath = ({
+  username,
+  year,
+  orgNumber,
+  status,
+  globalStatus,
+}: NviCandidatesSearchParams) => {
+  const searchParams = new URLSearchParams();
+
+  if (status) {
+    searchParams.set(NviCandidatesSearchParam.Status, status);
+  }
+
+  if (globalStatus) {
+    searchParams.set(NviCandidatesSearchParam.GlobalStatus, globalStatus);
+  }
+
+  if (username) {
+    searchParams.set(NviCandidatesSearchParam.Assignee, username);
   }
   if (year) {
-    searchParams.set('year', year.toString()); // NviCandidatesSearchParam.Year
+    searchParams.set(NviCandidatesSearchParam.Year, year.toString());
+  }
+  if (orgNumber) {
+    searchParams.set(NviCandidatesSearchParam.Affiliations, orgNumber);
   }
   return `${UrlPathTemplate.TasksNvi}?${searchParams.toString()}`;
 };

--- a/src/utils/urlPaths.ts
+++ b/src/utils/urlPaths.ts
@@ -164,7 +164,8 @@ export interface NviCandidatesSearchParams {
   year?: number;
   orgNumber?: string;
   status?: NviCandidateStatusEnum;
-  globalStatus?: NviCandidateGlobalStatusEnum;
+  globalStatus?: NviCandidateGlobalStatusEnum | NviCandidateGlobalStatusEnum[];
+  excludeUnassigned?: boolean;
 }
 
 export const getNviCandidatesSearchPath = ({
@@ -173,6 +174,7 @@ export const getNviCandidatesSearchPath = ({
   orgNumber,
   status,
   globalStatus,
+  excludeUnassigned,
 }: NviCandidatesSearchParams) => {
   const searchParams = new URLSearchParams();
 
@@ -181,7 +183,8 @@ export const getNviCandidatesSearchPath = ({
   }
 
   if (globalStatus) {
-    searchParams.set(NviCandidatesSearchParam.GlobalStatus, globalStatus);
+    const value = Array.isArray(globalStatus) ? globalStatus.join(',') : globalStatus;
+    searchParams.set(NviCandidatesSearchParam.GlobalStatus, value);
   }
 
   if (username) {
@@ -192,6 +195,9 @@ export const getNviCandidatesSearchPath = ({
   }
   if (orgNumber) {
     searchParams.set(NviCandidatesSearchParam.Affiliations, orgNumber);
+  }
+  if (excludeUnassigned !== undefined) {
+    searchParams.set(NviCandidatesSearchParam.ExcludeUnassigned, excludeUnassigned.toString());
   }
   return `${UrlPathTemplate.TasksNvi}?${searchParams.toString()}`;
 };


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-50098](https://sikt.atlassian.net/browse/NP-50098)

Make it possible to click the numbers in the "Vis rapporteringsstatus"-view in the NVI-section to get to t he candidate search with right parameters selected.

# How to test

Affected part of the application: [Nvi-kontroll](http://localhost:3000/tasks/nvi)

Go to Oppgaver -> NVI-kontroll and click the "Vis rapporteringsstatus"-button in the side panel. In the table in the main view the numbers are now clickable. Click each of the numbers to verify that the link leads you to a seach for NVI candidates that returns the expected results.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [ ] The changes are working as expected
- [ ] The changes are tested OK for different screen sizes
- [ ] The changes are tested OK for a11y
- [ ] Interactive elements have data-testids
- [ ] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-50098]: https://sikt.atlassian.net/browse/NP-50098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ