### PR TITLE
Remove disputes from candidate search from report status table

### DIFF
--- a/src/pages/messages/components/NviStatusTableRow.tsx
+++ b/src/pages/messages/components/NviStatusTableRow.tsx
@@ -130,6 +130,11 @@ export const NviStatusTableRow = ({ organization, aggregations, level = 0, user,
               to={getNviCandidatesSearchPath({
                 year: year,
                 orgNumber: getIdentifierFromId(organization.id),
+                globalStatus: [
+                  NviCandidateGlobalStatusEnum.Approved,
+                  NviCandidateGlobalStatusEnum.Rejected,
+                  NviCandidateGlobalStatusEnum.Pending,
+                ],
                 excludeSubUnits: true,
               })}>
               {orgAggregations?.candidateCount ?? 0}


### PR DESCRIPTION
# Description

Link to Jira issue: -

Url bak tallet for totalt antall kandidater i tabell for rapporteringsstatus tok ikke hensyn til tvister, så man fikk litt for mange treff tilbake. Bruker global status `approved`, `rejected` og `pending` for å filtrere bort `dispute`.

# How to test

Affected part of the application: http://localhost:3000/tasks/nvi/status

- Trykk på et tall i kolonnen "Totalt antall"
- Se at trefflisten inneholder like mange treff som tallet i tabell-cellen man kom fra
