### PR TITLE
Changed name of publication points column

### DIFF
--- a/src/pages/basic_data/app_admin/NviAdminPublicationPointsPage.tsx
+++ b/src/pages/basic_data/app_admin/NviAdminPublicationPointsPage.tsx
@@ -2,13 +2,13 @@ import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow
 import { useTranslation } from 'react-i18next';
 import { useGetUrlFilteredInstitutionReports } from '../../../api/hooks/useGetUrlFilteredInstitutionReports';
 import { AdminNviPublicationPointsTexts } from '../../../components/AdminNviPublicationPointsTexts';
+import { PercentageWithIcon } from '../../../components/atoms/PercentageWithIcon';
 import { TableSkeleton } from '../../../components/skeletons/TableSkeleton';
+import { HorizontalBox } from '../../../components/styled/Wrappers';
 import i18n from '../../../translations/i18n';
 import { InstitutionReport } from '../../../types/nvi.types';
 import { getLanguageString } from '../../../utils/translation-helpers';
 import { NviStatusWrapper } from '../../messages/components/NviStatusWrapper';
-import { HorizontalBox } from '../../../components/styled/Wrappers';
-import { PercentageWithIcon } from '../../../components/atoms/PercentageWithIcon';
 
 export const NviAdminPublicationPointsPage = () => {
   const { t } = useTranslation();
@@ -34,7 +34,7 @@ export const NviAdminPublicationPointsPage = () => {
                 <TableCell>{t('sector')}</TableCell>
                 <TableCell>{t('candidates_we_have_approved')}</TableCell>
                 <TableCell>{t('candidates_everyone_has_approved')}</TableCell>
-                <TableCell>{t('publication_points')}</TableCell>
+                <TableCell>{t('points_for_reporting')}</TableCell>
                 <TableCell>{t('percentage_approved')}</TableCell>
               </TableRow>
             </TableHead>

--- a/src/pages/messages/components/NviPublicationPointsHelper.tsx
+++ b/src/pages/messages/components/NviPublicationPointsHelper.tsx
@@ -18,7 +18,9 @@ export const NviPublicationPointsHelper = () => {
           <Trans t={t} i18nKey="points_for_reporting_modal_text" components={{ p: <Typography /> }} />
         </VerticalBox>
         <HorizontalBox sx={{ gap: '0.5rem', mb: '1rem' }}>
-          <OpenInNewLink href={NVI_REPORTING_INSTRUCTIONS_URL}>{t('view_the_reporting_instructions')}</OpenInNewLink>
+          <OpenInNewLink href={NVI_REPORTING_INSTRUCTIONS_URL} data-testid={dataTestId.nviPublicationPointsHelpLink}>
+            {t('view_the_reporting_instructions')}
+          </OpenInNewLink>
         </HorizontalBox>
       </VerticalBox>
     </HelperTextModal>

--- a/src/pages/messages/components/NviPublicationPointsHelper.tsx
+++ b/src/pages/messages/components/NviPublicationPointsHelper.tsx
@@ -1,0 +1,26 @@
+import { Typography } from '@mui/material';
+import { Trans, useTranslation } from 'react-i18next';
+import { OpenInNewLink } from '../../../components/OpenInNewLink';
+import { HorizontalBox, VerticalBox } from '../../../components/styled/Wrappers';
+import { dataTestId } from '../../../utils/dataTestIds';
+import { NVI_REPORTING_INSTRUCTIONS_URL } from '../../../utils/externalLinks';
+import { HelperTextModal } from '../../registration/HelperTextModal';
+
+export const NviPublicationPointsHelper = () => {
+  const { t } = useTranslation();
+  return (
+    <HelperTextModal
+      modalTitle={t('points_for_reporting')}
+      modalDataTestId={dataTestId.nviPublicationPointsHelpModal}
+      buttonDataTestId={dataTestId.nviPublicationPointsHelpButton}>
+      <VerticalBox>
+        <VerticalBox sx={{ gap: '1rem' }}>
+          <Trans t={t} i18nKey="points_for_reporting_modal_text" components={{ p: <Typography /> }} />
+        </VerticalBox>
+        <HorizontalBox sx={{ gap: '0.5rem', mb: '1rem' }}>
+          <OpenInNewLink href={NVI_REPORTING_INSTRUCTIONS_URL}>{t('view_the_reporting_instructions')}</OpenInNewLink>
+        </HorizontalBox>
+      </VerticalBox>
+    </HelperTextModal>
+  );
+};

--- a/src/pages/messages/components/NviPublicationPointsPage.tsx
+++ b/src/pages/messages/components/NviPublicationPointsPage.tsx
@@ -32,7 +32,7 @@ export const NviPublicationPointsPage = () => {
             <TableRow sx={{ whiteSpace: 'nowrap', bgcolor: 'white' }}>
               <TableCell sx={{ width: '80%' }}>{t('registration.contributors.department')}</TableCell>
               <TableCell>{t('tasks.nvi.status.Approved')}</TableCell>
-              <TableCell>{t('tasks.nvi.points_for_reporting')}</TableCell>
+              <TableCell>{t('points_for_reporting')}</TableCell>
               <TableCell>
                 <Box component="span" sx={visuallyHidden}>
                   {t('tasks.nvi.show_subunits')}

--- a/src/pages/messages/components/NviPublicationPointsPage.tsx
+++ b/src/pages/messages/components/NviPublicationPointsPage.tsx
@@ -5,8 +5,10 @@ import { useSelector } from 'react-redux';
 import { useFetchNviInstitutionStatus } from '../../../api/hooks/useFetchNviStatus';
 import { useFetchOrganization } from '../../../api/hooks/useFetchOrganization';
 import { NviPublicationPointsTexts } from '../../../components/NviPublicationPointsTexts';
+import { HorizontalBox } from '../../../components/styled/Wrappers';
 import { RootState } from '../../../redux/store';
 import { getDefaultNviYear } from '../../../utils/hooks/useNviCandidatesParams';
+import { NviPublicationPointsHelper } from './NviPublicationPointsHelper';
 import { NviPublicationPointsTableRow } from './NviPublicationPointsTableRow';
 import { NviStatusWrapper } from './NviStatusWrapper';
 
@@ -30,11 +32,16 @@ export const NviPublicationPointsPage = () => {
         <Table size="small">
           <TableHead>
             <TableRow sx={{ bgcolor: 'white' }}>
-              <TableCell sx={{ width: '50%' }}>{t('registration.contributors.department')}</TableCell>
+              <TableCell sx={{ width: '40%' }}>{t('registration.contributors.department')}</TableCell>
               <TableCell align="center">{t('candidates_we_have_approved')}</TableCell>
               <TableCell align="center">{t('tasks.nvi.candidates_pending_verification_by_others')}</TableCell>
               <TableCell align="center">{t('candidates_everyone_has_approved')}</TableCell>
-              <TableCell align="center">{t('points_for_reporting')}</TableCell>
+              <TableCell align="center">
+                <HorizontalBox>
+                  {t('points_for_reporting')}
+                  <NviPublicationPointsHelper />
+                </HorizontalBox>
+              </TableCell>
               <TableCell align="center">{t('percentage_approved_by_all')}</TableCell>
               <TableCell>
                 {/* This cell is hidden to make the number of cells in the table header the same as in the table row, where we display an accordion-like arrow to expand or close rows that have subunits */}

--- a/src/pages/messages/components/NviPublicationPointsPage.tsx
+++ b/src/pages/messages/components/NviPublicationPointsPage.tsx
@@ -37,7 +37,7 @@ export const NviPublicationPointsPage = () => {
               <TableCell align="center">{t('tasks.nvi.candidates_pending_verification_by_others')}</TableCell>
               <TableCell align="center">{t('candidates_everyone_has_approved')}</TableCell>
               <TableCell align="center">
-                <HorizontalBox>
+                <HorizontalBox sx={{ justifyContent: 'center' }}>
                   {t('points_for_reporting')}
                   <NviPublicationPointsHelper />
                 </HorizontalBox>

--- a/src/pages/messages/components/NviPublicationPointsPage.tsx
+++ b/src/pages/messages/components/NviPublicationPointsPage.tsx
@@ -29,12 +29,12 @@ export const NviPublicationPointsPage = () => {
       <TableContainer component={Paper} variant="outlined">
         <Table size="small">
           <TableHead>
-            <TableRow sx={{ whiteSpace: 'nowrap', bgcolor: 'white' }}>
-              <TableCell sx={{ width: '30%' }}>{t('registration.contributors.department')}</TableCell>
+            <TableRow sx={{ bgcolor: 'white' }}>
+              <TableCell sx={{ width: '50%' }}>{t('registration.contributors.department')}</TableCell>
               <TableCell align="center">{t('candidates_we_have_approved')}</TableCell>
               <TableCell align="center">{t('tasks.nvi.candidates_pending_verification_by_others')}</TableCell>
               <TableCell align="center">{t('candidates_everyone_has_approved')}</TableCell>
-              <TableCell align="center">{t('tasks.nvi.points_for_reporting')}</TableCell>
+              <TableCell align="center">{t('points_for_reporting')}</TableCell>
               <TableCell align="center">{t('percentage_approved_by_all')}</TableCell>
               <TableCell>
                 {/* This cell is hidden to make the number of cells in the table header the same as in the table row, where we display an accordion-like arrow to expand or close rows that have subunits */}

--- a/src/pages/messages/components/NviPublicationPointsPage.tsx
+++ b/src/pages/messages/components/NviPublicationPointsPage.tsx
@@ -32,7 +32,7 @@ export const NviPublicationPointsPage = () => {
             <TableRow sx={{ whiteSpace: 'nowrap', bgcolor: 'white' }}>
               <TableCell sx={{ width: '80%' }}>{t('registration.contributors.department')}</TableCell>
               <TableCell>{t('tasks.nvi.status.Approved')}</TableCell>
-              <TableCell>{t('tasks.nvi.publication_points')}</TableCell>
+              <TableCell>{t('tasks.nvi.points_for_reporting')}</TableCell>
               <TableCell>
                 <Box component="span" sx={visuallyHidden}>
                   {t('tasks.nvi.show_subunits')}

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1870,7 +1870,7 @@
     "year_published": "Publiseringsår"
   },
   "rejected": "Avvist",
-  "reporting_status_description": "<0>Tabellen viser kandidater ved din institusjon som er godkjent av dere per nå og hvilke som mangler godkjenning av samarbeidende institusjoner.</0> <0>Kandidatene er lagt på den eller de enhetene hvor de er registrert. En kandidat kan være registrert på flere enheter. Kandidater i eventuell tvist vises ikke.</0>",
+  "reporting_status_description": "<0>Tabellen viser antall kandidater for min institusjon og behandlingsstatus på disse.</0> <0>Kandidatene er lagt på den eller de enhetene hvor de er registrert. En kandidat kan være registrert på flere enheter. Kandidater i eventuell tvist vises ikke.</0>",
   "reset": "Nullstill",
   "results": "Forskningsresultater",
   "science_categories_front_page": "<heading>Arbeid i ulike kategorier</heading><p>Forskning og formidling omfatter mye mer enn vitenskapelige publikasjoner.</p><p>Alt registreres i ulike kategorier, og du kan søke og gjøre oppslag i alle kategoriene nedenfor.</p>",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1997,7 +1997,7 @@
       "previous_candidate": "Gå til forrige kandidat",
       "problem_description": "<p>NVI-kandidaten har følgende mangler:</p><ul><li>$t(tasks.nvi.unidentified_person_with_nvi_institution)</li></ul><p>Identifiser person før du godkjenner ved å redigere resultatet. Kontrollstatuser blir opphevet når en uidentifisert person blir identifisert.</p>",
       "progress_nvi_reporting": "Fremdrift for NVI-rapporting",
-      "publication_points": "Publiseringspoeng",
+      "points_for_reporting": "Poeng til rapportering",
       "reject_nvi_candidate": "Avvis resultat",
       "reject_nvi_candidate_description": "Trykk på \"{{buttonText}}\" om publikasjonen ikke kan rapporteres. Du må begrunne avvisningen.",
       "reject_nvi_candidate_form_label": "Begrunnelse for avvisning",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -1115,7 +1115,7 @@
     "verify_project_manager": "Identifiser prosjektleder"
   },
   "projects": "Prosjekter",
-  "publication_points": "Publiseringspoeng",
+  "points_for_reporting": "Poeng til rapportering",
   "publication_points_description": "Tabellen viser kandidater som er godkjent per nå hos alle institusjoner og hvor mange som er ferdig kontrollert i forhold til antall kandidater.",
   "publication_points_description_more": "Kandidatene er lagt på enheten hvor de er registrert. Det er ikke tatt hensyn til samarbeidene institusjoner. Kandidater i eventuelt tvist vises ikke.",
   "published_result": "Publisert resultat",
@@ -1997,7 +1997,6 @@
       "previous_candidate": "Gå til forrige kandidat",
       "problem_description": "<p>NVI-kandidaten har følgende mangler:</p><ul><li>$t(tasks.nvi.unidentified_person_with_nvi_institution)</li></ul><p>Identifiser person før du godkjenner ved å redigere resultatet. Kontrollstatuser blir opphevet når en uidentifisert person blir identifisert.</p>",
       "progress_nvi_reporting": "Fremdrift for NVI-rapporting",
-      "points_for_reporting": "Poeng til rapportering",
       "reject_nvi_candidate": "Avvis resultat",
       "reject_nvi_candidate_description": "Trykk på \"{{buttonText}}\" om publikasjonen ikke kan rapporteres. Du må begrunne avvisningen.",
       "reject_nvi_candidate_form_label": "Begrunnelse for avvisning",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -2072,6 +2072,6 @@
   "x_results_are_ready_for_reporting_and_they_give_y_publication_points": "<b>{{num_results}} resultat</b> er klar for rapportering, og de gir <b>{{total_publicationpoints}} publiseringspoeng.</b>",
   "you_cannot_upload_files_to_this_result": "Du har ikke tilgang til å laste opp filer for dette resultatet.",
   "you_do_not_have_permission_to_edit_this_registration": "Du har ikke tilgang til å endre denne registreringen.",
-  "points_for_reporting_modal_text": "<p>Poengene i tabellen viser poeng for kandidater som er godkjent av alle altså poeng for kandidater som er klar til rapporteringen.</p><p>Tabellen vise antall poeng for NVI kandidater adressert på de ulike underenheten. Vær obs på at hvis en NVI kandidat har adressert flere underenheter på egen institusjon, vil samme poeng for NVI kandidat telles på flere underenheter. Du kan derfor ikke summere kolonnene vertikalt, kun horisontalt.</p><p>Ønsker du å vite hvordan poengene beregnes?</p>",
+  "points_for_reporting_modal_text": "<p>Poengene i tabellen viser poeng for kandidater som er godkjent av alle. Altså poeng for kandidater som er klar til rapporteringen.</p><p>Tabellen viser antall poeng for kandidater adressert på de ulike underenhetene. Vær obs på at hvis en kandidat har adressert flere underenheter på egen institusjon, vil samme poeng for kandidaten telles på flere underenheter. Du kan derfor ikke summere kolonnene vertikalt, kun horisontalt.</p><p>Ønsker du å vite hvordan poengene beregnes?</p>",
   "view_the_reporting_instructions": "Se rapporteringsinstruksen"
 }

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -2071,5 +2071,7 @@
   "x_results_are_ready_for_reporting_and_they_give_y_points": "<p><bold>{{num_publications_approved_by_all}} resultat</bold> er klar for rapportering, og de gir <bold>{{points_for_all_publications_approved_by_all}} publiseringspoeng.</bold></p>",
   "x_results_are_ready_for_reporting_and_they_give_y_publication_points": "<b>{{num_results}} resultat</b> er klar for rapportering, og de gir <b>{{total_publicationpoints}} publiseringspoeng.</b>",
   "you_cannot_upload_files_to_this_result": "Du har ikke tilgang til å laste opp filer for dette resultatet.",
-  "you_do_not_have_permission_to_edit_this_registration": "Du har ikke tilgang til å endre denne registreringen."
+  "you_do_not_have_permission_to_edit_this_registration": "Du har ikke tilgang til å endre denne registreringen.",
+  "points_for_reporting_modal_text": "<p>Poengene i tabellen viser poeng for kandidater som er godkjent av alle altså poeng for kandidater som er klar til rapporteringen.</p><p>Tabellen vise antall poeng for NVI kandidater adressert på de ulike underenheten. Vær obs på at hvis en NVI kandidat har adressert flere underenheter på egen institusjon, vil samme poeng for NVI kandidat telles på flere underenheter. Du kan derfor ikke summere kolonnene vertikalt, kun horisontalt.</p><p>Ønsker du å vite hvordan poengene beregnes?</p>",
+  "view_the_reporting_instructions": "Se rapporteringsinstruksen"
 }

--- a/src/utils/dataTestIds.ts
+++ b/src/utils/dataTestIds.ts
@@ -882,4 +882,5 @@ export const dataTestId = {
   nviFilterInstitutionClearSearch: 'nvi-filter-institution-clear-search',
   nviPublicationPointsHelpModal: 'nvi-publication-points-help-modal',
   nviPublicationPointsHelpButton: 'nvi-publication-points-help-button',
+  nviPublicationPointsHelpLink: 'nvi-publication-points-help-link',
 };

--- a/src/utils/dataTestIds.ts
+++ b/src/utils/dataTestIds.ts
@@ -880,4 +880,6 @@ export const dataTestId = {
   nviFilterSector: 'nvi-filter-sector',
   nviFilterInstitution: 'nvi-filter-institution',
   nviFilterInstitutionClearSearch: 'nvi-filter-institution-clear-search',
+  nviPublicationPointsHelpModal: 'nvi-publication-points-help-modal',
+  nviPublicationPointsHelpButton: 'nvi-publication-points-help-button',
 };

--- a/src/utils/externalLinks.ts
+++ b/src/utils/externalLinks.ts
@@ -1,0 +1,2 @@
+export const NVI_REPORTING_INSTRUCTIONS_URL =
+  'https://sikt.no/tjenester/nasjonalt-vitenarkiv-nva/hjelpeside-nva/nvi-rapporteringsinstruks';


### PR DESCRIPTION
# Description

Link to Jira issue:
* [Endre header for "Publiseringspoeng" til "Poeng til rapportering"](https://sikt.atlassian.net/browse/NP-50926)
* [Fikse tekster på rapporteringsstatus og publiseringspoeng så de stemmer med design ](https://sikt.atlassian.net/browse/NP-50977)
* [Legg til hjelpetekst for publiseringspoeng ](https://sikt.atlassian.net/browse/NP-50933)

# How to test

Affected part of the application: [Publiseringspoeng](http://localhost:3000/tasks/nvi/publication-points) and [publication points in admin view
](http://localhost:3000/basic-data/nvi/publication-points?year=2025)

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a help modal providing guidance on publication points and their role in reporting, including a link to detailed reporting instructions
  * Helper icon integrated into the publication points column for easy access to information

* **Improvements**
  * Updated terminology and labels around publication points for enhanced clarity
  * Improved reporting status description for better user understanding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->