### PR TITLE
NP-50905 Check ISBN for NVI applicable book type

### DIFF
--- a/src/pages/registration/resource_type_tab/components/NviValidation.tsx
+++ b/src/pages/registration/resource_type_tab/components/NviValidation.tsx
@@ -24,7 +24,8 @@ export const NviValidation = ({ registration }: NviValidationProps) => {
 
   const isNviApplicableJournalArticle =
     instanceType === JournalType.AcademicArticle || instanceType === JournalType.AcademicLiteratureReview;
-  const isNviApplicableBookMonograph = instanceType === BookType.AcademicMonograph;
+  const isNviApplicableBookMonograph =
+    instanceType === BookType.AcademicMonograph || instanceType === BookType.AcademicCommentary;
   const isNviApplicableChapter = instanceType === ChapterType.AcademicChapter;
 
   return isNviApplicableJournalArticle || isNviApplicableBookMonograph || isNviApplicableChapter ? (

--- a/src/pages/registration/resource_type_tab/sub_type_forms/BookForm.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/BookForm.tsx
@@ -19,8 +19,7 @@ export const BookForm = () => {
 
   const hasAnyIsbn = isbnList.length > 0 && isbnList.some((isbn) => !!isbn);
 
-  const isNviApplicable =
-    nviApplicableTypes.includes(instanceType as PublicationInstanceType) && hasAnyIsbn && !hasIsbnError;
+  const isNviApplicable = nviApplicableTypes.includes(instanceType as PublicationInstanceType);
 
   return (
     <>
@@ -33,7 +32,7 @@ export const BookForm = () => {
 
       <SeriesFields />
 
-      {instanceType && isNviApplicable ? <NviValidation registration={values} /> : null}
+      {instanceType && isNviApplicable && hasAnyIsbn && !hasIsbnError ? <NviValidation registration={values} /> : null}
     </>
   );
 };

--- a/src/pages/registration/resource_type_tab/sub_type_forms/BookForm.tsx
+++ b/src/pages/registration/resource_type_tab/sub_type_forms/BookForm.tsx
@@ -10,9 +10,17 @@ import { RevisionField } from '../components/RevisionField';
 import { SeriesFields } from '../components/SeriesFields';
 
 export const BookForm = () => {
-  const { values } = useFormikContext<BookRegistration>();
+  const { values, errors } = useFormikContext<BookRegistration>();
   const instanceType = values.entityDescription.reference?.publicationInstance.type;
-  const isNviApplicable = nviApplicableTypes.includes(instanceType as PublicationInstanceType);
+  const isbnList = values.entityDescription.reference?.publicationContext.isbnList ?? [];
+  const isbnErrors = (errors.entityDescription as any)?.reference?.publicationContext?.isbnList;
+  const hasIsbnError =
+    typeof isbnErrors === 'string' ? !!isbnErrors : Array.isArray(isbnErrors) ? isbnErrors.some(Boolean) : false;
+
+  const hasAnyIsbn = isbnList.length > 0 && isbnList.some((isbn) => !!isbn);
+
+  const isNviApplicable =
+    nviApplicableTypes.includes(instanceType as PublicationInstanceType) && hasAnyIsbn && !hasIsbnError;
 
   return (
     <>


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-50905

Only show the NVI info box when ISBN is present and valid

# How to test

Affected part of the application: New registration (NVI Book type)

1. Create a new registration with a type that is a book and nvi applicable.
2. Make sure the blue info box only shows up if the isbn is present and valid

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected NVI validation display logic for book entries with ISBN-related validation issues.

* **Enhancements**
  * Improved error handling for ISBN validation in book registration forms.
  * Extended NVI validation support to academic commentary publication types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->