### PR TITLE
Now using global numbers

### DIFF
--- a/src/api/hooks/useFetchNviPeriodReport.ts
+++ b/src/api/hooks/useFetchNviPeriodReport.ts
@@ -5,9 +5,10 @@ import { fetchNviPeriodReport } from '../scientificIndexApi';
 interface QueryOptions {
   year: number;
   enabled?: boolean;
+  hideErrorMessage?: boolean;
 }
 
-export const useFetchNviPeriodReport = ({ year, enabled = true }: QueryOptions) => {
+export const useFetchNviPeriodReport = ({ year, enabled = true, hideErrorMessage = false }: QueryOptions) => {
   const { t } = useTranslation();
   const isValidYear = Number.isInteger(year) && year >= 1000 && year <= 9999;
 
@@ -15,6 +16,6 @@ export const useFetchNviPeriodReport = ({ year, enabled = true }: QueryOptions) 
     enabled: !!year && isValidYear && enabled,
     queryKey: ['nviReportInstitution', year],
     queryFn: () => fetchNviPeriodReport(year),
-    meta: { errorMessage: t('feedback.error.get_nvi_period_report') },
+    meta: { errorMessage: hideErrorMessage ? false : t('feedback.error.get_nvi_period_report') },
   });
 };

--- a/src/components/AdminNviPublicationPointsTexts.tsx
+++ b/src/components/AdminNviPublicationPointsTexts.tsx
@@ -14,8 +14,8 @@ export const AdminNviPublicationPointsTexts = () => {
   const [textExpanded, setTextExpanded] = useState(false);
   const detailsId = 'publication-points-details';
   const year = getDefaultNviYear();
-  const periodReport = useFetchNviPeriodReport({ year });
-  const periodReportLastYear = useFetchNviPeriodReport({ year: year - 1 });
+  const periodReport = useFetchNviPeriodReport({ year, hideErrorMessage: true });
+  const periodReportLastYear = useFetchNviPeriodReport({ year: year - 1, hideErrorMessage: true });
   const periodTotals = periodReport.data?.totals;
   const periodTotalsLastYear = periodReportLastYear.data?.totals;
 

--- a/src/pages/basic_data/NviAdminNavigationAccordion.tsx
+++ b/src/pages/basic_data/NviAdminNavigationAccordion.tsx
@@ -21,7 +21,11 @@ export const NviAdminNavigationAccordion = () => {
   const isAppAdmin = !!user?.customerId && user.isAppAdmin;
   const location = useLocation();
   const currentPath = location.pathname.replace(/\/$/, ''); // Remove trailing slash
-  const reportQuery = useFetchNviPeriodReport({ year: getDefaultNviYear(), enabled: isAppAdmin });
+  const reportQuery = useFetchNviPeriodReport({
+    year: getDefaultNviYear(),
+    enabled: isAppAdmin,
+    hideErrorMessage: true,
+  });
   const periodTotals = reportQuery.data?.totals;
 
   return (

--- a/src/pages/basic_data/NviAdminNavigationAccordion.tsx
+++ b/src/pages/basic_data/NviAdminNavigationAccordion.tsx
@@ -3,7 +3,7 @@ import { Box, Divider } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
-import { useFetchNviReportForInstitution } from '../../api/hooks/useFetchNviReportForInstitution';
+import { useFetchNviPeriodReport } from '../../api/hooks/useFetchNviPeriodReport';
 import { BetaFunctionality } from '../../components/BetaFunctionality';
 import { NavigationListAccordion } from '../../components/NavigationListAccordion';
 import { NviReportProgressBar } from '../../components/NviReportProgressBar';
@@ -12,7 +12,6 @@ import { SelectableButton } from '../../components/SelectableButton';
 import { StyledNviStatusBox } from '../../components/styled/Wrappers';
 import { RootState } from '../../redux/store';
 import { dataTestId } from '../../utils/dataTestIds';
-import { getIdentifierFromId } from '../../utils/general-helpers';
 import { getDefaultNviYear } from '../../utils/hooks/useNviCandidatesParams';
 import { UrlPathTemplate } from '../../utils/urlPaths';
 
@@ -22,13 +21,8 @@ export const NviAdminNavigationAccordion = () => {
   const isAppAdmin = !!user?.customerId && user.isAppAdmin;
   const location = useLocation();
   const currentPath = location.pathname.replace(/\/$/, ''); // Remove trailing slash
-  const topOrgId = user?.topOrgCristinId ? getIdentifierFromId(user.topOrgCristinId) : '';
-  const reportQuery = useFetchNviReportForInstitution({
-    year: getDefaultNviYear(),
-    id: topOrgId,
-    enabled: isAppAdmin,
-  });
-  const nviNumbers = reportQuery.data?.institutionSummary.totals;
+  const reportQuery = useFetchNviPeriodReport({ year: getDefaultNviYear(), enabled: isAppAdmin });
+  const periodTotals = reportQuery.data?.totals;
 
   return (
     <NavigationListAccordion
@@ -39,15 +33,15 @@ export const NviAdminNavigationAccordion = () => {
       <NavigationList aria-label={t('common.nvi')}>
         <StyledNviStatusBox>
           <BetaFunctionality>
-            {reportQuery.isError || !nviNumbers ? undefined : (
+            {reportQuery.isError || !periodTotals ? undefined : (
               <NviReportProgressBar
                 completedPercentage={
-                  nviNumbers.undisputedTotalCount > 0
-                    ? Math.round((nviNumbers.undisputedProcessedCount / nviNumbers.undisputedTotalCount) * 100)
+                  periodTotals.undisputedTotalCount > 0
+                    ? Math.round((periodTotals.undisputedProcessedCount / periodTotals.undisputedTotalCount) * 100)
                     : 0
                 }
-                completedCount={nviNumbers.undisputedProcessedCount}
-                totalCount={nviNumbers.undisputedTotalCount}
+                completedCount={periodTotals.undisputedProcessedCount}
+                totalCount={periodTotals.undisputedTotalCount}
                 isPending={reportQuery.isPending}
               />
             )}


### PR DESCRIPTION
# Description

Link to Jira issue: [Progressbar viser ikke rett verdi](https://sikt.atlassian.net/browse/NP-50952)

Fix the progressbar in the NVI admin view, so that it displays global values instead of the values for the organization.

# How to test

Affected part of the application: [NVI admin view](http://localhost:3000/basic-data/nvi/publication-points?year=2025) (side panel)

<img width="309" height="110" alt="image" src="https://github.com/user-attachments/assets/e738fdc1-ac84-4910-8b5e-b803d69ad600" />

Also removed error message when the fetch fails, because it's not something the users need to the notified of.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error message handling in NVI period report components to provide more refined feedback visibility across administrative interfaces and dashboards, reducing unnecessary error notifications in specific contexts whilst maintaining existing data functionality and validation behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->