### PR TITLE
Enhance message list UI with icons and improved layout

### DIFF
--- a/src/components/styled/Wrappers.tsx
+++ b/src/components/styled/Wrappers.tsx
@@ -121,7 +121,7 @@ export const MediumTypography = styled(Typography)({
   fontSize: '0.9rem',
 });
 
-export const StyledTruncatableTypography = styled(Typography)({
+export const EllipsisTypography = styled(Typography)({
   whiteSpace: 'nowrap',
   overflow: 'hidden',
   textOverflow: 'ellipsis',

--- a/src/pages/basic_data/app_admin/central_import/CentralImportDuplicationCheckPage.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportDuplicationCheckPage.tsx
@@ -175,6 +175,7 @@ export const CentralImportDuplicationCheckPage = () => {
                 text={importCandidate.importStatus.comment}
                 date={importCandidate.importStatus.modifiedDate ?? ''}
                 username={importCandidate.importStatus.setBy ?? ''}
+                messageType={'Justification'}
                 backgroundColor="centralImport.main"
               />
             </>

--- a/src/pages/basic_data/app_admin/central_import/CentralImportDuplicationCheckPage.tsx
+++ b/src/pages/basic_data/app_admin/central_import/CentralImportDuplicationCheckPage.tsx
@@ -176,7 +176,7 @@ export const CentralImportDuplicationCheckPage = () => {
                 date={importCandidate.importStatus.modifiedDate ?? ''}
                 username={importCandidate.importStatus.setBy ?? ''}
                 messageType={'Justification'}
-                backgroundColor="centralImport.main"
+                backgroundColor="background.neutral87"
               />
             </>
           )}

--- a/src/pages/messages/components/MessageList.tsx
+++ b/src/pages/messages/components/MessageList.tsx
@@ -1,10 +1,12 @@
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
+import ChatBubbleIcon from '@mui/icons-material/ChatBubble';
 import { Box, BoxProps, Divider, Skeleton, Tooltip, Typography } from '@mui/material';
 import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useFetchUserQuery } from '../../../api/hooks/useFetchUserQuery';
 import { ErrorBoundary } from '../../../components/ErrorBoundary';
-import { StyledTruncatableTypography } from '../../../components/styled/Wrappers';
+import { HorizontalBox, StyledTruncatableTypography } from '../../../components/styled/Wrappers';
 import { RootState } from '../../../redux/store';
 import { Ticket } from '../../../types/publication_types/ticket.types';
 import { dataTestId } from '../../../utils/dataTestIds';
@@ -77,37 +79,49 @@ export const MessageItem = ({ text, date, username, menuElement, showOrganizatio
         flexDirection: 'column',
       }}>
       <Box sx={{ display: 'grid', gridTemplateColumns: '1fr auto auto', alignItems: 'center', gap: '0.3rem' }}>
-        <Tooltip title={senderName ? senderName : t('common.unknown')}>
-          <StyledTruncatableTypography
-            data-testid={dataTestId.registrationLandingPage.tasksPanel.messageSender}
-            sx={{ fontWeight: 'bold' }}>
-            {senderQuery.isPending ? (
-              <Skeleton sx={{ width: '8rem' }} />
-            ) : senderName ? (
-              senderName
-            ) : (
-              <i>{t('common.unknown')}</i>
-            )}
-          </StyledTruncatableTypography>
-        </Tooltip>
+        <HorizontalBox sx={{ gap: '0.25rem' }}>
+          <ChatBubbleIcon sx={{ fontSize: '1.1rem' }} />
+          <Typography sx={{ fontWeight: 'bold' }}>{t('tasks.nvi.note')}</Typography>
+        </HorizontalBox>
         {showOrganization ? (
           <MessageItemOrganization organizationId={senderQuery.data?.institutionCristinId ?? ''} />
-        ) : (
-          <Typography data-testid={dataTestId.registrationLandingPage.tasksPanel.messageTimestamp}>
-            {toDateString(date)}
-          </Typography>
-        )}
+        ) : undefined}
         {menuElement}
       </Box>
 
       <Divider sx={{ mb: '0.5rem', bgcolor: 'primary.main' }} />
 
       <Box
-        sx={{ color: 'primary.main' }}
+        sx={{ color: 'primary.main', my: '0.1rem' }}
         data-testid={dataTestId.registrationLandingPage.tasksPanel.messageText}
         component={typeof text === 'string' ? Typography : 'div'}>
         {text ? text : <i>{t('my_page.messages.message_deleted')}</i>}
       </Box>
+      <HorizontalBox>
+        <Box sx={{ flexGrow: 1 }}>
+          <Tooltip title={senderName ? senderName : t('common.unknown')}>
+            <StyledTruncatableTypography
+              data-testid={dataTestId.registrationLandingPage.tasksPanel.messageSender}
+              sx={{ fontWeight: 'bold' }}>
+              {senderQuery.isPending ? (
+                <Skeleton sx={{ width: '8rem' }} />
+              ) : senderName ? (
+                senderName
+              ) : (
+                <i>{t('common.unknown')}</i>
+              )}
+            </StyledTruncatableTypography>
+          </Tooltip>
+        </Box>
+        <HorizontalBox>
+          <CalendarMonthIcon />
+          <Typography
+            sx={{ pt: '0.1rem' }}
+            data-testid={dataTestId.registrationLandingPage.tasksPanel.messageTimestamp}>
+            {toDateString(date)}
+          </Typography>
+        </HorizontalBox>
+      </HorizontalBox>
     </Box>
   );
 };

