### PR TITLE
NP-50907 Remove excludeScientificValueSeries from correction list filter

### DIFF
--- a/src/utils/hooks/useCorrectionListConfig.ts
+++ b/src/utils/hooks/useCorrectionListConfig.ts
@@ -99,7 +99,6 @@ export const useCorrectionListConfig = (): CorrectionListSearchConfig => {
           BookType.ExhibitionCatalog,
           BookType.Anthology,
         ],
-        excludeScientificValueSeries: [ScientificValueLevels.LevelOne, ScientificValueLevels.LevelTwo],
         hasIsbn: false,
       },
       disabledFilters: [],


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-50907](https://sikt.atlassian.net/browse/NP-50907)

Fjerner excludeScientificValueSeries fra params i retteliste for ISxN fordi serier på nivå 1 og 2 ikke skal ekskluderes allikevel.

# How to test

Affected part of the application: [Retteliste](http://localhost:3000/tasks/correction-list?list=ScientificMonographyOrAnthologyWithoutIsxns&categoryShould=AcademicMonograph%2CAcademicCommentary%2CNonFictionMonograph%2CPopularScienceMonograph%2CTextbook%2CEncyclopedia%2CExhibitionCatalog%2CBookAnthology&topLevelOrganization=https%3A%2F%2Fapi.dev.nva.aws.unit.no%2Fcristin%2Forganization%2F20754.0.0.0&publicationYear=2025)

For å teste: Finn en bok uten isbn for gitt år, med serie på nivå 1 eller 2. Denne skal nå dukker opp i rettelisten.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-50907]: https://sikt.atlassian.net/browse/NP-50907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