### PR TITLE
NP-50945 Add author shares link to admin page

### DIFF
--- a/src/api/hooks/useExportNviAuthorSharesMutation.ts
+++ b/src/api/hooks/useExportNviAuthorSharesMutation.ts
@@ -3,7 +3,7 @@ import { generateReportFile, ReportProfile } from '../reports-api';
 
 interface ExportNviStatusParams {
   year: number;
-  institutionId: string;
+  institutionId?: string;
 }
 export const useExportNviAuthorSharesMutation = () => {
   return useMutation({

--- a/src/api/reports-api.ts
+++ b/src/api/reports-api.ts
@@ -1,7 +1,7 @@
 import { AxiosRequestConfig } from 'axios';
+import i18n from '../translations/i18n';
 import { API_URL } from '../utils/constants';
 import { apiRequest2, authenticatedApiRequest2 } from './apiRequest';
-import i18n from '../translations/i18n';
 
 const BASE_URL = `${API_URL}scientific-index`;
 

--- a/src/components/AdminNviPublicationPointsTexts.tsx
+++ b/src/components/AdminNviPublicationPointsTexts.tsx
@@ -1,12 +1,13 @@
 import { Skeleton, Typography } from '@mui/material';
 import { Trans, useTranslation } from 'react-i18next';
 import { useFetchNviPeriodReport } from '../api/hooks/useFetchNviPeriodReport';
+import { ExportNviStatusLink } from '../pages/messages/components/ExportNviStatusLink';
+import { HelperTextModal } from '../pages/registration/HelperTextModal';
 import { dataTestId } from '../utils/dataTestIds';
 import { formatLocaleNumber } from '../utils/general-helpers';
 import { getDefaultNviYear } from '../utils/hooks/useNviCandidatesParams';
 import { ExpandableNviTopView } from './ExpandableNviTopView';
-import { VerticalBox } from './styled/Wrappers';
-import { ExportNviStatusLink } from '../pages/messages/components/ExportNviStatusLink';
+import { HorizontalBox, VerticalBox } from './styled/Wrappers';
 
 export const AdminNviPublicationPointsTexts = () => {
   const { t } = useTranslation();
@@ -25,14 +26,19 @@ export const AdminNviPublicationPointsTexts = () => {
         {periodReport.isPending ? (
           <Skeleton sx={{ width: '50%' }} />
         ) : periodReport.isError || !periodTotals ? undefined : (
-          <Trans
-            i18nKey="x_results_are_ready_for_reporting_and_they_give_y_publication_points"
-            values={{
-              approvals: formatLocaleNumber(periodTotals.undisputedTotalCount),
-              publication_points: formatLocaleNumber(periodTotals.validPoints),
-            }}
-            components={{ p: <Typography />, b: <strong />, link: <ExportNviStatusLink isOnAdminPage /> }}
-          />
+          <HorizontalBox>
+            <Trans
+              i18nKey="x_results_are_ready_for_reporting_and_they_give_y_publication_points"
+              values={{
+                approvals: formatLocaleNumber(periodTotals.undisputedTotalCount),
+                publication_points: formatLocaleNumber(periodTotals.validPoints),
+              }}
+              components={{ p: <Typography />, b: <strong />, link: <ExportNviStatusLink isOnAdminPage /> }}
+            />
+            <HelperTextModal modalTitle={t('export_dataset_for_nvi_report')}>
+              <Trans i18nKey="export_dataset_for_nvi_report_description" components={{ p: <Typography /> }} />
+            </HelperTextModal>
+          </HorizontalBox>
         )}
         {periodReport.isPending || periodReportLastYear.isPending ? (
           <Skeleton sx={{ width: '40%' }} />

--- a/src/components/AdminNviPublicationPointsTexts.tsx
+++ b/src/components/AdminNviPublicationPointsTexts.tsx
@@ -33,7 +33,7 @@ export const AdminNviPublicationPointsTexts = () => {
                 approvals: formatLocaleNumber(periodTotals.undisputedTotalCount),
                 publication_points: formatLocaleNumber(periodTotals.validPoints),
               }}
-              components={{ p: <Typography />, b: <strong />, link: <ExportNviStatusLink isOnAdminPage /> }}
+              components={{ p: <Typography />, b: <strong />, link: <ExportNviStatusLink exportAllInstitutions /> }}
             />
             <HelperTextModal modalTitle={t('export_dataset_for_nvi_report')}>
               <Trans i18nKey="export_dataset_for_nvi_report_description" components={{ p: <Typography /> }} />

--- a/src/components/AdminNviPublicationPointsTexts.tsx
+++ b/src/components/AdminNviPublicationPointsTexts.tsx
@@ -6,6 +6,7 @@ import { formatLocaleNumber } from '../utils/general-helpers';
 import { getDefaultNviYear } from '../utils/hooks/useNviCandidatesParams';
 import { ExpandableNviTopView } from './ExpandableNviTopView';
 import { VerticalBox } from './styled/Wrappers';
+import { ExportNviStatusLink } from '../pages/messages/components/ExportNviStatusLink';
 
 export const AdminNviPublicationPointsTexts = () => {
   const { t } = useTranslation();
@@ -24,16 +25,14 @@ export const AdminNviPublicationPointsTexts = () => {
         {periodReport.isPending ? (
           <Skeleton sx={{ width: '50%' }} />
         ) : periodReport.isError || !periodTotals ? undefined : (
-          <Typography>
-            <Trans
-              i18nKey="x_results_are_ready_for_reporting_and_they_give_y_publication_points"
-              values={{
-                num_results: formatLocaleNumber(periodTotals.undisputedTotalCount),
-                total_publicationpoints: formatLocaleNumber(periodTotals.validPoints),
-              }}
-              components={{ b: <strong /> }}
-            />
-          </Typography>
+          <Trans
+            i18nKey="x_results_are_ready_for_reporting_and_they_give_y_publication_points"
+            values={{
+              approvals: formatLocaleNumber(periodTotals.undisputedTotalCount),
+              publication_points: formatLocaleNumber(periodTotals.validPoints),
+            }}
+            components={{ p: <Typography />, b: <strong />, link: <ExportNviStatusLink isOnAdminPage /> }}
+          />
         )}
         {periodReport.isPending || periodReportLastYear.isPending ? (
           <Skeleton sx={{ width: '40%' }} />

--- a/src/components/NviPublicationPointsTexts.tsx
+++ b/src/components/NviPublicationPointsTexts.tsx
@@ -40,14 +40,14 @@ export const NviPublicationPointsTexts = ({ aggregationsQuery, exportAcronym }: 
           <HorizontalBox sx={{ mt: '1rem', gap: '0.25rem', mb: '0.5rem' }}>
             <Trans
               t={t}
-              i18nKey="x_results_are_ready_for_reporting_and_they_give_y_points"
+              i18nKey="x_results_are_ready_for_reporting_and_they_give_y_publication_points"
               values={{
-                num_publications_approved_by_all: formatLocaleNumber(aggregations.totals.globalApprovalStatus.Approved),
-                points_for_all_publications_approved_by_all: formatLocaleNumber(aggregations.totals.points),
+                approvals: formatLocaleNumber(aggregations.totals.globalApprovalStatus.Approved),
+                publication_points: formatLocaleNumber(aggregations.totals.points),
               }}
               components={{
                 p: <Typography />,
-                bold: <Typography component="span" sx={{ fontWeight: 'bold' }} />,
+                b: <Typography component="span" sx={{ fontWeight: 'bold' }} />,
                 link: exportAcronym ? <ExportNviStatusLink acronym={exportAcronym} /> : <span />,
               }}
             />

--- a/src/pages/messages/components/ExportNviStatusLink.tsx
+++ b/src/pages/messages/components/ExportNviStatusLink.tsx
@@ -11,10 +11,10 @@ import { useNviCandidatesParams } from '../../../utils/hooks/useNviCandidatesPar
 
 interface ExportNviStatusLinkProps {
   acronym?: string;
-  isOnAdminPage?: boolean;
+  exportAllInstitutions?: boolean;
 }
 
-export const ExportNviStatusLink = ({ acronym, isOnAdminPage }: ExportNviStatusLinkProps) => {
+export const ExportNviStatusLink = ({ acronym, exportAllInstitutions }: ExportNviStatusLinkProps) => {
   const { t } = useTranslation();
   const { year } = useNviCandidatesParams();
   const dispatch = useDispatch();
@@ -30,7 +30,7 @@ export const ExportNviStatusLink = ({ acronym, isOnAdminPage }: ExportNviStatusL
     }
 
     try {
-      const blob = isOnAdminPage
+      const blob = exportAllInstitutions
         ? await exportMutation.mutateAsync({ year })
         : await exportMutation.mutateAsync({ year, institutionId });
 

--- a/src/pages/messages/components/ExportNviStatusLink.tsx
+++ b/src/pages/messages/components/ExportNviStatusLink.tsx
@@ -10,10 +10,11 @@ import { getIdentifierFromId } from '../../../utils/general-helpers';
 import { useNviCandidatesParams } from '../../../utils/hooks/useNviCandidatesParams';
 
 interface ExportNviStatusLinkProps {
-  acronym: string;
+  acronym?: string;
+  isOnAdminPage?: boolean;
 }
 
-export const ExportNviStatusLink = ({ acronym }: ExportNviStatusLinkProps) => {
+export const ExportNviStatusLink = ({ acronym, isOnAdminPage }: ExportNviStatusLinkProps) => {
   const { t } = useTranslation();
   const { year } = useNviCandidatesParams();
   const dispatch = useDispatch();
@@ -29,11 +30,13 @@ export const ExportNviStatusLink = ({ acronym }: ExportNviStatusLinkProps) => {
     }
 
     try {
-      const blob = await exportMutation.mutateAsync({ year, institutionId });
+      const blob = isOnAdminPage
+        ? await exportMutation.mutateAsync({ year })
+        : await exportMutation.mutateAsync({ year, institutionId });
 
       const url = URL.createObjectURL(blob);
 
-      const fileName = `nvi-status-${acronym}-${year}.xlsx`;
+      const fileName = acronym ? `nvi-status-${acronym}-${year}.xlsx` : `nvi-status-${year}.xlsx`;
 
       const a = document.createElement('a');
       a.href = url;

--- a/src/translations/enTranslations.json
+++ b/src/translations/enTranslations.json
@@ -2098,7 +2098,6 @@
   "visibility_of_units": "",
   "vocabulary_missing": "The institution has not added vocabulary",
   "what_you_find_in_nva_description": "<heading>What can you find in NVA?</heading><p>The Norwegian Research Information Repository (NVA) collects and makes information about Norwegian research accessible.</p><p>Here, you can explore publications, research projects, and researchers across universities, university colleges, and research institutions.</p>",
-  "x_results_are_ready_for_reporting_and_they_give_y_points": "",
   "x_results_are_ready_for_reporting_and_they_give_y_publication_points": "",
   "you_cannot_upload_files_to_this_result": "You do not have access to upload files for this result.",
   "you_do_not_have_permission_to_edit_this_registration": "You do not have access to edit this registration."

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -543,6 +543,7 @@
     }
   },
   "export_dataset_for_nvi_report": "Eksporter datagrunnlag for NVI-rapport",
+  "export_dataset_for_nvi_report_description": "<p>Filen inneholder NVI-kandidater som er godkjent eller fortsatt under kontroll. </p><p>Kandidater som er avvist av en eller flere institusjoner er ikke med i oversikten.</p>",
   "export_nvi_status_button_tooltip_text": "Knapp for nedlasting av forfatterandel er flyttet til side for publiseringspoeng. Denne knappen er midlertidig deaktivert — nedlasting av tall fra tabellen kommer snart.",
   "feedback": {
     "error": {

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -2098,8 +2098,7 @@
   "visibility_of_units": "Visning av enheter",
   "vocabulary_missing": "Institusjonen har ikke lagt til vokabular.",
   "what_you_find_in_nva_description": "<heading>Hva finner du i NVA?</heading><p>Nasjonalt vitenarkiv (NVA) samler og gjør tilgjengelig informasjon om norsk forskning.</p><p>Her kan du utforske publikasjoner, forskningsprosjekt og forskere på tvers av universiteter, høyskoler og forskningsinstitusjoner.</p>",
-  "x_results_are_ready_for_reporting_and_they_give_y_points": "<p><bold>{{num_publications_approved_by_all}} resultat</bold> er klar for rapportering, og de gir <bold>{{points_for_all_publications_approved_by_all}} publiseringspoeng.</bold><link></p>",
-  "x_results_are_ready_for_reporting_and_they_give_y_publication_points": "<b>{{num_results}} resultat</b> er klar for rapportering, og de gir <b>{{total_publicationpoints}} publiseringspoeng.</b>",
+  "x_results_are_ready_for_reporting_and_they_give_y_publication_points": "<p><b>{{approvals}} resultat</b> er klar for rapportering, og de gir <b>{{publication_points}} publiseringspoeng.</b><link></p>",
   "you_cannot_upload_files_to_this_result": "Du har ikke tilgang til å laste opp filer for dette resultatet.",
   "you_do_not_have_permission_to_edit_this_registration": "Du har ikke tilgang til å endre denne registreringen."
 }

--- a/src/translations/nnTranslations.json
+++ b/src/translations/nnTranslations.json
@@ -2098,7 +2098,6 @@
   "visibility_of_units": "",
   "vocabulary_missing": "Institusjonen har ikkje lagt til vokabular",
   "what_you_find_in_nva_description": "<heading>Kva finn du i NVA?</heading><p>Nasjonalt vitenarkiv (NVA) samlar og gjer tilgjengeleg informasjon om norsk forsking.</p><p>Her kan du utforske publikasjonar, forskingsprosjekt og forskarar på tvers av universitet, høgskular og forskingsinstitusjonar.</p>",
-  "x_results_are_ready_for_reporting_and_they_give_y_points": "",
   "x_results_are_ready_for_reporting_and_they_give_y_publication_points": "",
   "you_cannot_upload_files_to_this_result": "Du har ikkje tilgang til å laste opp filer for dette resultatet.",
   "you_do_not_have_permission_to_edit_this_registration": "Du har ikkje tilgang til å endre denne registreringa."


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-50945

Add link-button to download author shares for NVI Admin. Also added helper modal and updated some duplicate translation keys. Same as before: This wont't work on localhost, so it can't be tested properly until it is in the dev environment

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added NVI reporting data export functionality with flexible configuration for institutional and administrative use cases.
  * Introduced informational helper modal explaining which NVI candidates are included in exported reports.

* **Documentation**
  * Updated translation strings with clearer terminology for NVI reporting metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->