--- a/src/pages/messages/components/MessageList.tsx
+++ b/src/pages/messages/components/MessageList.tsx
@@ -1,16 +1,17 @@
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import ChatBubbleIcon from '@mui/icons-material/ChatBubble';
+import SellIcon from '@mui/icons-material/Sell';
 import { Box, BoxProps, Divider, Skeleton, Tooltip, Typography } from '@mui/material';
 import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useFetchUserQuery } from '../../../api/hooks/useFetchUserQuery';
 import { ErrorBoundary } from '../../../components/ErrorBoundary';
-import { HorizontalBox, StyledTruncatableTypography } from '../../../components/styled/Wrappers';
+import { EllipsisTypography, HorizontalBox } from '../../../components/styled/Wrappers';
 import { RootState } from '../../../redux/store';
 import { Ticket } from '../../../types/publication_types/ticket.types';
 import { dataTestId } from '../../../utils/dataTestIds';
-import { toDateString } from '../../../utils/date-helpers';
+import { toDateString, toDateStringWithTime } from '../../../utils/date-helpers';
 import { getFullName, userCanDeleteMessage } from '../../../utils/user-helpers';
 import { MessageItemOrganization } from './MessageItemOrganization';
 import { MessageMenu } from './MessageMenu';
@@ -60,9 +61,17 @@ interface MessageItemProps {
   backgroundColor: BoxProps['bgcolor'];
   menuElement?: ReactNode;
   showOrganization?: boolean;
+  approvalStatus?: 'Approved' | 'Rejected';
 }
 
