### PR TITLE
NP-50526 Ignore NPI-field on Central Import

### DIFF
--- a/src/pages/registration/resource_type_tab/components/NpiDisciplineField.tsx
+++ b/src/pages/registration/resource_type_tab/components/NpiDisciplineField.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from 'react-i18next';
 import disciplines from '../../../../resources/disciplines.json';
 import { ResourceFieldNames } from '../../../../types/publicationFieldNames';
 import { dataTestId } from '../../../../utils/dataTestIds';
+import { isOnPage } from '../../../../utils/general-helpers';
+import { UrlPathTemplate } from '../../../../utils/urlPaths';
 
 const disciplineOptions = disciplines
   .map((mainDiscipline) =>
@@ -48,7 +50,7 @@ export const NpiDisciplineField = ({ required }: NpiDisciplineFieldProps) => {
                 {...params}
                 onBlur={() => (!touched ? setFieldTouched(name, true, false) : null)}
                 label={t('registration.description.npi_disciplines')}
-                required={required}
+                required={!isOnPage(UrlPathTemplate.BasicDataCentralImport) && required}
                 fullWidth
                 variant="filled"
                 placeholder={!value ? t('velg_subject_area') : ''}

--- a/src/utils/general-helpers.ts
+++ b/src/utils/general-helpers.ts
@@ -1,6 +1,8 @@
 import * as Yup from 'yup';
 import { toDateString } from './date-helpers';
 
+export const isOnPage = (url: string) => window.location.pathname.startsWith(url);
+
 export const isValidUrl = (value: string) => value && Yup.string().url().isValidSync(value);
 
 export const doiUrlBase = 'https://doi.org/';

--- a/src/utils/validation/registration/registrationValidation.ts
+++ b/src/utils/validation/registration/registrationValidation.ts
@@ -25,6 +25,8 @@ import {
   reportReference,
   researchDataReference,
 } from './referenceValidation';
+import { isOnPage } from '../../general-helpers';
+import { UrlPathTemplate } from '../../urlPaths';
 
 const registrationErrorMessage = {
   titleRequired: i18n.t('feedback.validation.is_required', { field: i18n.t('common.title') }),
@@ -48,6 +50,7 @@ export const registrationValidationSchema = Yup.object<YupShape<Registration>>({
     npiSubjectHeading: Yup.string()
       .nullable()
       .when('$publicationInstanceType', ([publicationInstanceType], schema) =>
+        !isOnPage(UrlPathTemplate.BasicDataCentralImport) &&
         nviApplicableTypes.includes(publicationInstanceType) &&
         (isBook(publicationInstanceType) || isChapter(publicationInstanceType))
           ? schema.required(registrationErrorMessage.npiSubjectRequired)


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-50526

Ignore "Fagfelt i Norsk publiseringsindikator" when importing a candidate. The issue will still be reported on the final publication, but this is for the institution to correct, not the importer.

Also added new helper function for checking location

# How to test

Affected part of the application: http://localhost:3000/basic-data/central-import?type=AcademicMonograph

1. Import a candidate with type "Book"
2. Make sure the field is empty and does not give a validation error.
3. Import the candidate
4. Confirm that the published result has a warning indicator on the landing page, and that it gives a validation error in the wizard.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
