### PR TITLE
NP-50781 Append import candidate identifiers to existing registration

### DIFF
--- a/src/components/merge_results/MergeImportCandidate.tsx
+++ b/src/components/merge_results/MergeImportCandidate.tsx
@@ -76,7 +76,14 @@ export const MergeImportCandidate = () => {
         sourceResult={expandImportCandidate(importCandidateQuery.data)}
         targetResult={registrationQuery.data}
         onSave={async (data) => {
-          await registrationMutation.mutateAsync(data);
+          const mergedDataWithIdentifiers = {
+            ...data,
+            additionalIdentifiers: [
+              ...(data.additionalIdentifiers ?? []),
+              ...(importCandidateQuery.data.additionalIdentifiers ?? []),
+            ],
+          };
+          await registrationMutation.mutateAsync(mergedDataWithIdentifiers);
           await importCandidateMutation.mutateAsync();
           dispatch(setNotification({ message: t('feedback.success.merge_import_candidate'), variant: 'success' }));
           navigate(getRegistrationWizardPath(registrationQuery.data.identifier), {

--- a/src/components/merge_results/MergeImportCandidate.tsx
+++ b/src/components/merge_results/MergeImportCandidate.tsx
@@ -22,6 +22,9 @@ interface MergeImportCandidateParams extends Record<string, string | undefined> 
   registrationIdentifier: string;
 }
 
+const isSameIdentifier = (a: AdditionalIdentifier, b: AdditionalIdentifier) =>
+  a.type === b.type && a.sourceName === b.sourceName && a.value === b.value;
+
 export const MergeImportCandidate = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
@@ -79,10 +82,6 @@ export const MergeImportCandidate = () => {
         onSave={async (data) => {
           const existing = data.additionalIdentifiers ?? [];
           const incoming = importCandidateQuery.data.additionalIdentifiers ?? [];
-
-          const isSameIdentifier = (a: AdditionalIdentifier, b: AdditionalIdentifier) =>
-            a.type === b.type && a.sourceName === b.sourceName && a.value === b.value;
-
           const mergedDataWithIdentifiers = {
             ...data,
             additionalIdentifiers: [

--- a/src/components/merge_results/MergeImportCandidate.tsx
+++ b/src/components/merge_results/MergeImportCandidate.tsx
@@ -80,7 +80,6 @@ export const MergeImportCandidate = () => {
             ...data,
             additionalIdentifiers: [
               ...(data.additionalIdentifiers ?? []),
-              ...(importCandidateQuery.data.additionalIdentifiers ?? []),
               ...(importCandidateQuery.data.additionalIdentifiers ?? []).filter(
                 (importId) =>
                   !(data.additionalIdentifiers ?? []).some(

--- a/src/components/merge_results/MergeImportCandidate.tsx
+++ b/src/components/merge_results/MergeImportCandidate.tsx
@@ -15,6 +15,7 @@ import { HeadTitle } from '../HeadTitle';
 import { PageSpinner } from '../PageSpinner';
 import { StyledPageContent } from '../styled/Wrappers';
 import { MergeResultsWizard } from './MergeResultsWizard';
+import { AdditionalIdentifier } from '../../types/registration.types';
 
 interface MergeImportCandidateParams extends Record<string, string | undefined> {
   candidateIdentifier: string;
@@ -76,18 +77,19 @@ export const MergeImportCandidate = () => {
         sourceResult={expandImportCandidate(importCandidateQuery.data)}
         targetResult={registrationQuery.data}
         onSave={async (data) => {
+          const existing = data.additionalIdentifiers ?? [];
+          const incoming = importCandidateQuery.data.additionalIdentifiers ?? [];
+
+          const isSameIdentifier = (a: AdditionalIdentifier, b: AdditionalIdentifier) =>
+            a.type === b.type && a.sourceName === b.sourceName && a.value === b.value;
+
           const mergedDataWithIdentifiers = {
             ...data,
             additionalIdentifiers: [
-              ...(data.additionalIdentifiers ?? []),
-              ...(importCandidateQuery.data.additionalIdentifiers ?? []).filter(
-                (importId) =>
-                  !(data.additionalIdentifiers ?? []).some(
-                    (existingId) =>
-                      existingId.type === importId.type &&
-                      existingId.sourceName === importId.sourceName &&
-                      existingId.value === importId.value
-                  )
+              ...existing,
+              ...incoming.filter(
+                (importIdentifier) =>
+                  !existing.some((existingIdentifier) => isSameIdentifier(existingIdentifier, importIdentifier))
               ),
             ],
           };

--- a/src/components/merge_results/MergeImportCandidate.tsx
+++ b/src/components/merge_results/MergeImportCandidate.tsx
@@ -81,6 +81,15 @@ export const MergeImportCandidate = () => {
             additionalIdentifiers: [
               ...(data.additionalIdentifiers ?? []),
               ...(importCandidateQuery.data.additionalIdentifiers ?? []),
+              ...(importCandidateQuery.data.additionalIdentifiers ?? []).filter(
+                (importId) =>
+                  !(data.additionalIdentifiers ?? []).some(
+                    (existingId) =>
+                      existingId.type === importId.type &&
+                      existingId.sourceName === importId.sourceName &&
+                      existingId.value === importId.value
+                  )
+              ),
             ],
           };
           await registrationMutation.mutateAsync(mergedDataWithIdentifiers);


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-50781

Maintain `ScopusIdentifier` from the `ImportCandidate` when merging with an existing result

# How to test

Affected part of the application: [Central Import
](http://localhost:3000/basic-data/central-import)

1. Merge a Candidate with and existing result and confirm that the scopus identifier is maintained.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed identifier data handling during import merge operations to ensure all identifiers are properly consolidated and preserved when saving import candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->