### PR TITLE
Np 51053 fix percentage controlled

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -10,7 +10,7 @@ import { hasCuratorRole } from './utils/user-helpers';
 
 const Dashboard = lazy(() => import('./pages/dashboard/Dashboard'));
 const FrontPage = lazy(() => import('./pages/frontpage/FrontPage'));
-const BasicDataPage = lazy(() => import('./pages/basic_data/BasicDataPage'));
+const BasicDataPage = lazy(() => import('./pages/basic-data/BasicDataPage'));
 const EditorPage = lazy(() => import('./pages/editor/InstitutionPage'));
 const EditRegistration = lazy(() => import('./pages/registration/new_registration/EditRegistration'));
 const CopyrightActTerms = lazy(() => import('./pages/infopages/CopyrightActTerms'));

--- a/src/pages/basic-data/BasicDataPage.tsx
+++ b/src/pages/basic-data/BasicDataPage.tsx
@@ -25,17 +25,17 @@ import { getAdminInstitutionPath, getSubUrl, UrlPathTemplate } from '../../utils
 import { PublisherClaimsSettings } from '../editor/PublisherClaimsSettings';
 import { SerialPublicationClaimsSettings } from '../editor/SerialPublicationClaimsSettings';
 import NotFound from '../errorpages/NotFound';
-import { AdminCustomerInstitutionsContainer } from './app_admin/AdminCustomerInstitutionsContainer';
-import { CentralImportCandidateForm } from './app_admin/central_import/CentralImportCandidateForm';
-import { CentralImportDuplicationCheckPage } from './app_admin/central_import/CentralImportDuplicationCheckPage';
-import { CentralImportPage } from './app_admin/central_import/CentralImportPage';
-import { ImportCandidatesMenuFilters } from './app_admin/central_import/ImportCandidatesMenuFilters';
-import { NviAdminPublicationPointsPage } from '../basic-data/nvi/publication-points/NviAdminPublicationPointsPage';
-import { NviAdminStatusPage } from '../basic-data/nvi/status/NviAdminStatusPage';
-import { NviPeriodsPage } from './app_admin/NviPeriodsPage';
-import { AddEmployeePage } from './institution_admin/AddEmployeePage';
-import { PersonRegisterPage } from './institution_admin/person_register/PersonRegisterPage';
-import { NviAdminNavigationAccordion } from './NviAdminNavigationAccordion';
+import { AdminCustomerInstitutionsContainer } from '../basic_data/app_admin/AdminCustomerInstitutionsContainer';
+import { CentralImportCandidateForm } from '../basic_data/app_admin/central_import/CentralImportCandidateForm';
+import { CentralImportDuplicationCheckPage } from '../basic_data/app_admin/central_import/CentralImportDuplicationCheckPage';
+import { CentralImportPage } from '../basic_data/app_admin/central_import/CentralImportPage';
+import { ImportCandidatesMenuFilters } from '../basic_data/app_admin/central_import/ImportCandidatesMenuFilters';
+import { NviAdminPublicationPointsPage } from './nvi/publication-points/NviAdminPublicationPointsPage';
+import { NviAdminStatusPage } from './nvi/status/NviAdminStatusPage';
+import { NviPeriodsPage } from '../basic_data/app_admin/NviPeriodsPage';
+import { AddEmployeePage } from '../basic_data/institution_admin/AddEmployeePage';
+import { PersonRegisterPage } from '../basic_data/institution_admin/person_register/PersonRegisterPage';
+import { NviAdminNavigationAccordion } from '../basic_data/NviAdminNavigationAccordion';
 
 const isOnEditOrMergeImportCandidate = (path: string) =>
   path.endsWith(UrlPathTemplate.BasicDataCentralImportCandidateWizard.split('/').pop() as string) ||

