### PR TITLE
NP-50841 Set file to Open as default

### DIFF
--- a/src/pages/registration/files_and_license_tab/FileUploader.tsx
+++ b/src/pages/registration/files_and_license_tab/FileUploader.tsx
@@ -1,7 +1,7 @@
 import Uppy from '@uppy/core';
 import { useEffect } from 'react';
 import { UppyDashboard } from '../../../components/UppyDashboard';
-import { AssociatedFile, emptyFile } from '../../../types/associatedArtifact.types';
+import { AssociatedFile, emptyFile, FileType } from '../../../types/associatedArtifact.types';
 
 interface FileUploaderProps {
   addFile: (file: AssociatedFile) => void;
@@ -17,11 +17,12 @@ type UploadedFile = Pick<
 export const FileUploader = ({ addFile, uppy }: FileUploaderProps) => {
   useEffect(() => {
     if (uppy && !uppy.opts.meta.hasUploadSuccessEventListener) {
-      uppy.on('upload-success', (file, response) => {
+      uppy.on('upload-success', (_file, response) => {
         const uploadedFile = response.body as unknown as UploadedFile;
         const newFile: AssociatedFile = {
           ...emptyFile,
           ...uploadedFile,
+          type: FileType.PendingOpenFile,
         };
         addFile(newFile);
       });

--- a/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
+++ b/src/pages/registration/files_and_license_tab/FilesTableRow.tsx
@@ -229,11 +229,6 @@ export const FilesTableRow = ({
                   input: { sx: { '.MuiSelect-select': { py: '0.75rem' } } },
                   select: { inputProps: { 'aria-label': t('registration.files_and_license.availability') } },
                 }}>
-                {field.value === FileType.UpdloadedFile && (
-                  <MenuItem value={FileType.UpdloadedFile} disabled hidden>
-                    <i>{t('registration.files_and_license.select_availability')}</i>
-                  </MenuItem>
-                )}
                 <MenuItem value={isCompletedFile ? FileType.OpenFile : FileType.PendingOpenFile}>
                   <StyledFileTypeMenuItemContent>
                     <CheckIcon fontSize="small" />

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -737,7 +737,7 @@
   "go_to_advanced_search": "Gå til avansert resultatsøk",
   "institution_support": "Institusjonens brukerstøtte",
   "institutions_service_support": "Institusjonenes brukerstøtte",
-  "internal_file_info_description": "Velg åpen fil for forskningsresultater som skal gjøres åpent tilgjengelige. Korrekt lisens må velges, og kurator bistår med valg av lisens. Intern fil skal kun brukes for dokumenter som kun skal deles med kurator, som forfatteravtaler o.l.",
+  "internal_file_info_description": "Velg “Åpen fil” for forskningsresultater som skal gjøres åpent tilgjengelige. Husk å velge korrekt lisens. Kurator kan bistå deg med dette. Velg “Intern fil” for dokumenter som kun skal deles med kurator, for eksempel forfatteravtaler og lignende.",
   "internal_nvi_status": "Intern NVI-status",
   "keep_all_contributors": "Behold bidragsytere fra både {{sourceType}} og publisert resultat",
   "keep_contributors_from_published_result": "Behold kun bidragsytere fra publisert resultat",
@@ -1306,7 +1306,6 @@
       "registration_without_file": "Resultat uten fil",
       "resource_has_no_files_or_links": "Ressursen har ingen filer eller lenker å publisere",
       "resource_is_a_reference": "Ressursen er en referanse og har ingen filer eller lenker å publisere",
-      "select_availability": "Velg tilgjengelighet",
       "show_all_older_versions": "Vis alle tidligere versjoner",
       "version_helper_text": "<p>Last opp akseptert versjon, dersom publisert versjon ikke er åpent publisert med en <ccLink>Creative Commons-lisens</ccLink>.</p><heading>Akseptert versjon (authors accepted manuscript, AAM)</heading> <p>Forfatters siste versjon etter fagfellevurdering, slik den er sendt til forlaget. Denne versjonen har ikke forlagets sidetall og grafiske stil, eller eventuelle redaksjonelle omskrivinger, som den publiserte versjonen har.</p><heading>Publisert versjon (version of records, VOR)</heading> <p>Artikkelen slik den presenteres i et tidsskrift. Denne versjonen vil inkludere redaksjonelle forbedringer, og forlagets grafiske profil. Vanligvis tilgjengelig på en utgivers nettsted, i PDF-format. Du må velge den samme Creative Commons-lisensen som artikkelen er publisert med.</p>"
     },

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -737,7 +737,7 @@
   "go_to_advanced_search": "Gå til avansert resultatsøk",
   "institution_support": "Institusjonens brukerstøtte",
   "institutions_service_support": "Institusjonenes brukerstøtte",
-  "internal_file_info_description": "Internfiler skal primært ikke benyttes for resultater, men til kommunikasjon med kurator, forfatteravtaler o.l. Resultater skal i utgangspunktet publiseres som åpen fil. Velg i så fall hvilken versjon som skal publiseres og hvilken lisens den har.",
+  "internal_file_info_description": "Velg åpen fil for forskningsresultater som skal gjøres åpent tilgjengelige. Korrekt lisens må velges, og kurator bistår med valg av lisens. Intern fil skal kun brukes for dokumenter som kun skal deles med kurator, som forfatteravtaler o.l.",
   "internal_nvi_status": "Intern NVI-status",
   "keep_all_contributors": "Behold bidragsytere fra både {{sourceType}} og publisert resultat",
   "keep_contributors_from_published_result": "Behold kun bidragsytere fra publisert resultat",


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-50841

Set uploaded file to `PendingOpenFile` as default

# How to test

Affected part of the application: Files and Licenses-panel

Upload a new file and make sure it is set to "Open" by default.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  - Removed an inaccessible menu option from the file management interface to reduce user confusion and improve interface clarity.

* **Improvements**
  - Refined Norwegian language translations to provide clearer, more user-friendly guidance during file upload and registration workflows.
  - Enhanced file upload handling for improved reliability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->