### PR TITLE
Took into account time of year when selecting newest NVI year

### DIFF
--- a/src/pages/search/advanced_search/NviReportedYearFilter.tsx
+++ b/src/pages/search/advanced_search/NviReportedYearFilter.tsx
@@ -3,11 +3,12 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router';
 import { ResultParam } from '../../../api/searchApi';
 import { dataTestId } from '../../../utils/dataTestIds';
+import { getDefaultNviYear } from '../../../utils/hooks/useNviCandidatesParams';
 import { useRegistrationsQueryParams } from '../../../utils/hooks/useRegistrationSearchParams';
 import { getNviYearFilterValues } from '../../../utils/nviHelpers';
 import { syncParamsWithSearchFields } from '../../../utils/searchHelpers';
 
-const relevantNviYears = getNviYearFilterValues(new Date().getFullYear() - 1);
+const relevantNviYears = getNviYearFilterValues(getDefaultNviYear() - 1);
 
 export const NviReportedYearFilter = () => {
   const { t } = useTranslation();


### PR DESCRIPTION
# Description

Link to Jira issue: [NVI-period dropdown in advanced search should not show current year before its official](https://sikt.atlassian.net/browse/NP-51077)

# How to test

Affected part of the application: [http://localhost:3000/search](http://localhost:3000/search)

In the NVI section of advanced serach, verify that if its April or earlier in the year, the highest available year is two years earlier, but if its May or later the highest available year is the year before.

**Before (in april):**

<img width="318" height="221" alt="image" src="https://github.com/user-attachments/assets/67318bdc-910f-4c5f-a4b6-96b8b847dd89" />


**After (still april):**

<img width="316" height="223" alt="image" src="https://github.com/user-attachments/assets/ef574e12-4dbe-4dcf-8df4-1aaf068b0382" />

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Updated the baseline year calculation for the NVI reported year filter, which changes the available year options displayed to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->