### PR TITLE
NP-50653 Filter on scientific value for correction lists

### DIFF
--- a/src/pages/messages/components/NviCorrectionList.tsx
+++ b/src/pages/messages/components/NviCorrectionList.tsx
@@ -69,7 +69,8 @@ export const NviCorrectionList = () => {
                 />
               </Box>
 
-              <ScientificValueFilter />
+              {(listId === 'ApplicableCategoriesWithNonApplicableChannel' ||
+                listId === 'NonApplicableCategoriesWithApplicableChannel') && <ScientificValueFilter />}
 
               <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem 1rem' }}>
                 <PublisherFilter />

--- a/src/pages/messages/components/NviCorrectionList.tsx
+++ b/src/pages/messages/components/NviCorrectionList.tsx
@@ -12,6 +12,7 @@ import { sanitizeSearchParams } from '../../../utils/searchHelpers';
 import { JournalFilter } from '../../search/advanced_search/JournalFilter';
 import { OrganizationFilters } from '../../search/advanced_search/OrganizationFilters';
 import { PublisherFilter } from '../../search/advanced_search/PublisherFilter';
+import { ScientificValueFilter } from '../../search/advanced_search/ScientificValueFilter';
 import { SeriesFilter } from '../../search/advanced_search/SeriesFilter';
 import { ExportResultsButton } from '../../search/ExportResultsButton';
 import { RegistrationSearch } from '../../search/registration_search/RegistrationSearch';
@@ -67,6 +68,8 @@ export const NviCorrectionList = () => {
                   disabled={listConfig.disabledFilters.includes(ResultParam.CategoryShould)}
                 />
               </Box>
+
+              <ScientificValueFilter />
 
               <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem 1rem' }}>
                 <PublisherFilter />

--- a/src/pages/search/advanced_search/ScientificValueFilter.tsx
+++ b/src/pages/search/advanced_search/ScientificValueFilter.tsx
@@ -3,23 +3,53 @@ import { ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router';
 import { ResultParam } from '../../../api/searchApi';
+import { StyledFilterHeading } from '../../../components/styled/Wrappers';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 
 export enum ScientificValueLevels {
-  LevelZero = 'Unassigned,LevelZero',
+  Unassigned = 'Unassigned',
+  LevelZero = 'LevelZero',
   LevelOne = 'LevelOne',
   LevelTwo = 'LevelTwo',
 }
+
+enum ScientificValueFilterMode {
+  UnassignedAndZero = 'UnassignedAndZero',
+  OneAndTwo = 'OneAndTwo',
+  All = 'All',
+}
+
+enum CorrectionListType {
+  ApplicableCategoriesWithNonApplicableChannel = 'ApplicableCategoriesWithNonApplicableChannel',
+  NonApplicableCategoriesWithApplicableChannel = 'NonApplicableCategoriesWithApplicableChannel',
+}
+
+const getScientificValueFilterModeFromParams = (searchParams: URLSearchParams): ScientificValueFilterMode => {
+  const listParam = searchParams.get('list') as CorrectionListType | null;
+
+  switch (listParam) {
+    case CorrectionListType.ApplicableCategoriesWithNonApplicableChannel:
+      return ScientificValueFilterMode.UnassignedAndZero;
+
+    case CorrectionListType.NonApplicableCategoriesWithApplicableChannel:
+      return ScientificValueFilterMode.OneAndTwo;
+
+    default:
+      return ScientificValueFilterMode.All;
+  }
+};
 
 export const ScientificValueFilter = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
+  const mode = getScientificValueFilterModeFromParams(searchParams);
   const scientificValueParam = searchParams.get(ResultParam.ScientificValue) ?? '';
 
   const selectedScientificValues = {
+    unassigned: scientificValueParam.includes(ScientificValueLevels.Unassigned),
     levelZero: scientificValueParam.includes(ScientificValueLevels.LevelZero),
     levelOne: scientificValueParam.includes(ScientificValueLevels.LevelOne),
     levelTwo: scientificValueParam.includes(ScientificValueLevels.LevelTwo),
@@ -33,6 +63,7 @@ export const ScientificValueFilter = () => {
     };
 
     const scientificValues = [
+      newSelectedScientificValues.unassigned ? ScientificValueLevels.Unassigned : '',
       newSelectedScientificValues.levelZero ? ScientificValueLevels.LevelZero : '',
       newSelectedScientificValues.levelOne ? ScientificValueLevels.LevelOne : '',
       newSelectedScientificValues.levelTwo ? ScientificValueLevels.LevelTwo : '',
@@ -51,23 +82,48 @@ export const ScientificValueFilter = () => {
     navigate({ search: syncedParams.toString() });
   };
 
+  const checkboxConfigs = [
+    {
+      key: 'unassigned' as const,
+      shouldShow: mode === ScientificValueFilterMode.UnassignedAndZero || mode === ScientificValueFilterMode.All,
+      label: t('search.advanced_search.scientific_value.unassigned'),
+      testId: dataTestId.startPage.advancedSearch.scientificValueLevels.unassignedCheckbox,
+    },
+    {
+      key: 'levelZero' as const,
+      shouldShow: mode === ScientificValueFilterMode.UnassignedAndZero || mode === ScientificValueFilterMode.All,
+      label: t('search.advanced_search.scientific_value.level', { level: 0 }),
+      testId: dataTestId.startPage.advancedSearch.scientificValueLevels.levelZeroCheckbox,
+    },
+    {
+      key: 'levelOne' as const,
+      shouldShow: mode === ScientificValueFilterMode.OneAndTwo || mode === ScientificValueFilterMode.All,
+      label: t('search.advanced_search.scientific_value.level', { level: 1 }),
+      testId: dataTestId.startPage.advancedSearch.scientificValueLevels.levelOneCheckbox,
+    },
+    {
+      key: 'levelTwo' as const,
+      shouldShow: mode === ScientificValueFilterMode.OneAndTwo || mode === ScientificValueFilterMode.All,
+      label: t('search.advanced_search.scientific_value.level', { level: 2 }),
+      testId: dataTestId.startPage.advancedSearch.scientificValueLevels.levelTwoCheckbox,
+    },
+  ];
+
   return (
-    <FormGroup row onChange={handleChange}>
-      <FormControlLabel
-        data-testid={dataTestId.startPage.advancedSearch.scientificValueLevels.levelZeroCheckbox}
-        control={<Checkbox name="levelZero" checked={selectedScientificValues.levelZero} />}
-        label={t('search.advanced_search.scientific_value.level', { level: 0 })}
-      />
-      <FormControlLabel
-        data-testid={dataTestId.startPage.advancedSearch.scientificValueLevels.levelOneCheckbox}
-        control={<Checkbox name="levelOne" checked={selectedScientificValues.levelOne} />}
-        label={t('search.advanced_search.scientific_value.level', { level: 1 })}
-      />
-      <FormControlLabel
-        data-testid={dataTestId.startPage.advancedSearch.scientificValueLevels.levelTwoCheckbox}
-        control={<Checkbox name="levelTwo" checked={selectedScientificValues.levelTwo} />}
-        label={t('search.advanced_search.scientific_value.level', { level: 2 })}
-      />
-    </FormGroup>
+    <section>
+      <StyledFilterHeading>{t('registration.resource_type.level')}</StyledFilterHeading>
+      <FormGroup row onChange={handleChange} sx={{ justifySelf: 'center' }}>
+        {checkboxConfigs
+          .filter((config) => config.shouldShow)
+          .map((config) => (
+            <FormControlLabel
+              key={config.key}
+              data-testid={config.testId}
+              control={<Checkbox name={config.key} checked={selectedScientificValues[config.key]} />}
+              label={config.label}
+            />
+          ))}
+      </FormGroup>
+    </section>
   );
 };

--- a/src/pages/search/advanced_search/ScientificValueFilter.tsx
+++ b/src/pages/search/advanced_search/ScientificValueFilter.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, FormControlLabel, FormGroup } from '@mui/material';
+import { Box, Checkbox, FormControlLabel, FormGroup } from '@mui/material';
 import { ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router';
@@ -118,7 +118,7 @@ export const ScientificValueFilter = () => {
   return (
     <section>
       <StyledFilterHeading>{t('registration.resource_type.level')}</StyledFilterHeading>
-      <FormGroup row onChange={handleChange} sx={{ justifySelf: 'center' }}>
+      <FormGroup row onChange={handleChange}>
         {checkboxConfigs
           .filter((config) => config.shouldShow)
           .map((config) => (

--- a/src/pages/search/advanced_search/ScientificValueFilter.tsx
+++ b/src/pages/search/advanced_search/ScientificValueFilter.tsx
@@ -1,4 +1,4 @@
-import { Box, Checkbox, FormControlLabel, FormGroup } from '@mui/material';
+import { Checkbox, FormControlLabel, FormGroup } from '@mui/material';
 import { ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router';

--- a/src/pages/search/advanced_search/ScientificValueFilter.tsx
+++ b/src/pages/search/advanced_search/ScientificValueFilter.tsx
@@ -14,7 +14,7 @@ export enum ScientificValueLevels {
   LevelTwo = 'LevelTwo',
 }
 
-enum ScientificValueFilterMode {
+enum ScientificValueLevelsToShow {
   UnassignedAndZero = 'UnassignedAndZero',
   OneAndTwo = 'OneAndTwo',
   All = 'All',
@@ -25,18 +25,18 @@ enum CorrectionListType {
   NonApplicableCategoriesWithApplicableChannel = 'NonApplicableCategoriesWithApplicableChannel',
 }
 
-const getScientificValueFilterModeFromParams = (searchParams: URLSearchParams): ScientificValueFilterMode => {
+const getScientificValueFiltersFromParams = (searchParams: URLSearchParams): ScientificValueLevelsToShow => {
   const listParam = searchParams.get('list') as CorrectionListType | null;
 
   switch (listParam) {
     case CorrectionListType.ApplicableCategoriesWithNonApplicableChannel:
-      return ScientificValueFilterMode.UnassignedAndZero;
+      return ScientificValueLevelsToShow.UnassignedAndZero;
 
     case CorrectionListType.NonApplicableCategoriesWithApplicableChannel:
-      return ScientificValueFilterMode.OneAndTwo;
+      return ScientificValueLevelsToShow.OneAndTwo;
 
     default:
-      return ScientificValueFilterMode.All;
+      return ScientificValueLevelsToShow.All;
   }
 };
 
@@ -45,7 +45,7 @@ export const ScientificValueFilter = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
-  const mode = getScientificValueFilterModeFromParams(searchParams);
+  const levelsToShow = getScientificValueFiltersFromParams(searchParams);
   const scientificValueParam = searchParams.get(ResultParam.ScientificValue) ?? '';
 
   const selectedScientificValues = {
@@ -85,25 +85,31 @@ export const ScientificValueFilter = () => {
   const checkboxConfigs = [
     {
       key: 'unassigned' as const,
-      shouldShow: mode === ScientificValueFilterMode.UnassignedAndZero || mode === ScientificValueFilterMode.All,
+      shouldShow:
+        levelsToShow === ScientificValueLevelsToShow.UnassignedAndZero ||
+        levelsToShow === ScientificValueLevelsToShow.All,
       label: t('search.advanced_search.scientific_value.unassigned'),
       testId: dataTestId.startPage.advancedSearch.scientificValueLevels.unassignedCheckbox,
     },
     {
       key: 'levelZero' as const,
-      shouldShow: mode === ScientificValueFilterMode.UnassignedAndZero || mode === ScientificValueFilterMode.All,
+      shouldShow:
+        levelsToShow === ScientificValueLevelsToShow.UnassignedAndZero ||
+        levelsToShow === ScientificValueLevelsToShow.All,
       label: t('search.advanced_search.scientific_value.level', { level: 0 }),
       testId: dataTestId.startPage.advancedSearch.scientificValueLevels.levelZeroCheckbox,
     },
     {
       key: 'levelOne' as const,
-      shouldShow: mode === ScientificValueFilterMode.OneAndTwo || mode === ScientificValueFilterMode.All,
+      shouldShow:
+        levelsToShow === ScientificValueLevelsToShow.OneAndTwo || levelsToShow === ScientificValueLevelsToShow.All,
       label: t('search.advanced_search.scientific_value.level', { level: 1 }),
       testId: dataTestId.startPage.advancedSearch.scientificValueLevels.levelOneCheckbox,
     },
     {
       key: 'levelTwo' as const,
-      shouldShow: mode === ScientificValueFilterMode.OneAndTwo || mode === ScientificValueFilterMode.All,
+      shouldShow:
+        levelsToShow === ScientificValueLevelsToShow.OneAndTwo || levelsToShow === ScientificValueLevelsToShow.All,
       label: t('search.advanced_search.scientific_value.level', { level: 2 }),
       testId: dataTestId.startPage.advancedSearch.scientificValueLevels.levelTwoCheckbox,
     },

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1872,7 +1872,8 @@
       "publishing_period": "Publiseringsperiode",
       "reported": "Rapporterte",
       "scientific_value": {
-        "level": "Nivå {{level}}"
+        "level": "Nivå {{level}}",
+        "unassigned": "Ikke bestemt"
       },
       "title_search": "Tittelsøk"
     },

--- a/src/utils/dataTestIds.ts
+++ b/src/utils/dataTestIds.ts
@@ -246,6 +246,7 @@ export const dataTestId = {
       removeFilterButton: 'remove-filter-button',
       scientificIndexStatusCheckbox: 'scientific-index-status-checkbox',
       scientificValueLevels: {
+        unassignedCheckbox: 'unassigned-checkbox',
         levelOneCheckbox: 'level-one-checkbox',
         levelTwoCheckbox: 'level-two-checkbox',
         levelZeroCheckbox: 'level-zero-checkbox',

--- a/src/utils/hooks/useCorrectionListConfig.ts
+++ b/src/utils/hooks/useCorrectionListConfig.ts
@@ -14,7 +14,7 @@ export const useCorrectionListConfig = (): CorrectionListSearchConfig => {
       i18nKey: 'tasks.nvi.correction_list_type.applicable_category_in_non_applicable_channel',
       queryParams: {
         categoryShould: nviApplicableTypes,
-        allScientificValues: ScientificValueLevels.LevelZero,
+        allScientificValues: [ScientificValueLevels.Unassigned, ScientificValueLevels.LevelZero].join(','),
       },
       disabledFilters: [],
       topLevelOrganization: userTopLevelOrg,


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-50653

Add `ScientificValueFilter` to applicable correction lists. Also refactored the component for easier conditional rendering of checkboxes. 

# How to test

Affected part of the application: [Correction List](http://localhost:3000/tasks/correction-list?list=ApplicableCategoriesWithNonApplicableChannel&categoryShould=AcademicArticle%2CAcademicLiteratureReview%2CAcademicMonograph%2CAcademicCommentary%2CAcademicChapter&topLevelOrganization=https%3A%2F%2Fapi.dev.nva.aws.unit.no%2Fcristin%2Forganization%2F20754.0.0.0&publicationYear=2025)

Confirm that the correct checkboxes are shown for the top two correction lists, and are filtering as intended. Should also confirm that it still owrks on `AdvancedSearch`

P.S It is intentional that the boxes are not checked by default, since the user does not have the context of the correction list itself when entering the page. In my opinion, it makes more sense that they apply a filter, rather than remove it.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Expanded scientific value filtering in advanced search and correction lists with support for "Unassigned" items, enabling users to identify and filter entries without assigned scientific value levels alongside existing level-based filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->