### PR TITLE
NP-50970 Add status NEW to candidates for control status search

### DIFF
--- a/src/pages/messages/components/NviCandidatesNavigationAccordion.tsx
+++ b/src/pages/messages/components/NviCandidatesNavigationAccordion.tsx
@@ -60,7 +60,7 @@ export const NviCandidatesNavigationAccordion = () => {
       accordionPath={UrlPathTemplate.TasksNvi}
       defaultPath={getNviCandidatesSearchPath({
         username: user?.nvaUsername,
-        status: NviCandidateStatusEnum.Pending,
+        status: [NviCandidateStatusEnum.New, NviCandidateStatusEnum.Pending],
         globalStatus: NviCandidateGlobalStatusEnum.Pending,
       })}
       dataTestId={dataTestId.tasksPage.nviAccordion}>
@@ -118,7 +118,7 @@ export const NviCandidatesNavigationAccordion = () => {
               to={getNviCandidatesSearchPath({
                 username: user?.nvaUsername,
                 year: nviParams.year,
-                status: NviCandidateStatusEnum.Pending,
+                status: [NviCandidateStatusEnum.New, NviCandidateStatusEnum.Pending],
                 globalStatus: NviCandidateGlobalStatusEnum.Pending,
               })}>
               {t('tasks.nvi.show_candidate_search')}

--- a/src/pages/messages/nviUtils.test.ts
+++ b/src/pages/messages/nviUtils.test.ts
@@ -17,7 +17,7 @@ describe('computeDropdownStatusFromParams', () => {
   describe("status: pending and globalStatus: pending'", () => {
     it('returns the search status "candidates for control"', () => {
       const res = computeDropdownStatusFromParams(
-        [NviCandidateStatusEnum.Pending],
+        [NviCandidateStatusEnum.New, NviCandidateStatusEnum.Pending],
         [NviCandidateGlobalStatusEnum.Pending]
       );
       expect(res).toEqual([NviSearchStatusEnum.CandidatesForControl]);
@@ -96,7 +96,7 @@ describe('computeParamsFromDropdownStatus', () => {
     it('returns pending statuses', () => {
       const res = computeParamsFromDropdownStatus([NviSearchStatusEnum.CandidatesForControl]);
       expect(res).toEqual({
-        newStatuses: [NviCandidateStatusEnum.Pending],
+        newStatuses: [NviCandidateStatusEnum.New, NviCandidateStatusEnum.Pending],
         newGlobalStatuses: [NviCandidateGlobalStatusEnum.Pending],
       });
     });
@@ -126,7 +126,7 @@ describe('computeParamsFromDropdownStatus', () => {
         NviSearchStatusEnum.Approved,
       ]);
       expect(res).toEqual({
-        newStatuses: [NviCandidateStatusEnum.Pending, NviCandidateStatusEnum.Approved],
+        newStatuses: [NviCandidateStatusEnum.New, NviCandidateStatusEnum.Pending, NviCandidateStatusEnum.Approved],
         newGlobalStatuses: [NviCandidateGlobalStatusEnum.Pending, NviCandidateGlobalStatusEnum.Approved],
       });
     });
@@ -138,7 +138,7 @@ describe('computeParamsFromDropdownStatus', () => {
         NviSearchStatusEnum.Rejected,
       ]);
       expect(res).toEqual({
-        newStatuses: [NviCandidateStatusEnum.Pending, NviCandidateStatusEnum.Rejected],
+        newStatuses: [NviCandidateStatusEnum.New, NviCandidateStatusEnum.Pending, NviCandidateStatusEnum.Rejected],
         newGlobalStatuses: [NviCandidateGlobalStatusEnum.Pending, NviCandidateGlobalStatusEnum.Rejected],
       });
     });
@@ -164,7 +164,12 @@ describe('computeParamsFromDropdownStatus', () => {
         NviSearchStatusEnum.Rejected,
       ]);
       expect(res).toEqual({
-        newStatuses: [NviCandidateStatusEnum.Pending, NviCandidateStatusEnum.Approved, NviCandidateStatusEnum.Rejected],
+        newStatuses: [
+          NviCandidateStatusEnum.New,
+          NviCandidateStatusEnum.Pending,
+          NviCandidateStatusEnum.Approved,
+          NviCandidateStatusEnum.Rejected,
+        ],
         newGlobalStatuses: [
           NviCandidateGlobalStatusEnum.Pending,
           NviCandidateGlobalStatusEnum.Approved,

--- a/src/pages/messages/nviUtils.ts
+++ b/src/pages/messages/nviUtils.ts
@@ -56,6 +56,7 @@ export const computeParamsFromDropdownStatus = (dropdownStatus: NviSearchStatus[
 
   dropdownStatus.forEach((value) => {
     if (value === NviSearchStatusEnum.CandidatesForControl) {
+      newStatus.add(NviCandidateStatusEnum.New);
       newStatus.add(NviCandidateStatusEnum.Pending);
       newGlobalStatus.add(NviCandidateGlobalStatusEnum.Pending);
     } else if (value === NviSearchStatusEnum.Approved) {


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-50970

Add (back) the `status=new` param for candidate search

# How to test

Affected part of the application: [Candidate search](http://localhost:3000/tasks/nvi?status=new%2Cpending&globalStatus=pending&assignee=1545741%4020754.0.0.0)

1. Make sure the param is added correctly when:
  - Clicking the navigation accordion
  - Updating the params from the dropdown menu

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NVI candidate filters and searches now include both New and Pending statuses by default, improving visibility of candidate records during navigation and filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->