### PR TITLE
stricter check on rendering source organization

### DIFF
--- a/src/pages/basic_data/app_admin/central_import/ImportCandidateContributorBox.tsx
+++ b/src/pages/basic_data/app_admin/central_import/ImportCandidateContributorBox.tsx
@@ -13,7 +13,7 @@ export const ImportCandidateContributorBox = ({ importContributor }: ImportCandi
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
         <Typography sx={{ mt: '0.5rem' }}>{importContributor.identity.name}</Typography>
         {importContributor.affiliations.map((affiliation, index) => {
-          if (affiliation.sourceOrganization) {
+          if (affiliation.sourceOrganization?.names && affiliation.sourceOrganization?.names.length != 0) {
             return <CentralImportAffiliationBox key={index} affiliation={affiliation} />;
           }
 


### PR DESCRIPTION
# Description


Fixed a bug where empty organization boxes would be rendered in central import

Before:
<img width="1278" height="1150" alt="image" src="https://github.com/user-attachments/assets/a759071c-e8aa-4777-8d2b-b3d183be98d7" />

After:
<img width="1188" height="1108" alt="image" src="https://github.com/user-attachments/assets/88dcec3a-65bb-4696-8391-3bfdf5c67280" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the central import workflow for candidate contributors by improving affiliation box visibility, which now only displays when organisation names are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->