### PR TITLE
NP-50825 new correction list 

### DIFF
--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -394,7 +394,6 @@ export enum ResultParam {
   Issn = 'issn',
   Journal = 'journal',
   Order = 'order',
-  ParentPublicationYear = 'parentPublicationYear',
   Project = 'project',
   PublicationLanguageShould = 'publicationLanguageShould',
   PublicationPages = 'publicationPages',
@@ -456,7 +455,6 @@ export interface FetchResultsParams {
   [ResultParam.Issn]?: string | null;
   [ResultParam.Journal]?: string | null;
   [ResultParam.Order]?: ResultSearchOrder | null;
-  [ResultParam.ParentPublicationYear]?: string | null;
   [ResultParam.Project]?: string | null;
   [ResultParam.PublicationLanguageShould]?: string | null;
   [ResultParam.PublicationPages]?: string | null;
@@ -571,9 +569,6 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
   }
   if (params.journal) {
     searchParams.set(ResultParam.Journal, params.journal);
-  }
-  if (params.parentPublicationYear) {
-    searchParams.set(ResultParam.ParentPublicationYear, params.parentPublicationYear);
   }
   if (params.project) {
     searchParams.set(ResultParam.Project, params.project);

--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -375,6 +375,7 @@ export enum ResultParam {
   Course = 'course',
   CristinIdentifier = 'cristinIdentifier',
   Doi = 'doi',
+  ExcludeParentPublicationYear = 'excludeParentPublicationYear',
   ExcludeParentType = 'excludeParentType',
   ExcludeScientificValueSeries = 'excludeScientificValueSeries',
   ExcludeSubunits = 'excludeSubunits',
@@ -393,6 +394,7 @@ export enum ResultParam {
   Issn = 'issn',
   Journal = 'journal',
   Order = 'order',
+  ParentPublicationYear = 'parentPublicationYear',
   Project = 'project',
   PublicationLanguageShould = 'publicationLanguageShould',
   PublicationPages = 'publicationPages',
@@ -435,6 +437,7 @@ export interface FetchResultsParams {
   [ResultParam.Course]?: string | null;
   [ResultParam.CristinIdentifier]?: string | null;
   [ResultParam.Doi]?: string | null;
+  [ResultParam.ExcludeParentPublicationYear]?: string | null;
   [ResultParam.ExcludeParentType]?: PublicationInstanceType[] | null;
   [ResultParam.ExcludeScientificValueSeries]?: ScientificValueLevels[] | null;
   [ResultParam.ExcludeSubunits]?: boolean | null;
@@ -453,6 +456,7 @@ export interface FetchResultsParams {
   [ResultParam.Issn]?: string | null;
   [ResultParam.Journal]?: string | null;
   [ResultParam.Order]?: ResultSearchOrder | null;
+  [ResultParam.ParentPublicationYear]?: string | null;
   [ResultParam.Project]?: string | null;
   [ResultParam.PublicationLanguageShould]?: string | null;
   [ResultParam.PublicationPages]?: string | null;
@@ -517,6 +521,9 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
     const formattedDoiValue = getDoiValue(params.doi);
     searchParams.set(ResultParam.Doi, formattedDoiValue);
   }
+  if (params.excludeParentPublicationYear) {
+    searchParams.set(ResultParam.ExcludeParentPublicationYear, params.excludeParentPublicationYear);
+  }
   if (params.excludeParentType?.length) {
     searchParams.set(ResultParam.ExcludeParentType, params.excludeParentType.join(','));
   }
@@ -564,6 +571,9 @@ export const fetchResults = async (params: FetchResultsParams, signal?: AbortSig
   }
   if (params.journal) {
     searchParams.set(ResultParam.Journal, params.journal);
+  }
+  if (params.parentPublicationYear) {
+    searchParams.set(ResultParam.ParentPublicationYear, params.parentPublicationYear);
   }
   if (params.project) {
     searchParams.set(ResultParam.Project, params.project);

--- a/src/pages/messages/components/CorrectionListYearFilter.tsx
+++ b/src/pages/messages/components/CorrectionListYearFilter.tsx
@@ -8,19 +8,32 @@ import { syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 
 const currentYear = new Date().getFullYear();
 
+const LISTS_EXCLUDING_SHOW_ALL = ['YearBetweenChapterAndBookMismatch'];
+
 export const CorrectionListYearFilter = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
-  const selectedYear = searchParams.get(ResultParam.PublicationYear) || 'showAll';
 
-  const options = [
+  const listParam = searchParams.get('list');
+  const shouldExcludeShowAll = !!listParam && LISTS_EXCLUDING_SHOW_ALL.includes(listParam);
+
+  const publicationYearParam = searchParams.get(ResultParam.PublicationYear);
+  const yearSelectionFromQuery = publicationYearParam ?? 'showAll';
+
+  const selectedYear =
+    shouldExcludeShowAll && yearSelectionFromQuery === 'showAll' ? currentYear.toString() : yearSelectionFromQuery;
+
+  const baseOptions = [
     { value: (currentYear + 1).toString(), label: `${currentYear + 1}` },
     { value: currentYear.toString(), label: `${currentYear}` },
     { value: (currentYear - 1).toString(), label: `${currentYear - 1}` },
-    { value: 'showAll', label: t('common.show_all') },
   ];
+
+  const options = shouldExcludeShowAll
+    ? baseOptions
+    : [...baseOptions, { value: 'showAll', label: t('common.show_all') }];
 
   return (
     <Box>
@@ -34,11 +47,14 @@ export const CorrectionListYearFilter = () => {
         onChange={(event) => {
           const selectedValue = event.target.value;
           const syncedParams = syncParamsWithSearchFields(searchParams);
+
           if (selectedValue !== 'showAll') {
             syncedParams.set(ResultParam.PublicationYear, selectedValue);
+            syncedParams.set(ResultParam.ExcludeParentPublicationYear, selectedValue);
           } else {
             syncedParams.delete(ResultParam.PublicationYear);
           }
+
           navigate({ search: syncedParams.toString() });
         }}
         slotProps={{
@@ -46,13 +62,11 @@ export const CorrectionListYearFilter = () => {
             'aria-label': t('basic_data.nvi.period_year'),
           },
         }}>
-        {options.map((option) => {
-          return (
-            <MenuItem key={option.value} value={option.value}>
-              {option.label}
-            </MenuItem>
-          );
-        })}
+        {options.map((option) => (
+          <MenuItem key={option.value} value={option.value}>
+            {option.label}
+          </MenuItem>
+        ))}
       </TextField>
     </Box>
   );

--- a/src/pages/messages/components/CorrectionListYearFilter.tsx
+++ b/src/pages/messages/components/CorrectionListYearFilter.tsx
@@ -50,11 +50,16 @@ export const CorrectionListYearFilter = () => {
 
           if (selectedValue !== 'showAll') {
             syncedParams.set(ResultParam.PublicationYear, selectedValue);
-            syncedParams.set(ResultParam.ExcludeParentPublicationYear, selectedValue);
+
+            if (shouldExcludeShowAll) {
+              syncedParams.set(ResultParam.ExcludeParentPublicationYear, selectedValue);
+            } else {
+              syncedParams.delete(ResultParam.ExcludeParentPublicationYear);
+            }
           } else {
             syncedParams.delete(ResultParam.PublicationYear);
+            syncedParams.delete(ResultParam.ExcludeParentPublicationYear);
           }
-
           navigate({ search: syncedParams.toString() });
         }}
         slotProps={{

--- a/src/pages/messages/components/CorrectionListYearFilter.tsx
+++ b/src/pages/messages/components/CorrectionListYearFilter.tsx
@@ -21,9 +21,10 @@ export const CorrectionListYearFilter = () => {
 
   const publicationYearParam = searchParams.get(ResultParam.PublicationYear);
   const yearSelectionFromQuery = publicationYearParam ?? 'showAll';
-
   const selectedYear =
-    shouldExcludeShowAll && yearSelectionFromQuery === 'showAll' ? currentYear.toString() : yearSelectionFromQuery;
+    shouldExcludeShowAll && yearSelectionFromQuery === 'showAll'
+      ? (currentYear - 1).toString()
+      : yearSelectionFromQuery;
 
   const baseOptions = [
     { value: (currentYear + 1).toString(), label: `${currentYear + 1}` },

--- a/src/pages/messages/components/NviCorrectionList.tsx
+++ b/src/pages/messages/components/NviCorrectionList.tsx
@@ -71,7 +71,8 @@ export const NviCorrectionList = () => {
 
               {(listId === 'ApplicableCategoriesWithNonApplicableChannel' ||
                 listId === 'NonApplicableCategoriesWithApplicableChannel' ||
-                listId === 'ScientificChapterNotInAnthology') && <ScientificValueFilter />}
+                listId === 'ScientificChapterNotInAnthology' ||
+                listId === 'YearBetweenChapterAndBookMismatch') && <ScientificValueFilter />}
 
               <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem 1rem' }}>
                 <PublisherFilter />

--- a/src/pages/messages/components/NviCorrectionListNavigationAccordion.tsx
+++ b/src/pages/messages/components/NviCorrectionListNavigationAccordion.tsx
@@ -70,6 +70,12 @@ export const NviCorrectionListNavigationAccordion = () => {
           {t('tasks.nvi.correction_list_type.book_with_less_than_50_pages')}
         </SelectableButton>
         <SelectableButton
+          data-testid={dataTestId.tasksPage.correctionList.chapterAndBookYearMismatchButton}
+          isSelected={selectedNviList === 'YearBetweenChapterAndBookMismatch'}
+          onClick={() => openNewCorrectionList('YearBetweenChapterAndBookMismatch')}>
+          {t('tasks.nvi.correction_list_type.chapter_and_book_year_mismatch')}
+        </SelectableButton>
+        <SelectableButton
           data-testid={dataTestId.tasksPage.correctionList.unidentifiedContributorWithIdentifiedAffiliationButton}
           isSelected={selectedNviList === 'UnidentifiedContributorWithIdentifiedAffiliation'}
           onClick={() => openNewCorrectionList('UnidentifiedContributorWithIdentifiedAffiliation')}>

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1974,6 +1974,7 @@
         "anthology_without_chapter": "Antologier uten kapittel",
         "applicable_category_in_non_applicable_channel": "Tellende kategorier i ikke-tellende kanaler",
         "book_with_less_than_50_pages": "Bøker med færre enn 50 sider",
+        "chapter_and_book_year_mismatch": "Årstall mellom kapittel og bok avviker",
         "non_applicable_category_in_applicable_channel": "Ikke-tellende kategorier i tellende kanaler",
         "scientific_chapter_not_in_anthology": "Vitenskapelig kapittel ikke i antologi",
         "scientific_monography_or_anthology_without_isxns": "Vitenskapelig monografi eller antologi uten ISxN-er",

--- a/src/types/nvi.types.ts
+++ b/src/types/nvi.types.ts
@@ -167,6 +167,7 @@ export type CorrectionListId =
   | 'NonApplicableCategoriesWithApplicableChannel'
   | 'AnthologyWithoutChapter'
   | 'AnthologyWithApplicableChapter'
+  | 'YearBetweenChapterAndBookMismatch'
   | 'BooksWithLessThan50Pages'
   | 'UnidentifiedContributorWithIdentifiedAffiliation'
   | 'ScientificChapterNotInAnthology'

--- a/src/utils/correctionListHelpers.ts
+++ b/src/utils/correctionListHelpers.ts
@@ -15,6 +15,8 @@ export const getCorrectionListSearchParams = (
   if (correctionListCategoryFilter && correctionListCategoryFilter.length > 0) {
     newSearchParams.set(ResultParam.CategoryShould, correctionListCategoryFilter.join(','));
   }
+  const excludeParentPublicationYearFilter =
+    correctionListConfig[newCorrectionListId].queryParams.excludeParentPublicationYear;
 
   if (correctionListTopLevelOrgFilter) {
     newSearchParams.set(ResultParam.TopLevelOrganization, correctionListTopLevelOrgFilter);
@@ -23,7 +25,13 @@ export const getCorrectionListSearchParams = (
   if (scientificValueFilter) {
     newSearchParams.set(ResultParam.ScientificValue, scientificValueFilter);
   }
+
+  if (excludeParentPublicationYearFilter) {
+    newSearchParams.set(ResultParam.ExcludeParentPublicationYear, (new Date().getFullYear() - 1).toString());
+  }
+
   newSearchParams.set(ResultParam.PublicationYear, (new Date().getFullYear() - 1).toString());
+
   return newSearchParams;
 };
 

--- a/src/utils/dataTestIds.ts
+++ b/src/utils/dataTestIds.ts
@@ -772,7 +772,7 @@ export const dataTestId = {
       anthologyWithoutChapterButton: 'anthology-without-chapter-button',
       booksWithLessThan50PagesButton: 'books-with-less-than-50-pages-button',
       applicableCategoriesWithNonApplicableChannelButton: 'applicable-categories-with-non-applicable-channel-button',
-      chapterAndBookYearMismatchButton: 'chaoter-and-book-year-mismatch-button',
+      chapterAndBookYearMismatchButton: 'chapter-and-book-year-mismatch-button',
       correctionListAccordion: 'correction-list-accordion',
       correctionListRadioButton: 'correction-list-radio-button',
       nonApplicableCategoriesWithApplicableChannelButton: 'non-applicable-categories-with-applicable-channel-button',

--- a/src/utils/dataTestIds.ts
+++ b/src/utils/dataTestIds.ts
@@ -772,6 +772,7 @@ export const dataTestId = {
       anthologyWithoutChapterButton: 'anthology-without-chapter-button',
       booksWithLessThan50PagesButton: 'books-with-less-than-50-pages-button',
       applicableCategoriesWithNonApplicableChannelButton: 'applicable-categories-with-non-applicable-channel-button',
+      chapterAndBookYearMismatchButton: 'chaoter-and-book-year-mismatch-button',
       correctionListAccordion: 'correction-list-accordion',
       correctionListRadioButton: 'correction-list-radio-button',
       nonApplicableCategoriesWithApplicableChannelButton: 'non-applicable-categories-with-applicable-channel-button',

--- a/src/utils/hooks/useCorrectionListConfig.ts
+++ b/src/utils/hooks/useCorrectionListConfig.ts
@@ -8,7 +8,6 @@ import { useLoggedInUser } from './useLoggedInUser';
 export const useCorrectionListConfig = (): CorrectionListSearchConfig => {
   const user = useLoggedInUser();
   const userTopLevelOrg = user?.topOrgCristinId;
-  const searchParams = new URLSearchParams(location.search);
 
   const correctionListConfig: CorrectionListSearchConfig = {
     ApplicableCategoriesWithNonApplicableChannel: {
@@ -52,7 +51,7 @@ export const useCorrectionListConfig = (): CorrectionListSearchConfig => {
       queryParams: {
         categoryShould: [ChapterType.AcademicChapter],
         hasParent: true,
-        excludeParentPublicationYear: 'true',
+        excludeParentPublicationYear: 'initial value',
       },
       disabledFilters: [],
       topLevelOrganization: userTopLevelOrg,

--- a/src/utils/hooks/useCorrectionListConfig.ts
+++ b/src/utils/hooks/useCorrectionListConfig.ts
@@ -51,7 +51,7 @@ export const useCorrectionListConfig = (): CorrectionListSearchConfig => {
       queryParams: {
         categoryShould: [ChapterType.AcademicChapter],
         hasParent: true,
-        excludeParentPublicationYear: 'initial value',
+        excludeParentPublicationYear: (new Date().getFullYear() - 1).toString(),
       },
       disabledFilters: [],
       topLevelOrganization: userTopLevelOrg,

--- a/src/utils/hooks/useCorrectionListConfig.ts
+++ b/src/utils/hooks/useCorrectionListConfig.ts
@@ -8,6 +8,7 @@ import { useLoggedInUser } from './useLoggedInUser';
 export const useCorrectionListConfig = (): CorrectionListSearchConfig => {
   const user = useLoggedInUser();
   const userTopLevelOrg = user?.topOrgCristinId;
+  const searchParams = new URLSearchParams(location.search);
 
   const correctionListConfig: CorrectionListSearchConfig = {
     ApplicableCategoriesWithNonApplicableChannel: {
@@ -42,6 +43,16 @@ export const useCorrectionListConfig = (): CorrectionListSearchConfig => {
       queryParams: {
         categoryShould: Object.values(BookType),
         publicationPages: '0,50',
+      },
+      disabledFilters: [],
+      topLevelOrganization: userTopLevelOrg,
+    },
+    YearBetweenChapterAndBookMismatch: {
+      i18nKey: 'tasks.nvi.correction_list_type.chapter_and_book_year_mismatch',
+      queryParams: {
+        categoryShould: [ChapterType.AcademicChapter],
+        hasParent: true,
+        excludeParentPublicationYear: 'true',
       },
       disabledFilters: [],
       topLevelOrganization: userTopLevelOrg,

--- a/src/utils/hooks/useRegistrationSearchParams.ts
+++ b/src/utils/hooks/useRegistrationSearchParams.ts
@@ -33,6 +33,7 @@ export const useRegistrationsQueryParams = () => {
     contributorName: searchParams.get(ResultParam.ContributorName),
     course: searchParams.get(ResultParam.Course),
     cristinIdentifier: searchParams.get(ResultParam.CristinIdentifier),
+    excludeParentPublicationYear: searchParams.get(ResultParam.ExcludeParentPublicationYear),
     excludeSubunits: searchParams.get(ResultParam.ExcludeSubunits) === 'true',
     files: searchParams.get(ResultParam.Files),
     doi: searchParams.get(ResultParam.Doi),


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-50826

Adds a new correction-list for showing chapters that have a mismatching publication date with its parent

# How to test

Affected part of the application: http://localhost:3000/tasks/correction-list?list=YearBetweenChapterAndBookMismatch&categoryShould=AcademicChapter&topLevelOrganization=https%3A%2F%2Fapi.dev.nva.aws.unit.no%2Fcristin%2Forganization%2F20754.0.0.0&excludeParentPublicationYear=2025&publicationYear=2025

1. Check that the chapters in the list belongs to book published at a different 
2. Confirm that the filters are working as expected

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new correction list type to identify year mismatches between chapters and books.
  * Added parent publication year filtering capability.

* **Enhancements**
  * Updated year filter behaviour for certain correction lists to exclude the "show all" option and default to the current year.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->