--- a/src/pages/basic_data/NviAdminNavigationAccordion.tsx
+++ b/src/pages/basic_data/NviAdminNavigationAccordion.tsx
@@ -40,7 +40,7 @@ export const NviAdminNavigationAccordion = () => {
             <NviReportProgressBar
               completedPercentage={
                 periodTotals.undisputedTotalCount > 0
-                  ? Math.round((periodTotals.undisputedProcessedCount / periodTotals.undisputedTotalCount) * 100)
+                  ? Math.floor((periodTotals.undisputedProcessedCount / periodTotals.undisputedTotalCount) * 100)
                   : 0
               }
               completedCount={periodTotals.undisputedProcessedCount}

--- a/src/pages/basic_data/app_admin/nviAdmin/NviAdminPublicationPointsRow.tsx
+++ b/src/pages/basic_data/app_admin/nviAdmin/NviAdminPublicationPointsRow.tsx
@@ -11,6 +11,7 @@ import {
   getNviInstitutionName,
   getNviSectorLabel,
   getNviValidPoints,
+  getPercentageControlled,
 } from './nviAdminHelpers';
 
 interface NviAdminPublicationPointsRowProps {
@@ -19,19 +20,15 @@ interface NviAdminPublicationPointsRowProps {
 
 export const NviAdminPublicationPointsRow = ({ report }: NviAdminPublicationPointsRowProps) => {
   const { t } = useTranslation();
-  const { id, institutionSummary } = report;
-  const { totals } = institutionSummary;
-  const approvedByEverybody = getNviApprovedByEverybody(report);
-  const undisputedTotals = totals.undisputedTotalCount;
-  const percentageControlled = undisputedTotals > 0 ? approvedByEverybody / undisputedTotals : 0;
+  const percentageControlled = getPercentageControlled(report);
 
   return (
-    <TableRow key={id} sx={{ height: '4rem' }}>
+    <TableRow key={report.id} sx={{ height: '4rem' }}>
       <TableCell>{getNviInstitutionName(report)}</TableCell>
       <TableCell>{getNviSectorLabel(report, t)}</TableCell>
       <CenteredTableCell>{getNviApprovedCount(report)}</CenteredTableCell>
       <CenteredTableCell>{getNviCountOthersMustApprove(report)}</CenteredTableCell>
-      <CenteredTableCell>{approvedByEverybody}</CenteredTableCell>
+      <CenteredTableCell>{getNviApprovedByEverybody(report)}</CenteredTableCell>
       <CenteredTableCell>{getNviValidPoints(report)}</CenteredTableCell>
       <TableCell>
         <HorizontalBox sx={{ justifyContent: 'center' }}>

--- a/src/pages/basic_data/app_admin/nviAdmin/NviAdminPublicationPointsRow.tsx
+++ b/src/pages/basic_data/app_admin/nviAdmin/NviAdminPublicationPointsRow.tsx
@@ -11,7 +11,7 @@ import {
   getNviInstitutionName,
   getNviSectorLabel,
   getNviValidPoints,
-  getPercentageControlled,
+  getPercentageControlledPublicationPoints,
 } from './nviAdminHelpers';
 
 interface NviAdminPublicationPointsRowProps {
@@ -20,7 +20,7 @@ interface NviAdminPublicationPointsRowProps {
 
 export const NviAdminPublicationPointsRow = ({ report }: NviAdminPublicationPointsRowProps) => {
   const { t } = useTranslation();
-  const percentageControlled = getPercentageControlled(report);
+  const percentageControlled = getPercentageControlledPublicationPoints(report);
 
   return (
     <TableRow key={report.id} sx={{ height: '4rem' }}>

--- a/src/pages/basic_data/app_admin/nviAdmin/NviAdminStatusPageRow.tsx
+++ b/src/pages/basic_data/app_admin/nviAdmin/NviAdminStatusPageRow.tsx
@@ -12,6 +12,7 @@ import {
   getNviRejectedCount,
   getNviSectorLabel,
   getNviTotalCount,
+  getPercentageControlled,
 } from './nviAdminHelpers';
 
 interface NviAdminStatusPageRowProps {
@@ -22,10 +23,7 @@ export const NviAdminStatusPageRow = ({ report }: NviAdminStatusPageRowProps) =>
   const { t } = useTranslation();
   const { id, institutionSummary } = report;
   const { byLocalApprovalStatus, totals } = institutionSummary;
-  const percentageControlled =
-    totals.undisputedTotalCount > 0
-      ? (byLocalApprovalStatus.approved + byLocalApprovalStatus.rejected) / totals.undisputedTotalCount
-      : 0;
+  const percentageControlled = getPercentageControlled(report);
 
   return (
     <TableRow key={id} sx={{ height: '4rem' }}>

--- a/src/pages/basic_data/app_admin/nviAdmin/nviAdminHelpers.ts
+++ b/src/pages/basic_data/app_admin/nviAdmin/nviAdminHelpers.ts
@@ -28,3 +28,9 @@ export const getNviRejectedCount = (report: InstitutionReport) =>
   report.institutionSummary.byLocalApprovalStatus.rejected;
 
 export const getNviTotalCount = (report: InstitutionReport) => report.institutionSummary.totals.undisputedTotalCount;
+
+export const getPercentageControlled = (report: InstitutionReport) => {
+  const undisputedTotals = report.institutionSummary.totals.undisputedTotalCount;
+  const { approved, rejected } = report.institutionSummary.byLocalApprovalStatus;
+  return undisputedTotals > 0 ? (approved + rejected) / undisputedTotals : 0;
+};

--- a/src/pages/basic_data/app_admin/nviAdmin/nviAdminHelpers.ts
+++ b/src/pages/basic_data/app_admin/nviAdmin/nviAdminHelpers.ts
@@ -34,3 +34,11 @@ export const getPercentageControlled = (report: InstitutionReport) => {
   const { approved, rejected } = report.institutionSummary.byLocalApprovalStatus;
   return undisputedTotals > 0 ? (approved + rejected) / undisputedTotals : 0;
 };
+
+export const getPercentageControlledPublicationPoints = (report: InstitutionReport) => {
+  const approvedByEverybody = getNviApprovedByEverybody(report);
+  const all = getNviTotalCount(report);
+  const rejected = getNviRejectedCount(report);
+  const allExceptRejected = all - rejected;
+  return allExceptRejected > 0 ? approvedByEverybody / allExceptRejected : 0;
+};

--- a/src/pages/messages/components/NviCandidatesNavigationAccordion.tsx
+++ b/src/pages/messages/components/NviCandidatesNavigationAccordion.tsx
@@ -51,7 +51,7 @@ export const NviCandidatesNavigationAccordion = () => {
   const nviCandidatesTotal = nviAggregations?.totalCount.docCount ?? 0;
   const nviCandidatesCompleted = nviAggregations?.completed.docCount ?? 0;
   const nviCompletedPercentage =
-    nviCandidatesTotal > 0 ? Math.round((nviCandidatesCompleted / nviCandidatesTotal) * 100) : 100;
+    nviCandidatesTotal > 0 ? Math.floor((nviCandidatesCompleted / nviCandidatesTotal) * 100) : 100;
 
   return (
     <NavigationListAccordion


### PR DESCRIPTION
# Description

Link to Jira issue: 
* [Endre prosent for ferdig kontrollert i Fremdriftskomponent i venstremeny](https://sikt.atlassian.net/browse/NP-51053) 
* [Endre på brøk i Andel godkjent på siden for publiseringspoeng](https://sikt.atlassian.net/browse/NP-50997)

# How to test

Affected part of the application: [http://localhost:3000/basic-data/nvi/status?year=2025](http://localhost:3000/basic-data/nvi/status?year=2025)

The NVI progressbar in the side view would show 100% in cases where the institution were almost finished but not completely because we didn't round down.

<img width="316" height="92" alt="image" src="https://github.com/user-attachments/assets/8e36db2e-f768-4f36-9a99-62dce5dce2c6" />

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tweaked percentage calculations so NVI progress/metric values use floor rounding for more consistent displayed percentages and preserved fallback values.

* **Refactor**
  * Consolidated percentage calculation logic into shared helpers and updated components to use them, improving consistency.
  * Minor import/path adjustments to align modules with the refactor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->