### PR TITLE
Add support for scientific chapters not in anthology in correction list

### DIFF
--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -375,6 +375,7 @@ export enum ResultParam {
   CristinIdentifier = 'cristinIdentifier',
   Doi = 'doi',
   ExcludeSubunits = 'excludeSubunits',
+  ExcludeParentType = 'excludeParentType',
   Files = 'files',
   From = 'from',
   FundingIdentifier = 'fundingIdentifier',
@@ -431,6 +432,7 @@ export interface FetchResultsParams {
   [ResultParam.CristinIdentifier]?: string | null;
   [ResultParam.Doi]?: string | null;
   [ResultParam.ExcludeSubunits]?: boolean | null;
+  [ResultParam.ExcludeParentType]?: PublicationInstanceType[] | null;
   [ResultParam.Files]?: string | null;
   [ResultParam.From]?: number | null;
   [ResultParam.FundingIdentifier]?: string | null;

--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -374,6 +374,7 @@ export enum ResultParam {
   Course = 'course',
   CristinIdentifier = 'cristinIdentifier',
   Doi = 'doi',
+  ExcludeParentType = 'excludeParentType',
   ExcludeSubunits = 'excludeSubunits',
   Files = 'files',
   From = 'from',
@@ -389,7 +390,6 @@ export enum ResultParam {
   Issn = 'issn',
   Journal = 'journal',
   Order = 'order',
-  ParentType = 'parentType',
   Project = 'project',
   PublicationLanguageShould = 'publicationLanguageShould',
   PublicationPages = 'publicationPages',
@@ -432,6 +432,7 @@ export interface FetchResultsParams {
   [ResultParam.Course]?: string | null;
   [ResultParam.CristinIdentifier]?: string | null;
   [ResultParam.Doi]?: string | null;
+  [ResultParam.ExcludeParentType]?: PublicationInstanceType[] | null;
   [ResultParam.ExcludeSubunits]?: boolean | null;
   [ResultParam.Files]?: string | null;
   [ResultParam.From]?: number | null;
@@ -447,7 +448,6 @@ export interface FetchResultsParams {
   [ResultParam.Issn]?: string | null;
   [ResultParam.Journal]?: string | null;
   [ResultParam.Order]?: ResultSearchOrder | null;
-  [ResultParam.ParentType]?: PublicationInstanceType[] | null;
   [ResultParam.Project]?: string | null;
   [ResultParam.PublicationLanguageShould]?: string | null;
   [ResultParam.PublicationPages]?: string | null;
@@ -512,6 +512,9 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
     const formattedDoiValue = getDoiValue(params.doi);
     searchParams.set(ResultParam.Doi, formattedDoiValue);
   }
+  if (params.excludeParentType?.length) {
+    searchParams.set(ResultParam.ExcludeParentType, params.excludeParentType.join(','));
+  }
   if (params.excludeSubunits) {
     searchParams.set(ResultParam.ExcludeSubunits, params.excludeSubunits.toString());
   }
@@ -550,9 +553,6 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
   }
   if (params.journal) {
     searchParams.set(ResultParam.Journal, params.journal);
-  }
-  if (params.parentType) {
-    searchParams.set(ResultParam.ParentType, params.parentType.join(','));
   }
   if (params.project) {
     searchParams.set(ResultParam.Project, params.project);

--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -614,11 +614,6 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
   searchParams.set(ResultParam.Order, params.order ?? ResultSearchOrder.ModifiedDate);
   searchParams.set(ResultParam.Sort, params.sort ?? 'desc');
 
-  console.log('params', params);
-  console.log('params.excludeParentType', params.excludeParentType);
-  console.log('searchParams', searchParams);
-  console.log('searchParams.excludeParentType', searchParams.excludeParentType);
-
   const getResults = await apiRequest2<RegistrationSearchResponse>({
     url: `${SearchApiPath.Registrations}?${searchParams.toString()}`,
     // TODO: Remove version when it becomes default

--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -375,7 +375,6 @@ export enum ResultParam {
   CristinIdentifier = 'cristinIdentifier',
   Doi = 'doi',
   ExcludeSubunits = 'excludeSubunits',
-  ExcludeParentType = 'excludeParentType',
   Files = 'files',
   From = 'from',
   FundingIdentifier = 'fundingIdentifier',
@@ -383,12 +382,14 @@ export enum ResultParam {
   Handle = 'handle',
   HasChildren = 'hasChildren',
   HasNoChildren = 'hasNoChildren',
+  HasParent = 'hasParent',
   Identifier = 'id',
   IdentifierNot = 'idNot',
   Isbn = 'isbn',
   Issn = 'issn',
   Journal = 'journal',
   Order = 'order',
+  ParentType = 'parentType',
   Project = 'project',
   PublicationLanguageShould = 'publicationLanguageShould',
   PublicationPages = 'publicationPages',
@@ -432,7 +433,6 @@ export interface FetchResultsParams {
   [ResultParam.CristinIdentifier]?: string | null;
   [ResultParam.Doi]?: string | null;
   [ResultParam.ExcludeSubunits]?: boolean | null;
-  [ResultParam.ExcludeParentType]?: PublicationInstanceType[] | null;
   [ResultParam.Files]?: string | null;
   [ResultParam.From]?: number | null;
   [ResultParam.FundingIdentifier]?: string | null;
@@ -440,12 +440,14 @@ export interface FetchResultsParams {
   [ResultParam.Handle]?: string | null;
   [ResultParam.HasChildren]?: boolean | null;
   [ResultParam.HasNoChildren]?: boolean | null;
+  [ResultParam.HasParent]?: boolean | null;
   [ResultParam.Identifier]?: string | null;
   [ResultParam.IdentifierNot]?: string | null;
   [ResultParam.Isbn]?: string | null;
   [ResultParam.Issn]?: string | null;
   [ResultParam.Journal]?: string | null;
   [ResultParam.Order]?: ResultSearchOrder | null;
+  [ResultParam.ParentType]?: PublicationInstanceType[] | null;
   [ResultParam.Project]?: string | null;
   [ResultParam.PublicationLanguageShould]?: string | null;
   [ResultParam.PublicationPages]?: string | null;
@@ -513,9 +515,6 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
   if (params.excludeSubunits) {
     searchParams.set(ResultParam.ExcludeSubunits, params.excludeSubunits.toString());
   }
-  if (params.excludeParentType) {
-    searchParams.set(ResultParam.ExcludeParentType, params.excludeParentType.join(','));
-  }
   if (params.files) {
     searchParams.set(ResultParam.Files, params.files);
   }
@@ -534,6 +533,9 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
   if (params.hasNoChildren === true || params.hasNoChildren === false) {
     searchParams.set(ResultParam.HasNoChildren, params.hasNoChildren.toString());
   }
+  if (params.hasParent) {
+    searchParams.set(ResultParam.HasParent, params.hasParent.toString());
+  }
   if (params.id) {
     searchParams.set(ResultParam.Identifier, params.id);
   }
@@ -548,6 +550,9 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
   }
   if (params.journal) {
     searchParams.set(ResultParam.Journal, params.journal);
+  }
+  if (params.parentType) {
+    searchParams.set(ResultParam.ParentType, params.parentType.join(','));
   }
   if (params.project) {
     searchParams.set(ResultParam.Project, params.project);

--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -513,6 +513,9 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
   if (params.excludeSubunits) {
     searchParams.set(ResultParam.ExcludeSubunits, params.excludeSubunits.toString());
   }
+  if (params.excludeParentType) {
+    searchParams.set(ResultParam.ExcludeParentType, params.excludeParentType.join(','));
+  }
   if (params.files) {
     searchParams.set(ResultParam.Files, params.files);
   }
@@ -610,6 +613,11 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
   searchParams.set(ResultParam.Results, typeof params.results === 'number' ? params.results.toString() : '10');
   searchParams.set(ResultParam.Order, params.order ?? ResultSearchOrder.ModifiedDate);
   searchParams.set(ResultParam.Sort, params.sort ?? 'desc');
+
+  console.log('params', params);
+  console.log('params.excludeParentType', params.excludeParentType);
+  console.log('searchParams', searchParams);
+  console.log('searchParams.excludeParentType', searchParams.excludeParentType);
 
   const getResults = await apiRequest2<RegistrationSearchResponse>({
     url: `${SearchApiPath.Registrations}?${searchParams.toString()}`,

--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -533,7 +533,7 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
   if (params.hasNoChildren === true || params.hasNoChildren === false) {
     searchParams.set(ResultParam.HasNoChildren, params.hasNoChildren.toString());
   }
-  if (params.hasParent) {
+  if (params.hasParent === true || params.hasParent === false) {
     searchParams.set(ResultParam.HasParent, params.hasParent.toString());
   }
   if (params.id) {

--- a/src/pages/messages/components/NviCorrectionList.tsx
+++ b/src/pages/messages/components/NviCorrectionList.tsx
@@ -70,7 +70,8 @@ export const NviCorrectionList = () => {
               </Box>
 
               {(listId === 'ApplicableCategoriesWithNonApplicableChannel' ||
-                listId === 'NonApplicableCategoriesWithApplicableChannel') && <ScientificValueFilter />}
+                listId === 'NonApplicableCategoriesWithApplicableChannel' ||
+                listId === 'ScientificChapterNotInAnthology') && <ScientificValueFilter />}
 
               <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem 1rem' }}>
                 <PublisherFilter />

--- a/src/pages/messages/components/NviCorrectionListNavigationAccordion.tsx
+++ b/src/pages/messages/components/NviCorrectionListNavigationAccordion.tsx
@@ -75,6 +75,12 @@ export const NviCorrectionListNavigationAccordion = () => {
           onClick={() => openNewCorrectionList('UnidentifiedContributorWithIdentifiedAffiliation')}>
           {t('tasks.nvi.correction_list_type.unidentified_contributor_with_identified_affiliation')}
         </SelectableButton>
+        <SelectableButton
+          data-testid={dataTestId.tasksPage.correctionList.scientificChapterNotInAnthology}
+          isSelected={selectedNviList === 'ScientificChapterNotInAnthology'}
+          onClick={() => openNewCorrectionList('ScientificChapterNotInAnthology')}>
+          {t('tasks.nvi.correction_list_type.scientific_chapter_not_in_anthology')}
+        </SelectableButton>
       </NavigationList>
     </NavigationListAccordion>
   );

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1964,7 +1964,8 @@
         "applicable_category_in_non_applicable_channel": "Tellende kategorier i ikke-tellende kanaler",
         "book_with_less_than_50_pages": "Bøker med færre enn 50 sider",
         "non_applicable_category_in_applicable_channel": "Ikke-tellende kategorier i tellende kanaler",
-        "unidentified_contributor_with_identified_affiliation": "Uidentifisert bidragsyter med identifisert institusjon"
+        "unidentified_contributor_with_identified_affiliation": "Uidentifisert bidragsyter med identifisert institusjon",
+        "scientific_chapter_not_in_anthology": "Vitenskapelig kapittel ikke i antologi"
       },
       "delete_note": "Slett kommentar",
       "delete_note_description": "Er du sikker på at du vil slette denne kommentaren?",
@@ -2055,5 +2056,9 @@
   "publication_points": "Publiseringspoeng",
   "x_results_are_ready_for_reporting_and_they_give_y_publication_points": "<b>{{num_results}} resultat</b> er klar for rapportering, og de gir <b>{{total_publicationpoints}} publiseringspoeng.</b>",
   "percent_of_published_reports_in_year": "Det er <b>{{percentage}}%</b> av antallet resultat rapportert i {{year}}.",
-  "percent_of_publication_points_in_year": "Det er <b>{{percentage}}%</b> av antallet publiseringspoeng i {{year}}."
+  "percent_of_publication_points_in_year": "Det er <b>{{percentage}}%</b> av antallet publiseringspoeng i {{year}}.",
+  "channel_level": "Kanalnivå",
+  "level_0": "Nivå 0",
+  "level_1": "Nivå 1",
+  "level_2": "Nivå 2"
 }

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -2057,9 +2057,5 @@
   "publication_points": "Publiseringspoeng",
   "x_results_are_ready_for_reporting_and_they_give_y_publication_points": "<b>{{num_results}} resultat</b> er klar for rapportering, og de gir <b>{{total_publicationpoints}} publiseringspoeng.</b>",
   "percent_of_published_reports_in_year": "Det er <b>{{percentage}}%</b> av antallet resultat rapportert i {{year}}.",
-  "percent_of_publication_points_in_year": "Det er <b>{{percentage}}%</b> av antallet publiseringspoeng i {{year}}.",
-  "channel_level": "Kanalnivå",
-  "level_0": "Nivå 0",
-  "level_1": "Nivå 1",
-  "level_2": "Nivå 2"
+  "percent_of_publication_points_in_year": "Det er <b>{{percentage}}%</b> av antallet publiseringspoeng i {{year}}."
 }

--- a/src/types/nvi.types.ts
+++ b/src/types/nvi.types.ts
@@ -167,7 +167,8 @@ export type CorrectionListId =
   | 'AnthologyWithoutChapter'
   | 'AnthologyWithApplicableChapter'
   | 'BooksWithLessThan50Pages'
-  | 'UnidentifiedContributorWithIdentifiedAffiliation';
+  | 'UnidentifiedContributorWithIdentifiedAffiliation'
+  | 'ScientificChapterNotInAnthology';
 
 export type CorrectionListSearchConfig = {
   [key in CorrectionListId]: {

--- a/src/utils/correctionListHelpers.ts
+++ b/src/utils/correctionListHelpers.ts
@@ -11,7 +11,6 @@ export const getCorrectionListSearchParams = (
   newSearchParams.set(nviCorrectionListQueryKey, newCorrectionListId);
   const correctionListCategoryFilter = correctionListConfig[newCorrectionListId].queryParams.categoryShould;
   const correctionListTopLevelOrgFilter = correctionListConfig[newCorrectionListId].topLevelOrganization;
-  const parentTypeFilter = correctionListConfig[newCorrectionListId].queryParams.parentType;
   const scientificValueFilter = correctionListConfig[newCorrectionListId].queryParams.scientificValue;
   if (correctionListCategoryFilter && correctionListCategoryFilter.length > 0) {
     newSearchParams.set(ResultParam.CategoryShould, correctionListCategoryFilter.join(','));
@@ -21,9 +20,6 @@ export const getCorrectionListSearchParams = (
     newSearchParams.set(ResultParam.TopLevelOrganization, correctionListTopLevelOrgFilter);
   }
 
-  if (parentTypeFilter) {
-    newSearchParams.set(ResultParam.ParentType, parentTypeFilter.join(','));
-  }
   if (scientificValueFilter) {
     newSearchParams.set(ResultParam.ScientificValue, scientificValueFilter);
   }

--- a/src/utils/correctionListHelpers.ts
+++ b/src/utils/correctionListHelpers.ts
@@ -11,7 +11,8 @@ export const getCorrectionListSearchParams = (
   newSearchParams.set(nviCorrectionListQueryKey, newCorrectionListId);
   const correctionListCategoryFilter = correctionListConfig[newCorrectionListId].queryParams.categoryShould;
   const correctionListTopLevelOrgFilter = correctionListConfig[newCorrectionListId].topLevelOrganization;
-  const excludeParentTypeFilter = correctionListConfig[newCorrectionListId].queryParams.excludeParentType;
+  const parentTypeFilter = correctionListConfig[newCorrectionListId].queryParams.parentType;
+  const scientificValueFilter = correctionListConfig[newCorrectionListId].queryParams.scientificValue;
   if (correctionListCategoryFilter && correctionListCategoryFilter.length > 0) {
     newSearchParams.set(ResultParam.CategoryShould, correctionListCategoryFilter.join(','));
   }
@@ -20,8 +21,11 @@ export const getCorrectionListSearchParams = (
     newSearchParams.set(ResultParam.TopLevelOrganization, correctionListTopLevelOrgFilter);
   }
 
-  if (excludeParentTypeFilter) {
-    newSearchParams.set(ResultParam.ExcludeParentType, excludeParentTypeFilter.join(','));
+  if (parentTypeFilter) {
+    newSearchParams.set(ResultParam.ParentType, parentTypeFilter.join(','));
+  }
+  if (scientificValueFilter) {
+    newSearchParams.set(ResultParam.ScientificValue, scientificValueFilter);
   }
   newSearchParams.set(ResultParam.PublicationYear, (new Date().getFullYear() - 1).toString());
   return newSearchParams;

--- a/src/utils/correctionListHelpers.ts
+++ b/src/utils/correctionListHelpers.ts
@@ -1,6 +1,6 @@
 import { ResultParam } from '../api/searchApi';
 import { nviCorrectionListQueryKey } from '../pages/messages/components/NviCorrectionList';
-import { CorrectionListSearchConfig, CorrectionListId } from '../types/nvi.types';
+import { CorrectionListId, CorrectionListSearchConfig } from '../types/nvi.types';
 import { UrlPathTemplate } from './urlPaths';
 
 export const getCorrectionListSearchParams = (
@@ -11,12 +11,17 @@ export const getCorrectionListSearchParams = (
   newSearchParams.set(nviCorrectionListQueryKey, newCorrectionListId);
   const correctionListCategoryFilter = correctionListConfig[newCorrectionListId].queryParams.categoryShould;
   const correctionListTopLevelOrgFilter = correctionListConfig[newCorrectionListId].topLevelOrganization;
+  const excludeParentTypeFilter = correctionListConfig[newCorrectionListId].queryParams.excludeParentType;
   if (correctionListCategoryFilter && correctionListCategoryFilter.length > 0) {
     newSearchParams.set(ResultParam.CategoryShould, correctionListCategoryFilter.join(','));
   }
 
   if (correctionListTopLevelOrgFilter) {
     newSearchParams.set(ResultParam.TopLevelOrganization, correctionListTopLevelOrgFilter);
+  }
+
+  if (excludeParentTypeFilter) {
+    newSearchParams.set(ResultParam.ExcludeParentType, excludeParentTypeFilter.join(','));
   }
   newSearchParams.set(ResultParam.PublicationYear, (new Date().getFullYear() - 1).toString());
   return newSearchParams;

--- a/src/utils/dataTestIds.ts
+++ b/src/utils/dataTestIds.ts
@@ -773,11 +773,6 @@ export const dataTestId = {
       unidentifiedContributorWithIdentifiedAffiliationButton:
         'unidentified-contributor-with-identified-affiliation-button',
       scientificChapterNotInAnthology: 'scientific-chapter-not-in-anthology',
-      channelLevelSelect: {
-        level0: 'channel-level-select-0',
-        level1: 'channel-level-select-1',
-        level2: 'channel-level-select-2',
-      },
     },
     curatorSelector: 'curator-selector',
     dialoguesWithoutCuratorButton: 'dialogues-without-curator-button',

--- a/src/utils/dataTestIds.ts
+++ b/src/utils/dataTestIds.ts
@@ -771,6 +771,12 @@ export const dataTestId = {
       nonApplicableCategoriesWithApplicableChannelButton: 'non-applicable-categories-with-applicable-channel-button',
       unidentifiedContributorWithIdentifiedAffiliationButton:
         'unidentified-contributor-with-identified-affiliation-button',
+      scientificChapterNotInAnthology: 'scientific-chapter-not-in-anthology',
+      channelLevelSelect: {
+        level0: 'channel-level-select-0',
+        level1: 'channel-level-select-1',
+        level2: 'channel-level-select-2',
+      },
     },
     curatorSelector: 'curator-selector',
     dialoguesWithoutCuratorButton: 'dialogues-without-curator-button',

--- a/src/utils/hooks/useCorrectionListConfig.ts
+++ b/src/utils/hooks/useCorrectionListConfig.ts
@@ -70,7 +70,7 @@ export const useCorrectionListConfig = (): CorrectionListSearchConfig => {
       queryParams: {
         categoryShould: [ChapterType.AcademicChapter],
         parentType: [BookType.AcademicMonograph, BookType.AcademicCommentary],
-        scientificValue: 'LevelOne,LevelTwo',
+        scientificValue: [ScientificValueLevels.LevelOne, ScientificValueLevels.LevelTwo].join(','),
         hasParent: true,
       },
       disabledFilters: [],

--- a/src/utils/hooks/useCorrectionListConfig.ts
+++ b/src/utils/hooks/useCorrectionListConfig.ts
@@ -68,16 +68,10 @@ export const useCorrectionListConfig = (): CorrectionListSearchConfig => {
     ScientificChapterNotInAnthology: {
       i18nKey: 'tasks.nvi.correction_list_type.scientific_chapter_not_in_anthology',
       queryParams: {
-        unidentifiedNorwegian: true,
         categoryShould: [ChapterType.AcademicChapter],
-        excludeParentType: [
-          BookType.NonFictionMonograph,
-          BookType.PopularScienceMonograph,
-          BookType.Textbook,
-          BookType.Encyclopedia,
-          BookType.ExhibitionCatalog,
-          BookType.Anthology,
-        ],
+        parentType: [BookType.AcademicMonograph, BookType.AcademicCommentary],
+        scientificValue: 'LevelOne,LevelTwo',
+        hasParent: true,
       },
       disabledFilters: [],
       topLevelOrganization: userTopLevelOrg,

--- a/src/utils/hooks/useCorrectionListConfig.ts
+++ b/src/utils/hooks/useCorrectionListConfig.ts
@@ -69,7 +69,7 @@ export const useCorrectionListConfig = (): CorrectionListSearchConfig => {
       i18nKey: 'tasks.nvi.correction_list_type.scientific_chapter_not_in_anthology',
       queryParams: {
         categoryShould: [ChapterType.AcademicChapter],
-        parentType: [BookType.AcademicMonograph, BookType.AcademicCommentary],
+        excludeParentType: [BookType.Anthology],
         scientificValue: [ScientificValueLevels.LevelOne, ScientificValueLevels.LevelTwo].join(','),
         hasParent: true,
       },

--- a/src/utils/hooks/useCorrectionListConfig.ts
+++ b/src/utils/hooks/useCorrectionListConfig.ts
@@ -1,7 +1,7 @@
 import { ResultParam } from '../../api/searchApi';
 import { ScientificValueLevels } from '../../pages/search/advanced_search/ScientificValueFilter';
 import { CorrectionListSearchConfig } from '../../types/nvi.types';
-import { BookType } from '../../types/publicationFieldNames';
+import { BookType, ChapterType } from '../../types/publicationFieldNames';
 import { nviApplicableTypes } from '../registration-helpers';
 import { useLoggedInUser } from './useLoggedInUser';
 
@@ -61,6 +61,23 @@ export const useCorrectionListConfig = (): CorrectionListSearchConfig => {
       queryParams: {
         unidentifiedNorwegian: true,
         categoryShould: nviApplicableTypes,
+      },
+      disabledFilters: [],
+      topLevelOrganization: userTopLevelOrg,
+    },
+    ScientificChapterNotInAnthology: {
+      i18nKey: 'tasks.nvi.correction_list_type.scientific_chapter_not_in_anthology',
+      queryParams: {
+        unidentifiedNorwegian: true,
+        categoryShould: [ChapterType.AcademicChapter],
+        excludeParentType: [
+          BookType.NonFictionMonograph,
+          BookType.PopularScienceMonograph,
+          BookType.Textbook,
+          BookType.Encyclopedia,
+          BookType.ExhibitionCatalog,
+          BookType.Anthology,
+        ],
       },
       disabledFilters: [],
       topLevelOrganization: userTopLevelOrg,


### PR DESCRIPTION
# Description

Link to Jira issue: [Legg til ny retteliste for vitenskapelige kapitler ikke i antologi](https://sikt.atlassian.net/browse/NP-50586)

# How to test

Affected part of the application: Correction lists

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Introduced a new correction list category for scientific chapters not published in anthologies, with dedicated filtering options, navigation controls, and localised labels.
- Enhanced search capabilities with new filters to identify results based on parent publication type and parent publication status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->