### PR TITLE
Bump tanstack group 230326

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@mui/utils": "^7.3.6",
         "@mui/x-date-pickers": "^8.27.2",
         "@reduxjs/toolkit": "^2.11.2",
-        "@tanstack/react-query": "^5.90.21",
+        "@tanstack/react-query": "^5.95.0",
         "@uppy/aws-s3": "^5.1.0",
         "@uppy/core": "^5.1.0",
         "@uppy/dashboard": "^5.1.1",
@@ -45,8 +45,8 @@
         "yup": "^1.7.1"
       },
       "devDependencies": {
-        "@tanstack/eslint-plugin-query": "^5.91.4",
-        "@tanstack/react-query-devtools": "^5.91.3",
+        "@tanstack/eslint-plugin-query": "^5.95.0",
+        "@tanstack/react-query-devtools": "^5.95.0",
         "@types/jest": "^30.0.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -5256,9 +5256,9 @@
       "license": "MIT"
     },
     "node_modules/@tanstack/eslint-plugin-query": {
-      "version": "5.91.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.91.4.tgz",
-      "integrity": "sha512-8a+GAeR7oxJ5laNyYBQ6miPK09Hi18o5Oie/jx8zioXODv/AUFLZQecKabPdpQSLmuDXEBPKFh+W5DKbWlahjQ==",
+      "version": "5.95.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.95.0.tgz",
+      "integrity": "sha512-XvEfgHyZoeGYGt0uOFwEbgkNMrRxoPt8Gy44cu3OwYFw6CU8uPAaUUiDJCqeyvYNNkuhnR4gWRn6vu5fcFSTUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5270,7 +5270,7 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": "^5.0.0"
+        "typescript": "^5.4.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -5279,9 +5279,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.90.20",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
-      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
+      "version": "5.95.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.95.0.tgz",
+      "integrity": "sha512-H1/CWCe8tGL3YIVeo770Z6kPbt0B3M1d/iQXIIK1qlFiFt6G2neYdkHgLapOC8uMYNt9DmHjmGukEKgdMk1P+A==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5289,9 +5289,9 @@
       }
     },
     "node_modules/@tanstack/query-devtools": {
-      "version": "5.93.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.93.0.tgz",
-      "integrity": "sha512-+kpsx1NQnOFTZsw6HAFCW3HkKg0+2cepGtAWXjiiSOJJ1CtQpt72EE2nyZb+AjAbLRPoeRmPJ8MtQd8r8gsPdg==",
+      "version": "5.95.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.95.0.tgz",
+      "integrity": "sha512-i8IzjIsZSE9y9XGndeVYeUusrZpKyhOnOPIzWKao8iAVzmk8ZesPe5URt02aLwC5A0Rg72N+vgqolXXCXm4fFg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -5300,12 +5300,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.90.21",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
-      "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
+      "version": "5.95.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.95.0.tgz",
+      "integrity": "sha512-EMP8B+BK9zvnAemT8M/y3z/WO0NjZ7fIUY3T3wnHYK6AA3qK/k33i7tPgCXCejhX0cd4I6bJIXN2GmjrHjDBzg==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.90.20"
+        "@tanstack/query-core": "5.95.0"
       },
       "funding": {
         "type": "github",
@@ -5316,20 +5316,20 @@
       }
     },
     "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.91.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.91.3.tgz",
-      "integrity": "sha512-nlahjMtd/J1h7IzOOfqeyDh5LNfG0eULwlltPEonYy0QL+nqrBB+nyzJfULV+moL7sZyxc2sHdNJki+vLA9BSA==",
+      "version": "5.95.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.95.0.tgz",
+      "integrity": "sha512-w4lYQTuyGM6l8C32UDIvxeodCrOwbw0JGSK6sQXYlF24CJnTcNmCxvfvrW2L3f3NObyvEQYcGTfjOr0Vw8jaWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-devtools": "5.93.0"
+        "@tanstack/query-devtools": "5.95.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "@tanstack/react-query": "^5.90.20",
+        "@tanstack/react-query": "^5.95.0",
         "react": "^18 || ^19"
       }
     },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@mui/utils": "^7.3.6",
     "@mui/x-date-pickers": "^8.27.2",
     "@reduxjs/toolkit": "^2.11.2",
