### PR TITLE
NP-50946 Update url params for numbers in NVI tables

### DIFF
--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -264,6 +264,7 @@ export enum NviCandidateFilterEnum {
 export type NviCandidateFilter = `${NviCandidateFilterEnum}`;
 
 export enum NviCandidateStatusEnum {
+  New = 'new',
   Pending = 'pending',
   Approved = 'approved',
   Rejected = 'rejected',

--- a/src/pages/messages/components/NviPublicationPointsTableRow.tsx
+++ b/src/pages/messages/components/NviPublicationPointsTableRow.tsx
@@ -1,7 +1,7 @@
 import { Link, TableCell } from '@mui/material';
 import { useState } from 'react';
 import { Link as RouterLink } from 'react-router';
-import { NviCandidateGlobalStatusEnum, NviCandidateStatusEnum } from '../../../api/searchApi';
+import { NviCandidateGlobalStatusEnum } from '../../../api/searchApi';
 import { NviInstitutionStatusResponse } from '../../../types/nvi.types';
 import { Organization } from '../../../types/organization.types';
 import { dataTestId } from '../../../utils/dataTestIds';
@@ -55,8 +55,7 @@ export const NviPublicationPointsTableRow = ({
               to={getNviCandidatesSearchPath({
                 year: year,
                 orgNumber: getIdentifierFromId(organization.id),
-                status: NviCandidateStatusEnum.Approved,
-                globalStatus: [NviCandidateGlobalStatusEnum.Approved, NviCandidateGlobalStatusEnum.Pending],
+                globalStatus: NviCandidateGlobalStatusEnum.Approved,
                 excludeSubUnits: true,
               })}>
               {orgAggregations?.globalApprovalStatus.Approved ?? 0}

--- a/src/pages/messages/components/NviStatusTableRow.tsx
+++ b/src/pages/messages/components/NviStatusTableRow.tsx
@@ -48,10 +48,9 @@ export const NviStatusTableRow = ({ organization, aggregations, level = 0, user,
               component={RouterLink}
               data-testid={dataTestId.nviStatusTableRow.candidateLink}
               to={getNviCandidatesSearchPath({
-                username: user?.nvaUsername,
                 year: year,
                 orgNumber: getIdentifierFromId(organization.id),
-                status: NviCandidateStatusEnum.Pending,
+                status: NviCandidateStatusEnum.New,
                 globalStatus: NviCandidateGlobalStatusEnum.Pending,
                 excludeSubUnits: true,
               })}>
@@ -89,11 +88,7 @@ export const NviStatusTableRow = ({ organization, aggregations, level = 0, user,
                 year: year,
                 orgNumber: getIdentifierFromId(organization.id),
                 status: NviCandidateStatusEnum.Approved,
-                globalStatus: [
-                  NviCandidateGlobalStatusEnum.Approved,
-                  NviCandidateGlobalStatusEnum.Pending,
-                  NviCandidateGlobalStatusEnum.Dispute,
-                ],
+                globalStatus: [NviCandidateGlobalStatusEnum.Approved, NviCandidateGlobalStatusEnum.Pending],
                 excludeSubUnits: true,
               })}>
               {orgAggregations?.approvalStatus.Approved ?? 0}
@@ -111,7 +106,7 @@ export const NviStatusTableRow = ({ organization, aggregations, level = 0, user,
                 year: year,
                 orgNumber: getIdentifierFromId(organization.id),
                 status: NviCandidateStatusEnum.Rejected,
-                globalStatus: NviCandidateGlobalStatusEnum.Rejected,
+                globalStatus: [NviCandidateGlobalStatusEnum.Rejected, NviCandidateGlobalStatusEnum.Pending],
                 excludeSubUnits: true,
               })}>
               {orgAggregations?.approvalStatus.Rejected ?? 0}


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-50946](https://sikt.atlassian.net/browse/NP-50946)

Url-parametere for lenker i tabellene i "Vis rapportertingsstatus" og "Vis status for publiseringspoeng" har vært feil.

## Endringer

### Rapporteringsstatus-tabell

**Kolonne "Kandidat"**
- Lokal status:
  - `Pending` → `New`
- Global status:
  - `Pending` (uendret, brukes for å luke bort tvister)
- Fjerner kurator da kandidater (ikke til kontroll) ikke har kurator

**Kolonne "Kontrolleres"**
- Uendret

**Kolonne "Godkjent"**
- Lokal status:
  - `Approved` (uendret)
- Global status:
  - `Approved, Pending, Dispute` → `Approved, Pending`  
    (luker bort tvister)

**Kolonne "Avvist"**
- Lokal status:
  - `Rejected` (uendret)
- Global status:
  - `Rejected` → `Rejected, Pending`  
    (luker bort tvister, men inkluderer kandidater hvor andre institusjoner fortsatt er til kontroll)

### Publiseringspoeng-tabell

**Kolonne "Godkjent"**
- Lokal status:
  - `Approved` → fjernes (lokal status er implisitt global status i denne kolonnen)
- Global status:
  - `Approved, Pending` → `Approved`  
    (kun poenggivende kandidater, som betyr at alle har godkjent)

### NB
Backend gir samme respons om man bruker filter `New` og `Pending`. Dette skal endres i nær framtid. Så endringen fra `Pending` → `New` i denne PR'en har ingen effekt enda.

# How to test

Affected part of the application: 

http://localhost:3000/tasks/nvi/status
http://localhost:3000/tasks/nvi/publication-points

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._

[NP-50946]: https://sikt.atlassian.net/browse/NP-50946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