### PR TITLE
Configure cooldown for Dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: 'monday'
       time: '07:00'
       timezone: Europe/Oslo
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 20
     groups:
       mui:


### PR DESCRIPTION
Add cooldown period for Dependabot updates, which allows us a period of grace before accepting malicious supply chain attacks

# Description

Link to Jira issue: None

# How to test

Affected part of the application: This affects GH actions and should work if the declaration is valid.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [ *] The changes are working as expected
- [ *] The changes are tested OK for different screen sizes
- [ *] The changes are tested OK for a11y
- [ *] Interactive elements have data-testids
- [ *] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