-    "@tanstack/react-query": "^5.90.21",
+    "@tanstack/react-query": "^5.95.0",
     "@uppy/aws-s3": "^5.1.0",
     "@uppy/core": "^5.1.0",
     "@uppy/dashboard": "^5.1.1",
@@ -69,8 +69,8 @@
     "yup": "^1.7.1"
   },
   "devDependencies": {
-    "@tanstack/eslint-plugin-query": "^5.91.4",
-    "@tanstack/react-query-devtools": "^5.91.3",
+    "@tanstack/eslint-plugin-query": "^5.95.0",
+    "@tanstack/react-query-devtools": "^5.95.0",
     "@types/jest": "^30.0.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/src/api/hooks/useLookupDoi.ts
+++ b/src/api/hooks/useLookupDoi.ts
@@ -27,9 +27,6 @@ export const useLookupDoi = (doiQuery: string) => {
         onSuccess: () => {
           setLastMutatedDoi(doiQuery);
         },
-        onError: () => {
-          setLastMutatedDoi(doiQuery);
-        },
       });
     }
   }, [

--- a/src/api/hooks/useLookupDoi.ts
+++ b/src/api/hooks/useLookupDoi.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
 import { fetchResults } from '../searchApi';
 import { useCreateDoiPreview } from './useCreateDoiPreview';
 
@@ -9,13 +10,26 @@ export const useLookupDoi = (doiQuery: string) => {
     enabled: !!doiQuery,
     queryKey: ['doi-results', doiQuery],
     queryFn: async () => {
-      const results = await fetchResults({ doi: doiQuery });
-      if (results.hits.length === 0) {
-        doiPreviewMutation.mutate(doiQuery);
-      }
-      return results;
+      return fetchResults({ doi: doiQuery });
     },
   });
+
+  useEffect(() => {
+    if (!doiQuery) return;
+    if (!registrationSearch.data) return;
+
+    const hits = registrationSearch.data.hits ?? [];
+
+    if (hits.length === 0 && !doiPreviewMutation.isPending && !doiPreviewMutation.isSuccess) {
+      doiPreviewMutation.mutate(doiQuery);
+    }
+  }, [
+    doiQuery,
+    registrationSearch.data,
+    doiPreviewMutation.isPending,
+    doiPreviewMutation.isSuccess,
+    doiPreviewMutation,
+  ]);
 
   const registrationsWithDoi = registrationSearch.data?.hits ?? [];
   const isLookingUpDoi = registrationSearch.isFetching || doiPreviewMutation.isPending;

