### PR TITLE
New Percentage controlled-column and text on nvi status page

### DIFF
--- a/src/components/atoms/PercentageWithIcon.tsx
+++ b/src/components/atoms/PercentageWithIcon.tsx
@@ -18,15 +18,13 @@ export const PercentageWithIcon = ({
   displayEmpty,
 }: PercentageWithIconProps) => {
   return (
-    <CenteredGridBox sx={{ gridTemplateColumns: '1.5rem 1fr', width: '4rem' }}>
-      <HorizontalBox sx={{ justifySelf: 'end' }}>
-        {!displayEmpty && displayPercentage < warningThresholdMinimum && displayPercentage > 0 ? (
-          <WarningIcon fontSize="small" color="warning" />
-        ) : !displayEmpty && displayPercentage >= successThresholdMinimum ? (
-          <CheckCircleIcon fontSize="small" color="success" />
-        ) : null}
-      </HorizontalBox>
-      <HorizontalBox sx={{ justifySelf: 'start', pl: '0.5rem' }}>
+    <CenteredGridBox sx={{ gridTemplateColumns: '1rem 1rem', width: '4rem' }}>
+      {!displayEmpty && displayPercentage < warningThresholdMinimum && displayPercentage > 0 ? (
+        <WarningIcon fontSize="small" color="warning" sx={{ gridColumn: '1' }} />
+      ) : !displayEmpty && displayPercentage >= successThresholdMinimum ? (
+        <CheckCircleIcon fontSize="small" color="success" sx={{ gridColumn: '1' }} />
+      ) : null}
+      <HorizontalBox sx={{ justifySelf: 'start', pl: '0.5rem', gridColumn: '2' }}>
         {displayEmpty ? '-' : displayPercentage > 0 ? `${displayPercentage}%` : alternativeIfZero || '0%'}
       </HorizontalBox>
     </CenteredGridBox>

--- a/src/components/atoms/PercentageWithIcon.tsx
+++ b/src/components/atoms/PercentageWithIcon.tsx
@@ -7,6 +7,7 @@ interface PercentageWithIconProps {
   successThresholdMinimum: number;
   displayPercentage: number;
   alternativeIfZero?: string;
+  displayEmpty?: boolean;
 }
 
 export const PercentageWithIcon = ({
@@ -14,6 +15,7 @@ export const PercentageWithIcon = ({
   successThresholdMinimum,
   displayPercentage,
   alternativeIfZero,
+  displayEmpty,
 }: PercentageWithIconProps) => {
   return (
     <CenteredGridBox sx={{ gridTemplateColumns: '1.5rem 1fr', width: '4rem' }}>
@@ -25,7 +27,7 @@ export const PercentageWithIcon = ({
         ) : null}
       </HorizontalBox>
       <HorizontalBox sx={{ justifySelf: 'start', pl: '0.5rem' }}>
-        {displayPercentage > 0 ? `${displayPercentage}%` : alternativeIfZero || '0%'}
+        {displayEmpty ? '-' : displayPercentage > 0 ? `${displayPercentage}%` : alternativeIfZero || '0%'}
       </HorizontalBox>
     </CenteredGridBox>
   );

--- a/src/components/atoms/PercentageWithIcon.tsx
+++ b/src/components/atoms/PercentageWithIcon.tsx
@@ -20,9 +20,9 @@ export const PercentageWithIcon = ({
   return (
     <CenteredGridBox sx={{ gridTemplateColumns: '1.5rem 1fr', width: '4rem' }}>
       <HorizontalBox sx={{ justifySelf: 'end' }}>
-        {displayPercentage < warningThresholdMinimum && displayPercentage > 0 ? (
+        {!displayEmpty && displayPercentage < warningThresholdMinimum && displayPercentage > 0 ? (
           <WarningIcon fontSize="small" color="warning" />
-        ) : displayPercentage >= successThresholdMinimum ? (
+        ) : !displayEmpty && displayPercentage >= successThresholdMinimum ? (
           <CheckCircleIcon fontSize="small" color="success" />
         ) : null}
       </HorizontalBox>

--- a/src/pages/messages/components/NviStatusPage.tsx
+++ b/src/pages/messages/components/NviStatusPage.tsx
@@ -1,9 +1,20 @@
-import { Box, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
+import {
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
 import { visuallyHidden } from '@mui/utils';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useFetchNviInstitutionStatus } from '../../../api/hooks/useFetchNviStatus';
 import { useFetchOrganization } from '../../../api/hooks/useFetchOrganization';
+import { VerticalBox } from '../../../components/styled/Wrappers';
 import { RootState } from '../../../redux/store';
 import { useNviCandidatesParams } from '../../../utils/hooks/useNviCandidatesParams';
 import { NviStatusTableRow } from './NviStatusTableRow';
@@ -23,6 +34,11 @@ export const NviStatusPage = () => {
   return (
     <NviStatusWrapper
       headline={t('tasks.nvi.institution_nvi_status')}
+      topView={
+        <VerticalBox sx={{ mb: '1rem', gap: '0.5rem' }}>
+          <Trans t={t} i18nKey="reporting_status_description" components={[<Typography key="1" />]} />
+        </VerticalBox>
+      }
       exportAcronym={organizationQuery.data?.acronym}
       yearSelector
       visibilitySelector>
@@ -36,6 +52,7 @@ export const NviStatusPage = () => {
               <TableCell>{t('tasks.nvi.status.Approved')}</TableCell>
               <TableCell>{t('tasks.nvi.status.Rejected')}</TableCell>
               <TableCell>{t('common.total_number')}</TableCell>
+              <TableCell>{t('percentage_controlled')}</TableCell>
               <TableCell>
                 <Box component="span" sx={visuallyHidden}>
                   {t('tasks.nvi.show_subunits')}

--- a/src/pages/messages/components/NviStatusTableRow.tsx
+++ b/src/pages/messages/components/NviStatusTableRow.tsx
@@ -10,6 +10,8 @@ import { getIdentifierFromId } from '../../../utils/general-helpers';
 import { useNviCandidatesParams } from '../../../utils/hooks/useNviCandidatesParams';
 import { getNviCandidatesSearchPath } from '../../../utils/urlPaths';
 import { NviStatusTableRowWrapper } from './NviStatusTableRowWrapper';
+import { HorizontalBox } from '../../../components/styled/Wrappers';
+import { PercentageWithIcon } from '../../../components/atoms/PercentageWithIcon';
 
 interface NviStatusTableRowProps {
   organization: Organization;
@@ -29,6 +31,11 @@ export const NviStatusTableRow = ({ organization, aggregations, level = 0, user,
   const [expanded, setExpanded] = useState(level === 0);
   const orgAggregations = aggregations?.byOrganization[organization.id];
   const rowIsEmpty = !orgAggregations || orgAggregations.candidateCount === 0;
+  const percentageControlled =
+    orgAggregations && orgAggregations.candidateCount > 0
+      ? (orgAggregations.approvalStatus.Approved + orgAggregations.approvalStatus.Rejected) /
+        orgAggregations.candidateCount
+      : -1;
 
   if (rowIsEmpty && excludeEmptyRows) {
     return null;
@@ -132,6 +139,20 @@ export const NviStatusTableRow = ({ organization, aggregations, level = 0, user,
               })}>
               {orgAggregations?.candidateCount ?? 0}
             </Link>
+          ) : (
+            <StyledSkeleton />
+          )}
+        </TableCell>
+        <TableCell align="center">
+          {aggregations ? (
+            <HorizontalBox sx={{ justifyContent: 'center' }}>
+              <PercentageWithIcon
+                warningThresholdMinimum={30}
+                successThresholdMinimum={100}
+                displayPercentage={Math.round(percentageControlled * 100)}
+                displayEmpty={percentageControlled < 0}
+              />
+            </HorizontalBox>
           ) : (
             <StyledSkeleton />
           )}

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1113,6 +1113,7 @@
   "publication_points": "Publiseringspoeng",
   "publication_points_description": "Tabellen viser kandidater som er godkjent per nå hos alle institusjoner og hvor mange som er ferdig kontrollert i forhold til antall kandidater.",
   "publication_points_description_more": "Kandidatene er lagt på enheten hvor de er registrert. Det er ikke tatt hensyn til samarbeidene institusjoner. Kandidater i eventuelt tvist vises ikke.",
+  "reporting_status_description": "<0>Tabellen viser kandidater ved din institusjon som er godkjent av dere per nå og hvilke som mangler godkjenning av samarbeidende institusjoner.</0> <0>Kandidatene er lagt på den eller de enhetene hvor de er registrert. En kandidat kan være registrert på flere enheter. Kandidater i eventuell tvist vises ikke.</0>",
   "published_result": "Publisert resultat",
   "registration": {
     "cannot_update_published_result_with_validation_errors": "Kan ikke lagre fordi resultatet er publisert og inneholder valideringsfeil",


### PR DESCRIPTION
# Description

Link to Jira issues:
[Legge inn forklaringstekst på siden "Vis rapporteringsstatus"](https://sikt.atlassian.net/browse/NP-50645)
[Legg til kolonne for "Andel kontrollert" på siden "Vis rapporteringsstatus"](https://sikt.atlassian.net/browse/NP-50646)

# How to test

Affected part of the application: Go to "Oppgaver" - > Vis rapporteringsstatus and verify that the changes is as requested in the issues.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "percentage controlled" column to the NVI status table showing the proportion of controlled candidates with an icon and empty-state handling.
  * Added descriptive top-section content explaining how collaboration‑institution approvals are reflected in reporting status (translation added).

* **UI Improvements**
  * Improved percentage display and layout: empties now show '-' and spacing/icon alignment updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->