### PR TITLE
NP-50949 Hide publisher filter for correction list

### DIFF
--- a/src/pages/messages/components/NviCorrectionList.tsx
+++ b/src/pages/messages/components/NviCorrectionList.tsx
@@ -6,7 +6,7 @@ import { ResultParam } from '../../../api/searchApi';
 import { CategorySearchFilter } from '../../../components/CategorySearchFilter';
 import { HeadTitle } from '../../../components/HeadTitle';
 import { CorrectionListId, CorrectionListNames } from '../../../types/nvi.types';
-import { HideChannelFiltersListIds, ScientificValueFilterListIds } from '../../../utils/correctionListHelpers';
+import { hideChannelFiltersListIds, scientificValueFilterListIds } from '../../../utils/correctionListHelpers';
 import { useCorrectionListConfig } from '../../../utils/hooks/useCorrectionListConfig';
 import { useRegistrationsQueryParams } from '../../../utils/hooks/useRegistrationSearchParams';
 import { sanitizeSearchParams } from '../../../utils/searchHelpers';
@@ -29,8 +29,8 @@ export const NviCorrectionList = () => {
   const correctionListConfig = useCorrectionListConfig();
   const listConfig = listId && correctionListConfig[listId];
   const shouldShowScientificValueFilter =
-    !!listId && ScientificValueFilterListIds.includes(listId as CorrectionListNames);
-  const hideChannelFilters = !!listId && HideChannelFiltersListIds.includes(listId as CorrectionListNames);
+    !!listId && scientificValueFilterListIds.includes(listId as CorrectionListNames);
+  const hideChannelFilters = !!listId && hideChannelFiltersListIds.includes(listId as CorrectionListNames);
 
   const registrationParams = useRegistrationsQueryParams();
   const exportParams = new URLSearchParams(sanitizeSearchParams({ ...listConfig?.queryParams, ...registrationParams }));

--- a/src/pages/messages/components/NviCorrectionList.tsx
+++ b/src/pages/messages/components/NviCorrectionList.tsx
@@ -6,16 +6,14 @@ import { ResultParam } from '../../../api/searchApi';
 import { CategorySearchFilter } from '../../../components/CategorySearchFilter';
 import { HeadTitle } from '../../../components/HeadTitle';
 import { CorrectionListId, CorrectionListNames } from '../../../types/nvi.types';
+import { HiddenPublisherFilterListIds, ScientificValueFilterListIds } from '../../../utils/correctionListHelpers';
 import { useCorrectionListConfig } from '../../../utils/hooks/useCorrectionListConfig';
 import { useRegistrationsQueryParams } from '../../../utils/hooks/useRegistrationSearchParams';
 import { sanitizeSearchParams } from '../../../utils/searchHelpers';
 import { JournalFilter } from '../../search/advanced_search/JournalFilter';
 import { OrganizationFilters } from '../../search/advanced_search/OrganizationFilters';
-import { HiddenPublisherFilterListIds, PublisherFilter } from '../../search/advanced_search/PublisherFilter';
-import {
-  ScientificValueFilter,
-  ScientificValueFilterListIds,
-} from '../../search/advanced_search/ScientificValueFilter';
+import { PublisherFilter } from '../../search/advanced_search/PublisherFilter';
+import { ScientificValueFilter } from '../../search/advanced_search/ScientificValueFilter';
 import { SeriesFilter } from '../../search/advanced_search/SeriesFilter';
 import { ExportResultsButton } from '../../search/ExportResultsButton';
 import { RegistrationSearch } from '../../search/registration_search/RegistrationSearch';

--- a/src/pages/messages/components/NviCorrectionList.tsx
+++ b/src/pages/messages/components/NviCorrectionList.tsx
@@ -11,7 +11,7 @@ import { useRegistrationsQueryParams } from '../../../utils/hooks/useRegistratio
 import { sanitizeSearchParams } from '../../../utils/searchHelpers';
 import { JournalFilter } from '../../search/advanced_search/JournalFilter';
 import { OrganizationFilters } from '../../search/advanced_search/OrganizationFilters';
-import { PublisherFilter } from '../../search/advanced_search/PublisherFilter';
+import { HiddenPublisherFilterListIds, PublisherFilter } from '../../search/advanced_search/PublisherFilter';
 import {
   ScientificValueFilter,
   ScientificValueFilterListIds,
@@ -32,6 +32,7 @@ export const NviCorrectionList = () => {
   const listConfig = listId && correctionListConfig[listId];
   const shouldShowScientificValueFilter =
     !!listId && ScientificValueFilterListIds.includes(listId as CorrectionListNames);
+  const shouldHidePublisherFilter = !!listId && HiddenPublisherFilterListIds.includes(listId as CorrectionListNames);
 
   const registrationParams = useRegistrationsQueryParams();
   const exportParams = new URLSearchParams(sanitizeSearchParams({ ...listConfig?.queryParams, ...registrationParams }));
@@ -77,7 +78,7 @@ export const NviCorrectionList = () => {
               {shouldShowScientificValueFilter && <ScientificValueFilter />}
 
               <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem 1rem' }}>
-                <PublisherFilter />
+                <PublisherFilter hidden={shouldHidePublisherFilter} />
                 <JournalFilter />
                 <SeriesFilter />
                 <Divider flexItem orientation="vertical" sx={{ bgcolor: 'primary.main' }} />

--- a/src/pages/messages/components/NviCorrectionList.tsx
+++ b/src/pages/messages/components/NviCorrectionList.tsx
@@ -6,7 +6,7 @@ import { ResultParam } from '../../../api/searchApi';
 import { CategorySearchFilter } from '../../../components/CategorySearchFilter';
 import { HeadTitle } from '../../../components/HeadTitle';
 import { CorrectionListId, CorrectionListNames } from '../../../types/nvi.types';
-import { HiddenPublisherFilterListIds, ScientificValueFilterListIds } from '../../../utils/correctionListHelpers';
+import { HideChannelFiltersListIds, ScientificValueFilterListIds } from '../../../utils/correctionListHelpers';
 import { useCorrectionListConfig } from '../../../utils/hooks/useCorrectionListConfig';
 import { useRegistrationsQueryParams } from '../../../utils/hooks/useRegistrationSearchParams';
 import { sanitizeSearchParams } from '../../../utils/searchHelpers';
@@ -30,7 +30,7 @@ export const NviCorrectionList = () => {
   const listConfig = listId && correctionListConfig[listId];
   const shouldShowScientificValueFilter =
     !!listId && ScientificValueFilterListIds.includes(listId as CorrectionListNames);
-  const shouldHidePublisherFilter = !!listId && HiddenPublisherFilterListIds.includes(listId as CorrectionListNames);
+  const hideChannelFilters = !!listId && HideChannelFiltersListIds.includes(listId as CorrectionListNames);
 
   const registrationParams = useRegistrationsQueryParams();
   const exportParams = new URLSearchParams(sanitizeSearchParams({ ...listConfig?.queryParams, ...registrationParams }));
@@ -75,13 +75,15 @@ export const NviCorrectionList = () => {
 
               {shouldShowScientificValueFilter && <ScientificValueFilter />}
 
-              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem 1rem' }}>
-                <PublisherFilter hidden={shouldHidePublisherFilter} />
-                <JournalFilter />
-                <SeriesFilter />
-                <Divider flexItem orientation="vertical" sx={{ bgcolor: 'primary.main' }} />
-                <CorrectionListYearFilter />
-              </Box>
+              {!hideChannelFilters && (
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem 1rem' }}>
+                  <PublisherFilter />
+                  <JournalFilter />
+                  <SeriesFilter />
+                  <Divider flexItem orientation="vertical" sx={{ bgcolor: 'primary.main' }} />
+                  <CorrectionListYearFilter />
+                </Box>
+              )}
             </Box>
             <Box sx={{ m: '0.5rem', alignSelf: 'top' }}>
               <ExportResultsButton showText searchParams={exportParams} />

--- a/src/pages/search/advanced_search/PublisherFilter.tsx
+++ b/src/pages/search/advanced_search/PublisherFilter.tsx
@@ -18,10 +18,7 @@ import { useDebounce } from '../../../utils/hooks/useDebounce';
 import { syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 import { PublicationChannelOption } from '../../registration/resource_type_tab/components/PublicationChannelOption';
 
-interface PublisherFilterProps {
-  hidden?: boolean;
-}
-export const PublisherFilter = ({ hidden = false }: PublisherFilterProps) => {
+export const PublisherFilter = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
@@ -59,10 +56,6 @@ export const PublisherFilter = ({ hidden = false }: PublisherFilterProps) => {
   };
 
   const isFetching = publisherParam ? selectedPublisherQuery.isPending : publisherOptionsQuery.isFetching;
-
-  if (hidden) {
-    return null;
-  }
 
   return (
     <section>

--- a/src/pages/search/advanced_search/PublisherFilter.tsx
+++ b/src/pages/search/advanced_search/PublisherFilter.tsx
@@ -12,13 +12,21 @@ import {
 } from '../../../components/AutocompleteListboxWithExpansion';
 import { AutocompleteTextField } from '../../../components/AutocompleteTextField';
 import { StyledFilterHeading } from '../../../components/styled/Wrappers';
+import { CorrectionListNames } from '../../../types/nvi.types';
 import { Publisher } from '../../../types/registration.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
 import { syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 import { PublicationChannelOption } from '../../registration/resource_type_tab/components/PublicationChannelOption';
 
-export const PublisherFilter = () => {
+export const HiddenPublisherFilterListIds: CorrectionListNames[] = [
+  CorrectionListNames.ScientificChapterNotInAnthology,
+];
+
+interface PublisherFilterProps {
+  hidden?: boolean;
+}
+export const PublisherFilter = ({ hidden = false }: PublisherFilterProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
@@ -56,6 +64,10 @@ export const PublisherFilter = () => {
   };
 
   const isFetching = publisherParam ? selectedPublisherQuery.isPending : publisherOptionsQuery.isFetching;
+
+  if (hidden) {
+    return null;
+  }
 
   return (
     <section>

--- a/src/pages/search/advanced_search/PublisherFilter.tsx
+++ b/src/pages/search/advanced_search/PublisherFilter.tsx
@@ -12,16 +12,11 @@ import {
 } from '../../../components/AutocompleteListboxWithExpansion';
 import { AutocompleteTextField } from '../../../components/AutocompleteTextField';
 import { StyledFilterHeading } from '../../../components/styled/Wrappers';
-import { CorrectionListNames } from '../../../types/nvi.types';
 import { Publisher } from '../../../types/registration.types';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { useDebounce } from '../../../utils/hooks/useDebounce';
 import { syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 import { PublicationChannelOption } from '../../registration/resource_type_tab/components/PublicationChannelOption';
-
-export const HiddenPublisherFilterListIds: CorrectionListNames[] = [
-  CorrectionListNames.ScientificChapterNotInAnthology,
-];
 
 interface PublisherFilterProps {
   hidden?: boolean;

--- a/src/pages/search/advanced_search/ScientificValueFilter.tsx
+++ b/src/pages/search/advanced_search/ScientificValueFilter.tsx
@@ -22,14 +22,6 @@ enum ScientificValueLevelsToShow {
   All = 'All',
 }
 
-export const ScientificValueFilterListIds: CorrectionListNames[] = [
-  CorrectionListNames.ApplicableCategoriesWithNonApplicableChannel,
-  CorrectionListNames.NonApplicableCategoriesWithApplicableChannel,
-  CorrectionListNames.ScientificChapterNotInAnthology,
-  CorrectionListNames.YearBetweenChapterAndBookMismatch,
-  CorrectionListNames.ScientificMonographyOrAnthologyWithoutIsxns,
-];
-
 const getScientificValueFiltersFromParams = (searchParams: URLSearchParams): ScientificValueLevelsToShow => {
   const rawListParam = searchParams.get('list');
 

--- a/src/utils/correctionListHelpers.ts
+++ b/src/utils/correctionListHelpers.ts
@@ -51,3 +51,15 @@ export const getAccordionDefaultPath = (correctionListConfig: CorrectionListSear
 export const isCorrectionListName = (value: string): value is CorrectionListNames => {
   return Object.values(CorrectionListNames).includes(value as CorrectionListNames);
 };
+
+export const HiddenPublisherFilterListIds: CorrectionListNames[] = [
+  CorrectionListNames.ScientificChapterNotInAnthology,
+];
+
+export const ScientificValueFilterListIds: CorrectionListNames[] = [
+  CorrectionListNames.ApplicableCategoriesWithNonApplicableChannel,
+  CorrectionListNames.NonApplicableCategoriesWithApplicableChannel,
+  CorrectionListNames.ScientificChapterNotInAnthology,
+  CorrectionListNames.YearBetweenChapterAndBookMismatch,
+  CorrectionListNames.ScientificMonographyOrAnthologyWithoutIsxns,
+];

--- a/src/utils/correctionListHelpers.ts
+++ b/src/utils/correctionListHelpers.ts
@@ -52,9 +52,7 @@ export const isCorrectionListName = (value: string): value is CorrectionListName
   return Object.values(CorrectionListNames).includes(value as CorrectionListNames);
 };
 
-export const HiddenPublisherFilterListIds: CorrectionListNames[] = [
-  CorrectionListNames.ScientificChapterNotInAnthology,
-];
+export const HideChannelFiltersListIds: CorrectionListNames[] = [CorrectionListNames.ScientificChapterNotInAnthology];
 
 export const ScientificValueFilterListIds: CorrectionListNames[] = [
   CorrectionListNames.ApplicableCategoriesWithNonApplicableChannel,

--- a/src/utils/correctionListHelpers.ts
+++ b/src/utils/correctionListHelpers.ts
@@ -52,9 +52,9 @@ export const isCorrectionListName = (value: string): value is CorrectionListName
   return Object.values(CorrectionListNames).includes(value as CorrectionListNames);
 };
 
-export const HideChannelFiltersListIds: CorrectionListNames[] = [CorrectionListNames.ScientificChapterNotInAnthology];
+export const hideChannelFiltersListIds: CorrectionListNames[] = [CorrectionListNames.ScientificChapterNotInAnthology];
 
-export const ScientificValueFilterListIds: CorrectionListNames[] = [
+export const scientificValueFilterListIds: CorrectionListNames[] = [
   CorrectionListNames.ApplicableCategoriesWithNonApplicableChannel,
   CorrectionListNames.NonApplicableCategoriesWithApplicableChannel,
   CorrectionListNames.ScientificChapterNotInAnthology,


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-50949

Hide the `PublisherFilter` for the correction list `Scientific Chapter not in Anthology`
# How to test

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Publisher Filter is now hidden when viewing the Scientific Chapter Not In Anthology list, improving the relevance of available search options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->