### PR TITLE
NP-50897 Display labels correctly

### DIFF
--- a/src/utils/translation-helpers.ts
+++ b/src/utils/translation-helpers.ts
@@ -77,5 +77,5 @@ export const getSourceRegistrationHeading = (t: TFunction) => {
  * Note: relies on translation key 'use_rerender' which should remain exactly '{{value}}' in all locales.
  */
 export const triggerLanguageRerender = (t: TFunction, label: string) => {
-  return t('use_rerender', { value: label });
+  return t('use_rerender', { value: label, interpolation: { escapeValue: false } });
 };


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-50897

Fix HTML-entity escaping of special characters (like `'`) in labels rendered via `triggerLanguageRerender` by disabling `i18next`'s interpolation escaping, since the output is already safely rendered by `React`

# How to test

Affected part of the application: Contributor Tab

1. Add an affiliation to a contributor which has a special character in its name
2. Check that it is rendered correctly in the component

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