--- a/src/api/hooks/useLookupDoi.ts
+++ b/src/api/hooks/useLookupDoi.ts
@@ -1,17 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { fetchResults } from '../searchApi';
 import { useCreateDoiPreview } from './useCreateDoiPreview';
 
 export const useLookupDoi = (doiQuery: string) => {
   const doiPreviewMutation = useCreateDoiPreview();
 
+  const [lastMutatedDoi, setLastMutatedDoi] = useState<string | null>(null);
+
   const registrationSearch = useQuery({
     enabled: !!doiQuery,
     queryKey: ['doi-results', doiQuery],
-    queryFn: async () => {
-      return fetchResults({ doi: doiQuery });
-    },
+    queryFn: async () => fetchResults({ doi: doiQuery }),
   });
 
   useEffect(() => {
@@ -20,20 +20,31 @@ export const useLookupDoi = (doiQuery: string) => {
 
     const hits = registrationSearch.data.hits ?? [];
 
-    if (hits.length === 0 && !doiPreviewMutation.isPending && !doiPreviewMutation.isSuccess) {
-      doiPreviewMutation.mutate(doiQuery);
+    const isNewDoi = lastMutatedDoi !== doiQuery;
+
+    if (hits.length === 0 && isNewDoi && !doiPreviewMutation.isPending) {
+      doiPreviewMutation.mutate(doiQuery, {
+        onSuccess: () => {
+          setLastMutatedDoi(doiQuery);
+        },
+        onError: () => {
+          setLastMutatedDoi(doiQuery);
+        },
+      });
     }
   }, [
     doiQuery,
     registrationSearch.data,
     doiPreviewMutation.isPending,
-    doiPreviewMutation.isSuccess,
-    doiPreviewMutation,
+    doiPreviewMutation, // stable reference
+    lastMutatedDoi,
   ]);
 
   const registrationsWithDoi = registrationSearch.data?.hits ?? [];
   const isLookingUpDoi = registrationSearch.isFetching || doiPreviewMutation.isPending;
+
   const noHits = registrationSearch.isFetched && registrationsWithDoi.length === 0 && doiPreviewMutation.isError;
+
   const doiPreview = doiPreviewMutation.isSuccess && doiPreviewMutation.data ? doiPreviewMutation.data : null;
 
   return {

--- a/src/pages/registration/files_and_license_tab/DownloadFileButton.tsx
+++ b/src/pages/registration/files_and_license_tab/DownloadFileButton.tsx
@@ -1,7 +1,7 @@
 import OpenInNewOutlinedIcon from '@mui/icons-material/OpenInNewOutlined';
 import { CircularProgress, IconButton, Tooltip } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { downloadImportCandidateFile, downloadRegistrationFile } from '../../../api/fileApi';
 import { AssociatedFile } from '../../../types/associatedArtifact.types';
@@ -12,29 +12,34 @@ interface DownloadFileButtonProps {
   file: AssociatedFile;
   registration: Registration;
 }
-
 export const DownloadFileButton = ({ file, registration }: DownloadFileButtonProps) => {
   const { t } = useTranslation();
-
   const [downloadFile, setDownloadFile] = useState(false);
 
   const downloadFileQuery = useQuery({
     enabled: downloadFile,
     queryKey: ['downloadFile', registration.type, registration.identifier, file.identifier],
     queryFn: async () => {
-      const downloadFileResponse =
-        registration.type === 'Publication'
-          ? await downloadRegistrationFile(registration.identifier, file.identifier)
-          : await downloadImportCandidateFile(registration.identifier, file.identifier);
-      if (downloadFileResponse.id) {
-        openFileInNewTab(downloadFileResponse.id);
+      if (registration.type === 'Publication') {
+        return downloadRegistrationFile(registration.identifier, file.identifier);
       }
-      setDownloadFile(false); // Ensure that a new URL is obtained every time, due to expiration
-      return downloadFileResponse;
+      return downloadImportCandidateFile(registration.identifier, file.identifier);
     },
     meta: { errorMessage: t('feedback.error.download_file') },
     gcTime: 0,
   });
+
+  useEffect(() => {
+    const response = downloadFileQuery.data;
+    if (!response) return;
+
+    if ('id' in response && response.id) {
+      openFileInNewTab(response.id);
+    }
+
+    // Ensure we get a new URL next time
+    setDownloadFile(false);
+  }, [downloadFileQuery.data, setDownloadFile]);
 
   return downloadFileQuery.isFetching ? (
     <CircularProgress size="1.5rem" sx={{ m: '0.3rem' }} />


### PR DESCRIPTION
# Description

This PR resolves #8328 

There were some linting rules preventing successfully building. This PR bumps packages and moves functionality out of the queryFn and into a useEffect for a more stable queryKey. 

Additional information:
```
@tanstack/query/exhaustive-deps is an ESLint rule that enforces:

Every value used by queryFn (or other callbacks you pass to TanStack Query) must be stable and must be represented in the queryKey.
```


# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated TanStack React Query and associated development tooling packages to version 5.95.0 for improved stability and performance.

* **Bug Fixes**
  * Optimised DOI preview operation handling to prevent redundant requests when search results are unavailable.
  * Improved file download logic to eliminate unnecessary operations on subsequent downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->