-export const MessageItem = ({ text, date, username, menuElement, showOrganization = false }: MessageItemProps) => {
+export const MessageItem = ({
+  text,
+  date,
+  username,
+  menuElement,
+  showOrganization = false,
+  approvalStatus,
+}: MessageItemProps) => {
   const { t } = useTranslation();
 
   const senderQuery = useFetchUserQuery(username);
@@ -80,8 +89,14 @@ export const MessageItem = ({ text, date, username, menuElement, showOrganizatio
       }}>
       <Box sx={{ display: 'grid', gridTemplateColumns: '1fr auto auto', alignItems: 'center', gap: '0.3rem' }}>
         <HorizontalBox sx={{ gap: '0.25rem' }}>
-          <ChatBubbleIcon sx={{ fontSize: '1.1rem' }} />
-          <Typography sx={{ fontWeight: 'bold' }}>{t('tasks.nvi.note')}</Typography>
+          {approvalStatus === 'Rejected' ? (
+            <SellIcon sx={{ fontSize: '1.1rem' }} />
+          ) : (
+            <ChatBubbleIcon sx={{ fontSize: '1.1rem' }} />
+          )}
+          <Typography sx={{ fontWeight: 'bold' }}>
+            {approvalStatus === 'Rejected' ? t('common.justification') : t('tasks.nvi.note')}
+          </Typography>
         </HorizontalBox>
         {showOrganization ? (
           <MessageItemOrganization organizationId={senderQuery.data?.institutionCristinId ?? ''} />
@@ -97,12 +112,15 @@ export const MessageItem = ({ text, date, username, menuElement, showOrganizatio
         component={typeof text === 'string' ? Typography : 'div'}>
         {text ? text : <i>{t('my_page.messages.message_deleted')}</i>}
       </Box>
-      <HorizontalBox>
+      <HorizontalBox sx={{ gap: '1rem' }}>
         <Box sx={{ flexGrow: 1 }}>
           <Tooltip title={senderName ? senderName : t('common.unknown')}>
-            <StyledTruncatableTypography
+            <EllipsisTypography
               data-testid={dataTestId.registrationLandingPage.tasksPanel.messageSender}
-              sx={{ fontWeight: 'bold' }}>
+              sx={{
+                fontWeight: 'bold',
+                maxWidth: { sm: '10rem', md: '12rem', lg: '18rem', xl: '30rem' },
+              }}>
               {senderQuery.isPending ? (
                 <Skeleton sx={{ width: '8rem' }} />
               ) : senderName ? (
@@ -110,17 +128,19 @@ export const MessageItem = ({ text, date, username, menuElement, showOrganizatio
               ) : (
                 <i>{t('common.unknown')}</i>
               )}
-            </StyledTruncatableTypography>
+            </EllipsisTypography>
           </Tooltip>
         </Box>
-        <HorizontalBox sx={{ gap: '0.25rem' }}>
-          <CalendarMonthIcon />
-          <Typography
-            sx={{ pt: '0.1rem' }}
-            data-testid={dataTestId.registrationLandingPage.tasksPanel.messageTimestamp}>
-            {toDateString(date)}
-          </Typography>
-        </HorizontalBox>
+        <Tooltip title={toDateStringWithTime(date)}>
+          <HorizontalBox sx={{ gap: '0.25rem' }}>
+            <CalendarMonthIcon />
+            <Typography
+              sx={{ pt: '0.1rem' }}
+              data-testid={dataTestId.registrationLandingPage.tasksPanel.messageTimestamp}>
+              {toDateString(date)}
+            </Typography>
+          </HorizontalBox>
+        </Tooltip>
       </HorizontalBox>
     </Box>
   );

--- a/src/pages/messages/components/MessageList.tsx
+++ b/src/pages/messages/components/MessageList.tsx
@@ -44,6 +44,7 @@ export const TicketMessageList = ({ ticket }: MessageListProps) => {
               text={message.text}
               date={message.createdDate}
               username={message.sender}
+              messageType={'Message'}
               backgroundColor={'background.neutral87'}
               menuElement={canDeleteMessage && <MessageMenu messageId={message.id} />}
             />
@@ -61,7 +62,7 @@ interface MessageItemProps {
   backgroundColor: BoxProps['bgcolor'];
   menuElement?: ReactNode;
   showOrganization?: boolean;
-  approvalStatus?: 'Approved' | 'Rejected';
+  messageType?: 'Justification' | 'Message' | 'Comment';
 }
 
 export const MessageItem = ({
@@ -70,7 +71,7 @@ export const MessageItem = ({
   username,
   menuElement,
   showOrganization = false,
-  approvalStatus,
+  messageType = 'Comment',
 }: MessageItemProps) => {
   const { t } = useTranslation();
 
@@ -86,16 +87,21 @@ export const MessageItem = ({
         borderRadius: '4px',
         display: 'flex',
         flexDirection: 'column',
+        color: 'black !important',
       }}>
       <Box sx={{ display: 'grid', gridTemplateColumns: '1fr auto auto', alignItems: 'center', gap: '0.3rem' }}>
         <HorizontalBox sx={{ gap: '0.25rem' }}>
-          {approvalStatus === 'Rejected' ? (
-            <SellIcon sx={{ fontSize: '1.1rem' }} />
+          {messageType === 'Justification' ? (
+            <SellIcon sx={{ fontSize: '1.1rem', color: 'black !important' }} />
           ) : (
-            <ChatBubbleIcon sx={{ fontSize: '1.1rem' }} />
+            <ChatBubbleIcon sx={{ fontSize: '1.1rem', color: 'black !important' }} />
           )}
-          <Typography sx={{ fontWeight: 'bold' }}>
-            {approvalStatus === 'Rejected' ? t('common.justification') : t('tasks.nvi.note')}
+          <Typography sx={{ fontWeight: 'bold', color: 'black !important' }}>
+            {messageType === 'Justification'
+              ? t('common.justification')
+              : messageType === 'Message'
+                ? t('common.message')
+                : t('tasks.nvi.note')}
           </Typography>
         </HorizontalBox>
         {showOrganization ? (
@@ -107,12 +113,12 @@ export const MessageItem = ({
       <Divider sx={{ mb: '0.5rem', bgcolor: 'primary.main' }} />
 
       <Box
-        sx={{ color: 'primary.main', my: '0.1rem' }}
+        sx={{ color: 'black !important', my: '0.1rem' }}
         data-testid={dataTestId.registrationLandingPage.tasksPanel.messageText}
         component={typeof text === 'string' ? Typography : 'div'}>
         {text ? text : <i>{t('my_page.messages.message_deleted')}</i>}
       </Box>
-      <HorizontalBox sx={{ gap: '1rem' }}>
+      <HorizontalBox sx={{ gap: '1rem', color: 'black' }}>
         <Box sx={{ flexGrow: 1 }}>
           <Tooltip title={senderName ? senderName : t('common.unknown')}>
             <EllipsisTypography
@@ -120,6 +126,7 @@ export const MessageItem = ({
               sx={{
                 fontWeight: 'bold',
                 maxWidth: { sm: '10rem', md: '12rem', lg: '18rem', xl: '30rem' },
+                color: 'black !important',
               }}>
               {senderQuery.isPending ? (
                 <Skeleton sx={{ width: '8rem' }} />
@@ -132,10 +139,10 @@ export const MessageItem = ({
           </Tooltip>
         </Box>
         <Tooltip title={toDateStringWithTime(date)}>
-          <HorizontalBox sx={{ gap: '0.25rem' }}>
-            <CalendarMonthIcon />
+          <HorizontalBox sx={{ gap: '0.25rem', color: 'black' }}>
+            <CalendarMonthIcon sx={{ color: 'black !important' }} />
             <Typography
-              sx={{ pt: '0.1rem' }}
+              sx={{ pt: '0.1rem', color: 'black !important' }}
               data-testid={dataTestId.registrationLandingPage.tasksPanel.messageTimestamp}>
               {toDateString(date)}
             </Typography>

--- a/src/pages/messages/components/MessageList.tsx
+++ b/src/pages/messages/components/MessageList.tsx
@@ -72,6 +72,7 @@ export const MessageItem = ({
   menuElement,
   showOrganization = false,
   messageType = 'Comment',
+  backgroundColor = 'background.neutral87',
 }: MessageItemProps) => {
   const { t } = useTranslation();
 
@@ -82,7 +83,7 @@ export const MessageItem = ({
     <Box
       component="li"
       sx={{
-        bgcolor: 'background.neutral87',
+        bgcolor: backgroundColor,
         p: '0.5rem',
         borderRadius: '4px',
         display: 'flex',

--- a/src/pages/messages/components/MessageList.tsx
+++ b/src/pages/messages/components/MessageList.tsx
@@ -56,7 +56,7 @@ export const TicketMessageList = ({ ticket }: MessageListProps) => {
 };
 
 interface MessageItemProps {
-  text: ReactNode;
+  text: string | undefined;
   date: string;
   username: string;
   backgroundColor: BoxProps['bgcolor'];
@@ -88,16 +88,16 @@ export const MessageItem = ({
         borderRadius: '4px',
         display: 'flex',
         flexDirection: 'column',
-        color: 'black !important',
+        color: 'textPrimary.main',
       }}>
       <Box sx={{ display: 'grid', gridTemplateColumns: '1fr auto auto', alignItems: 'center', gap: '0.3rem' }}>
-        <HorizontalBox sx={{ gap: '0.25rem' }}>
+        <HorizontalBox sx={{ gap: '0.25rem', color: 'textPrimary.main' }}>
           {messageType === 'Justification' || messageType === 'Approval' ? (
-            <SellIcon sx={{ fontSize: '1.1rem', color: 'black !important' }} />
+            <SellIcon sx={{ fontSize: '1.1rem', color: 'textPrimary.main' }} />
           ) : (
-            <ChatBubbleIcon sx={{ fontSize: '1.1rem', color: 'black !important' }} />
+            <ChatBubbleIcon sx={{ fontSize: '1.1rem', color: 'textPrimary.main' }} />
           )}
-          <Typography sx={{ fontWeight: 'bold', color: 'black !important' }}>
+          <Typography sx={{ fontWeight: 'bold', color: 'textPrimary.main' }}>
             {messageType === 'Justification'
               ? t('common.justification')
               : messageType === 'Approval'
@@ -116,12 +116,12 @@ export const MessageItem = ({
       <Divider sx={{ mb: '0.5rem', bgcolor: 'primary.main' }} />
 
       <Box
-        sx={{ color: 'black !important', my: '0.1rem' }}
+        sx={{ color: 'textPrimary.main', my: '0.1rem' }}
         data-testid={dataTestId.registrationLandingPage.tasksPanel.messageText}
-        component={typeof text === 'string' ? Typography : 'div'}>
+        component={Typography}>
         {text ? text : messageType !== 'Approval' ? <i>{t('my_page.messages.message_deleted')}</i> : undefined}
       </Box>
-      <HorizontalBox sx={{ gap: '1rem', color: 'black' }}>
+      <HorizontalBox sx={{ gap: '1rem', color: 'textPrimary.main' }}>
         <Box sx={{ flexGrow: 1 }}>
           <Tooltip title={senderName ? senderName : t('common.unknown')}>
             <EllipsisTypography
@@ -129,7 +129,7 @@ export const MessageItem = ({
               sx={{
                 fontWeight: 'bold',
                 maxWidth: { sm: '10rem', md: '12rem', lg: '18rem', xl: '30rem' },
-                color: 'black !important',
+                color: 'textPrimary.main',
               }}>
               {senderQuery.isPending ? (
                 <Skeleton sx={{ width: '8rem' }} />
@@ -142,10 +142,10 @@ export const MessageItem = ({
           </Tooltip>
         </Box>
         <Tooltip title={toDateStringWithTime(date)}>
-          <HorizontalBox sx={{ gap: '0.25rem', color: 'black' }}>
-            <CalendarMonthIcon sx={{ color: 'black !important' }} />
+          <HorizontalBox sx={{ gap: '0.25rem', color: 'textPrimary.main' }}>
+            <CalendarMonthIcon sx={{ color: 'textPrimary.main' }} />
             <Typography
-              sx={{ pt: '0.1rem', color: 'black !important' }}
+              sx={{ pt: '0.1rem', color: 'textPrimary.main' }}
               data-testid={dataTestId.registrationLandingPage.tasksPanel.messageTimestamp}>
               {toDateString(date)}
             </Typography>

--- a/src/pages/messages/components/MessageList.tsx
+++ b/src/pages/messages/components/MessageList.tsx
@@ -62,7 +62,7 @@ interface MessageItemProps {
   backgroundColor: BoxProps['bgcolor'];
   menuElement?: ReactNode;
   showOrganization?: boolean;
-  messageType?: 'Justification' | 'Message' | 'Comment';
+  messageType?: 'Justification' | 'Message' | 'Comment' | 'Approval';
 }
 
 export const MessageItem = ({
@@ -91,7 +91,7 @@ export const MessageItem = ({
       }}>
       <Box sx={{ display: 'grid', gridTemplateColumns: '1fr auto auto', alignItems: 'center', gap: '0.3rem' }}>
         <HorizontalBox sx={{ gap: '0.25rem' }}>
-          {messageType === 'Justification' ? (
+          {messageType === 'Justification' || messageType === 'Approval' ? (
             <SellIcon sx={{ fontSize: '1.1rem', color: 'black !important' }} />
           ) : (
             <ChatBubbleIcon sx={{ fontSize: '1.1rem', color: 'black !important' }} />
@@ -99,9 +99,11 @@ export const MessageItem = ({
           <Typography sx={{ fontWeight: 'bold', color: 'black !important' }}>
             {messageType === 'Justification'
               ? t('common.justification')
-              : messageType === 'Message'
-                ? t('common.message')
-                : t('tasks.nvi.note')}
+              : messageType === 'Approval'
+                ? t('approved')
+                : messageType === 'Message'
+                  ? t('common.message')
+                  : t('tasks.nvi.note')}
           </Typography>
         </HorizontalBox>
         {showOrganization ? (
@@ -116,7 +118,7 @@ export const MessageItem = ({
         sx={{ color: 'black !important', my: '0.1rem' }}
         data-testid={dataTestId.registrationLandingPage.tasksPanel.messageText}
         component={typeof text === 'string' ? Typography : 'div'}>
-        {text ? text : <i>{t('my_page.messages.message_deleted')}</i>}
+        {text ? text : messageType !== 'Approval' ? <i>{t('my_page.messages.message_deleted')}</i> : undefined}
       </Box>
       <HorizontalBox sx={{ gap: '1rem', color: 'black' }}>
         <Box sx={{ flexGrow: 1 }}>

--- a/src/pages/messages/components/MessageList.tsx
+++ b/src/pages/messages/components/MessageList.tsx
@@ -113,7 +113,7 @@ export const MessageItem = ({ text, date, username, menuElement, showOrganizatio
             </StyledTruncatableTypography>
           </Tooltip>
         </Box>
-        <HorizontalBox>
+        <HorizontalBox sx={{ gap: '0.25rem' }}>
           <CalendarMonthIcon />
           <Typography
             sx={{ pt: '0.1rem' }}

--- a/src/pages/messages/components/NviCandidateActions.tsx
+++ b/src/pages/messages/components/NviCandidateActions.tsx
@@ -40,7 +40,7 @@ interface NviNote {
   username: string;
   institutionId?: string;
   text?: string;
-  messageType?: 'Justification' | 'General';
+  messageType?: 'Justification' | 'Approval' | 'Comment';
 }
 
 interface NviCandidateActionsProps {
@@ -128,8 +128,7 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
   ).map((approvalStatus) => ({
     type: 'FinalizedNote',
     date: approvalStatus.finalizedDate,
-    text: t('tasks.nvi.status.Approved'),
-    approvalStatus: 'Approved',
+    messageType: 'Approval',
     username: approvalStatus.finalizedBy,
     institutionId: approvalStatus.institutionId,
   }));
@@ -139,6 +138,7 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
     identifier: note.identifier,
     date: note.createdDate,
     text: note.text,
+    messageType: 'Comment',
     username: note.user,
   }));
 
@@ -318,7 +318,7 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
                   <ErrorBoundary key={noteIdentifier ?? note.date}>
                     <MessageItem
                       text={note.text}
-                      messageType={note.messageType === 'Justification' ? 'Justification' : 'Comment'}
+                      messageType={note.messageType}
                       date={note.date}
                       username={note.username}
                       backgroundColor="nvi.main"

--- a/src/pages/messages/components/NviCandidateActions.tsx
+++ b/src/pages/messages/components/NviCandidateActions.tsx
@@ -321,7 +321,7 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
                       messageType={note.messageType}
                       date={note.date}
                       username={note.username}
-                      backgroundColor="nvi.main"
+                      backgroundColor="background.neutral87"
                       showOrganization
                       menuElement={
                         !!deleteFunction && (

--- a/src/pages/messages/components/NviCandidateActions.tsx
+++ b/src/pages/messages/components/NviCandidateActions.tsx
@@ -40,6 +40,8 @@ interface NviNote {
   username: string;
   institutionId?: string;
   content: ReactNode;
+  text?: string;
+  approvalStatus?: 'Rejected' | 'Approved';
 }
 
 interface NviCandidateActionsProps {
@@ -125,6 +127,8 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
         {rejectionStatus.reason}
       </Typography>
     ),
+    text: rejectionStatus.reason,
+    approvalStatus: 'Rejected',
     username: rejectionStatus.finalizedBy,
     institutionId: rejectionStatus.institutionId,
   }));
@@ -135,6 +139,8 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
     type: 'FinalizedNote',
     date: approvalStatus.finalizedDate,
     content: <Typography fontWeight={700}>{t('tasks.nvi.status.Approved')}</Typography>,
+    text: t('tasks.nvi.status.Approved'),
+    approvalStatus: 'Approved',
     username: approvalStatus.finalizedBy,
     institutionId: approvalStatus.institutionId,
   }));
@@ -144,6 +150,7 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
     identifier: note.identifier,
     date: note.createdDate,
     content: note.text,
+    text: note.text,
     username: note.user,
   }));
 
@@ -322,7 +329,8 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
                 return (
                   <ErrorBoundary key={noteIdentifier ?? note.date}>
                     <MessageItem
-                      text={note.content}
+                      text={note.text}
+                      approvalStatus={note.approvalStatus}
                       date={note.date}
                       username={note.username}
                       backgroundColor="nvi.main"

--- a/src/pages/messages/components/NviCandidateActions.tsx
+++ b/src/pages/messages/components/NviCandidateActions.tsx
@@ -3,7 +3,7 @@ import ClearIcon from '@mui/icons-material/Clear';
 import EditIcon from '@mui/icons-material/Edit';
 import { Box, Button, Divider, Typography } from '@mui/material';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { ReactNode, useState } from 'react';
+import { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link as RouterLink } from 'react-router';
@@ -39,9 +39,8 @@ interface NviNote {
   date: string;
   username: string;
   institutionId?: string;
-  content: ReactNode;
   text?: string;
-  approvalStatus?: 'Rejected' | 'Approved';
+  messageType?: 'Justification' | 'General';
 }
 
 interface NviCandidateActionsProps {
@@ -118,17 +117,8 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
   ).map((rejectionStatus) => ({
     type: 'FinalizedNote',
     date: rejectionStatus.finalizedDate,
-    content: (
-      <Typography>
-        <Box component="span" fontWeight={700} sx={{ textDecoration: 'underline' }}>
-          {t('tasks.nvi.rejection_reason')}:
-        </Box>
-        <br />
-        {rejectionStatus.reason}
-      </Typography>
-    ),
     text: rejectionStatus.reason,
-    approvalStatus: 'Rejected',
+    messageType: 'Justification',
     username: rejectionStatus.finalizedBy,
     institutionId: rejectionStatus.institutionId,
   }));
@@ -138,7 +128,6 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
   ).map((approvalStatus) => ({
     type: 'FinalizedNote',
     date: approvalStatus.finalizedDate,
-    content: <Typography fontWeight={700}>{t('tasks.nvi.status.Approved')}</Typography>,
     text: t('tasks.nvi.status.Approved'),
     approvalStatus: 'Approved',
     username: approvalStatus.finalizedBy,
@@ -149,7 +138,6 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
     type: 'GeneralNote',
     identifier: note.identifier,
     date: note.createdDate,
-    content: note.text,
     text: note.text,
     username: note.user,
   }));
@@ -330,7 +318,7 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
                   <ErrorBoundary key={noteIdentifier ?? note.date}>
                     <MessageItem
                       text={note.text}
-                      approvalStatus={note.approvalStatus}
+                      messageType={note.messageType === 'Justification' ? 'Justification' : 'Comment'}
                       date={note.date}
                       username={note.username}
                       backgroundColor="nvi.main"

--- a/src/pages/public_registration/log/LogMessageAccordion.tsx
+++ b/src/pages/public_registration/log/LogMessageAccordion.tsx
@@ -53,7 +53,7 @@ export const LogMessageAccordion = ({ messages, topic }: LogMessageAccordionProp
                 date={message.createdDate}
                 messageType={'Message'}
                 username={message.sender}
-                backgroundColor={getMessageItemBackgroundColor(topic)}
+                backgroundColor={'background.neutral87'}
                 menuElement={canDeleteMessage && <MessageMenu messageId={message.id} />}
               />
             );
@@ -72,18 +72,5 @@ const getTicketTypeFromLogEntryTopic = (topic: LogEntry['topic']): TicketType =>
       return 'DoiRequest';
     default:
       return 'PublishingRequest';
-  }
-};
-
-const getMessageItemBackgroundColor = (topic: LogEntry['topic']) => {
-  switch (topic) {
-    case 'DoiRejected':
-    case 'DoiAssigned':
-      return 'doiRequest.main';
-    case 'FileApproved':
-    case 'FileRejected':
-      return 'publishingRequest.main';
-    default:
-      return 'secondary.main';
   }
 };

--- a/src/pages/public_registration/log/LogMessageAccordion.tsx
+++ b/src/pages/public_registration/log/LogMessageAccordion.tsx
@@ -51,6 +51,7 @@ export const LogMessageAccordion = ({ messages, topic }: LogMessageAccordionProp
                 key={message.identifier}
                 text={message.text}
                 date={message.createdDate}
+                messageType={'Message'}
                 username={message.sender}
                 backgroundColor={getMessageItemBackgroundColor(topic)}
                 menuElement={canDeleteMessage && <MessageMenu messageId={message.id} />}

--- a/src/themes/mainTheme.ts
+++ b/src/themes/mainTheme.ts
@@ -1,5 +1,6 @@
 import { createTheme, darken, PaletteColor, PaletteColorOptions, SxProps } from '@mui/material';
 import { enUS as coreEnUs, nbNO as coreNbNo, nnNO as coreNnNo } from '@mui/material/locale';
+import type {} from '@mui/x-date-pickers/themeAugmentation';
 import i18n from '../translations/i18n';
 
 // Colors: https://www.figma.com/file/3hggk6SX2ca81U8kwaZKFs/Farger-NVA

--- a/src/themes/mainTheme.ts
+++ b/src/themes/mainTheme.ts
@@ -1,6 +1,5 @@
 import { createTheme, darken, PaletteColor, PaletteColorOptions, SxProps } from '@mui/material';
 import { enUS as coreEnUs, nbNO as coreNbNo, nnNO as coreNnNo } from '@mui/material/locale';
-import type {} from '@mui/x-date-pickers/themeAugmentation';
 import i18n from '../translations/i18n';
 
 // Colors: https://www.figma.com/file/3hggk6SX2ca81U8kwaZKFs/Farger-NVA
@@ -41,6 +40,7 @@ declare module '@mui/material/styles' {
     person: PaletteColor;
     project: PaletteColor;
     centralImport: PaletteColor;
+    textPrimary: PaletteColor;
     neutral87: PaletteColor;
     taskType: {
       publishingRequest: PaletteColor;
@@ -55,6 +55,7 @@ declare module '@mui/material/styles' {
     person?: PaletteColorOptions;
     project?: PaletteColorOptions;
     centralImport?: PaletteColorOptions;
+    textPrimary?: PaletteColorOptions;
     neutral87?: PaletteColorOptions;
     taskType?: {
       publishingRequest?: PaletteColorOptions;
@@ -164,6 +165,9 @@ export const mainTheme = createTheme(
       },
       centralImport: {
         main: Color.CentralImportMain,
+      },
+      textPrimary: {
+        main: Color.TextPrimary,
       },
       background: {
         default: Color.Neutral95,


### PR DESCRIPTION
# Description

Link to Jira issue: [Add date on comment in NVI](https://sikt.atlassian.net/browse/NP-50792)

# How to test

All areas of NVA with messages / comments now gets new design. Earlier, comments that didn't have an organization logo had a date instead in the top right space, but now the date and the name is pushed down to the bottom line and a title, like the word "Kommentar" on the top line. If there is an organization logo, this is now displayed before the menu icon at the top right.

## Example from comments without organization logo

Kuratorstøtte before:
<img width="294" height="94" alt="image" src="https://github.com/user-attachments/assets/8bc6a5a4-edee-4ccd-bca1-02ab8cc272e7" />

Kuratorstøtte now:
<img width="240" height="98" alt="image" src="https://github.com/user-attachments/assets/f5cc0385-6dc8-4c26-b976-6a5e0c158c84" />

## Changes to the different types of comments:

### CentralImportDuplicationCheckPage
(grunndata -> sentralimport -> velg en med kommentar og se i sidepanel). Her er tittelen endret til "Begrunnelse", siden det ser ut til å være et resultat av at den er satt som mangelfull:

<img width="389" height="274" alt="image" src="https://github.com/user-attachments/assets/4af2776d-61fc-4657-8081-3695ca6ed78a" />

**For the next examples you can use the registration with id "019c9f3f030c-48772ebf-efab-41ce-bd94-8a1e3679f7aa" to see different types of messages:**

### DoiRequestAccordion
 Registration landing page -> DOI Request in side panel. Overskift: "Melding": 

Før:
<img width="303" height="95" alt="image" src="https://github.com/user-attachments/assets/9fd9cee9-0c2a-4481-9c66-a3339aef5ee6" />

Nå:
<img width="295" height="120" alt="image" src="https://github.com/user-attachments/assets/b86b1465-61d0-4a9a-9c2a-1934f916467a" />

### PublishingAccordionLastTicketInfo
- vises ved meldingskommunikasjon rundt publisering av registrering / filer og registreringen. Her er overskriften endret til "Melding", også ved avvisning, fordi "Grunngjevning ved avvisning" (ved avvisning av filer) eller "Begrunnelse for avvisning" (ved unpublish) er parset inn i beskjeden fra API'et:

Ved avvisning av filer:

Før:
<img width="327" height="731" alt="image" src="https://github.com/user-attachments/assets/7c000b71-87d0-42d2-aa8f-0881ceabc552" />

Nå:
<img width="315" height="788" alt="image" src="https://github.com/user-attachments/assets/89c24743-2340-425b-81a8-0617e1d7ab4c" />

Ved unpublishing av registeringen:

Før:
<img width="430" height="607" alt="image" src="https://github.com/user-attachments/assets/f93f748d-8ff0-473e-9599-1401184c3eb3" />

Nå:
<img width="360" height="666" alt="image" src="https://github.com/user-attachments/assets/c1290d47-81e3-41c5-bbaa-59a34b11ddef" />


### Kuratorstøtte
on registration landing page in the right panel. Endrer til "Melding"-overskrift her:

Før:
<img width="322" height="340" alt="image" src="https://github.com/user-attachments/assets/6501ab10-ab2d-457d-aaac-4745ef7836ff" />

Nå:
<img width="321" height="362" alt="image" src="https://github.com/user-attachments/assets/62446fb5-5749-4621-9074-f2cacb74db70" />

### Log panel
I tillegg til de generelle endringene på kommentarer har jeg endret overskrift på meldingene til "Melding", og sikret at fargen på tekst og ikoner er svart.

Før:
<img width="339" height="426" alt="image" src="https://github.com/user-attachments/assets/b6c70a80-cdf0-4281-891c-92308a105308" />

Nå:
<img width="326" height="493" alt="image" src="https://github.com/user-attachments/assets/1a1047d8-fb69-4037-adfe-df13cc5084e7" />

### NVI comments

The main target for this PR are NVI comments. Here there is also a requirement to say if the comment is a comment or a justification (begrunnelse). NVI comments also has an organization logo, so they didn't have date before.

NVI comments before:
<img width="275" height="151" alt="image" src="https://github.com/user-attachments/assets/bfea5278-5874-464e-9828-00488125fdd9" />

NVI comments now:
<img width="269" height="175" alt="image" src="https://github.com/user-attachments/assets/0f273c1b-2301-40da-9be9-6cd75f49fc06" />

NVI rejection before:
<img width="340" height="95" alt="image" src="https://github.com/user-attachments/assets/7a9140a0-abc8-4854-9d62-5f5cc2b0f8b1" />

NVI rejection now:
<img width="345" height="104" alt="image" src="https://github.com/user-attachments/assets/ac7f8cd2-32c8-4b7a-9d18-3be533fe8141" />

NVI approval before:
<img width="428" height="560" alt="image" src="https://github.com/user-attachments/assets/6b63e58f-edce-4a6b-b648-a6a45f11e4db" />

NVI approval now:
<img width="334" height="580" alt="image" src="https://github.com/user-attachments/assets/be582e27-e140-4d9d-8f73-d62b73a47d4e" />


# Acceptance criterias

- [x] Kommentarer i NVI viser dato kommentaren ble skrevet
- [x] Kommentarer i NVI viser klokkelsett kommentaren ble skrevet on hover på dato
- [x] Flytte kurator og dato under meldingen. 
- [x] Legg til om kommentar er kommentar eller begrunnelse

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Messages show a compact header with an icon and bold label indicating type (Justification, Message, Comment, Approval).
* **Style**
  * Timestamps and sender moved to a consistent bottom row with a calendar icon; header no longer shows inline timestamp when organisation is hidden.
  * Message text colour updated for improved readability; consistent truncation via ellipsis.
* **Chores**
  * Message backgrounds standardised for a more uniform appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->