### PR TITLE
NP-50780 Internal file info banner

### DIFF
--- a/src/components/InfoBanner.tsx
+++ b/src/components/InfoBanner.tsx
@@ -6,7 +6,7 @@ import { Paper, PaperProps, Typography } from '@mui/material';
 interface InfoBannerProps extends PaperProps {
   text: string;
   size?: 'small' | 'large';
-  type?: 'info' | 'warning' | 'error';
+  type?: 'info' | 'info-light' | 'warning' | 'error';
 }
 
 export const InfoBanner = ({ text, type = 'info', sx, size = 'large', ...props }: InfoBannerProps) => {
@@ -18,18 +18,20 @@ export const InfoBanner = ({ text, type = 'info', sx, size = 'large', ...props }
         gap: '0.5rem',
         alignItems: 'center',
         p: size === 'large' ? '1rem' : '0.3rem 2rem',
-        bgcolor: `${type}.main`,
+        bgcolor: type === 'info-light' ? '#E6F0FF' : `${type}.main`,
         ...sx,
       }}
       {...props}>
       {type === 'info' ? (
         <InfoIcon fontSize={size} sx={{ color: 'white' }} />
+      ) : type === 'info-light' ? (
+        <InfoIcon fontSize={size} sx={{ color: 'blue' }} />
       ) : type === 'warning' ? (
         <WarningIcon fontSize={size} sx={{ color: 'primary.main' }} />
       ) : (
         <ErrorIcon fontSize={size} sx={{ color: 'white' }} />
       )}
-      <Typography color={type === 'warning' ? 'black' : 'white'}>{text}</Typography>
+      <Typography color={type === 'warning' || type === 'info-light' ? 'black' : 'white'}>{text}</Typography>
     </Paper>
   );
 };

--- a/src/pages/registration/FilesAndLicensePanel.tsx
+++ b/src/pages/registration/FilesAndLicensePanel.tsx
@@ -200,6 +200,10 @@ export const FilesAndLicensePanel = ({ uppy }: FilesAndLicensePanelProps) => {
                   />
                 )}
 
+                {pendingFiles.every((file) => file.type === FileType.PendingInternalFile) && (
+                  <InfoBanner type="info-light" text={t('internal_file_info_description')} />
+                )}
+
                 {pendingFiles.length > 0 && (
                   <FileList
                     title={t('registration.files_and_license.files_in_progress')}

--- a/src/pages/registration/FilesAndLicensePanel.tsx
+++ b/src/pages/registration/FilesAndLicensePanel.tsx
@@ -200,9 +200,10 @@ export const FilesAndLicensePanel = ({ uppy }: FilesAndLicensePanelProps) => {
                   />
                 )}
 
-                {pendingFiles.every((file) => file.type === FileType.PendingInternalFile) && (
-                  <InfoBanner type="info-light" text={t('internal_file_info_description')} />
-                )}
+                {pendingFiles.length > 0 &&
+                  pendingFiles.every((file) => file.type === FileType.PendingInternalFile) && (
+                    <InfoBanner type="info-light" text={t('internal_file_info_description')} />
+                  )}
 
                 {pendingFiles.length > 0 && (
                   <FileList

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -2056,5 +2056,6 @@
   "publication_points": "Publiseringspoeng",
   "x_results_are_ready_for_reporting_and_they_give_y_publication_points": "<b>{{num_results}} resultat</b> er klar for rapportering, og de gir <b>{{total_publicationpoints}} publiseringspoeng.</b>",
   "percent_of_published_reports_in_year": "Det er <b>{{percentage}}%</b> av antallet resultat rapportert i {{year}}.",
-  "percent_of_publication_points_in_year": "Det er <b>{{percentage}}%</b> av antallet publiseringspoeng i {{year}}."
+  "percent_of_publication_points_in_year": "Det er <b>{{percentage}}%</b> av antallet publiseringspoeng i {{year}}.",
+  "internal_file_info_description": "Internfiler skal primært ikke benyttes for resultater, men til kommunikasjon med kurator, forfatteravtaler o.l. Resultater skal i utgangspunktet publiseres som åpen fil. Velg i så fall hvilken versjon som skal publiseres og hvilken lisens den har."
 }


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-50780

Add an infobanner when the only filetype in pending files are set to "internal File"

# How to test

Affected part of the application: [Insert URL]

Add an internal file to a publication. The banner should not appear if there is an open file

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new light-information banner variant with blue styling for improved visual distinction.
  * Information banners now appear contextually when managing internal files, providing relevant guidance to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->