### PR TITLE
Changed so that percentage is rounded down

### DIFF
--- a/src/pages/basic_data/app_admin/NviAdminStatusPage.tsx
+++ b/src/pages/basic_data/app_admin/NviAdminStatusPage.tsx
@@ -12,9 +12,9 @@ import {
 import { Trans, useTranslation } from 'react-i18next';
 import { useGetUrlFilteredInstitutionReports } from '../../../api/hooks/useGetUrlFilteredInstitutionReports';
 import { PercentageWithIcon } from '../../../components/atoms/PercentageWithIcon';
+import { TableSkeleton } from '../../../components/skeletons/TableSkeleton';
 import { HorizontalBox } from '../../../components/styled/Wrappers';
 import { InstitutionReport } from '../../../types/nvi.types';
-import { TableSkeleton } from '../../../components/skeletons/TableSkeleton';
 import { getLanguageString } from '../../../utils/translation-helpers';
 import { NviStatusWrapper } from '../../messages/components/NviStatusWrapper';
 
@@ -82,7 +82,7 @@ export const NviAdminStatusPage = () => {
                         <PercentageWithIcon
                           warningThresholdMinimum={30}
                           successThresholdMinimum={100}
-                          displayPercentage={Math.round(percentageControlled * 100)}
+                          displayPercentage={Math.floor(percentageControlled * 100)}
                           alternativeIfZero={'-'}
                         />
                       </HorizontalBox>


### PR DESCRIPTION
# Description

Link to Jira issue: [Percentages in rapporteringsstatus table should round down](https://sikt.atlassian.net/browse/NP-50956)

Prosentene i rapporteringsstatustabellen skal rundes ned, slik at det aldri blir grønn hake og 100% med mindre man er ferdig med alle kandidater.

# How to test

Affected part of the application: http://localhost:3000/basic-data/nvi/status?year=2025

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined percentage display calculation in the admin status view for more accurate rounding behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->