### PR TITLE
Moved fetching of numbers into the display component

### DIFF
--- a/src/components/nvi/top-texts/NviAdminReportingStatusTexts.tsx
+++ b/src/components/nvi/top-texts/NviAdminReportingStatusTexts.tsx
@@ -1,38 +1,33 @@
 import { Skeleton, Typography } from '@mui/material';
 import { Trans, useTranslation } from 'react-i18next';
 import { formatLocaleNumber } from '../../../utils/general-helpers';
+import { useNviCandidatesParams } from '../../../utils/hooks/useNviCandidatesParams';
 import { VerticalBox } from '../../styled/Wrappers';
+import { useNviPeriodReportNumbers } from '../hooks/useNviPeriodReportNumbers';
 
-interface NviAdminReportingStatusTextsProps {
-  previousYear?: number;
-  totalResults?: number;
-  percentage?: number;
-  isPending?: boolean;
-  isError?: boolean;
-}
-
-export const NviAdminReportingStatusTexts = ({
-  previousYear,
-  isPending = false,
-  isError = false,
-  totalResults,
-  percentage,
-}: NviAdminReportingStatusTextsProps) => {
+export const NviAdminReportingStatusTexts = () => {
   const { t } = useTranslation();
+  const { year } = useNviCandidatesParams();
+  const {
+    isPending,
+    isError,
+    numCandidatesForReporting,
+    percentageCandidatesComparedToPreviousYear: percentage,
+  } = useNviPeriodReportNumbers(year);
 
   return (
     <VerticalBox sx={{ mb: '1rem', gap: '0.5rem' }}>
       <Trans t={t} i18nKey="basic_data.nvi.reporting_status_description" components={{ p: <Typography /> }} />
       {isPending ? (
         <Skeleton sx={{ width: '50%' }} />
-      ) : isError || totalResults === undefined || previousYear === undefined ? null : (
+      ) : isError || numCandidatesForReporting === undefined ? null : (
         <Trans
           t={t}
           i18nKey="nvi_admin_reporting_status_numbers"
           values={{
-            num_results: formatLocaleNumber(totalResults),
+            num_results: formatLocaleNumber(numCandidatesForReporting),
             percentage: percentage !== undefined ? formatLocaleNumber(percentage) : '–',
-            previous_year: previousYear,
+            previous_year: year - 1,
           }}
           components={{
             p: <Typography />,

--- a/src/pages/basic-data/nvi/status/NviAdminReportingStatusPage.tsx
+++ b/src/pages/basic-data/nvi/status/NviAdminReportingStatusPage.tsx
@@ -1,7 +1,6 @@
 import { Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useInstitutionReportsFilteredAndSortedByUrl } from '../../../../components/nvi/hooks/useInstitutionReportsFilteredAndSortedByUrl';
-import { useNviPeriodReportNumbers } from '../../../../components/nvi/hooks/useNviPeriodReportNumbers';
 import { NviPageLayout } from '../../../../components/nvi/NviPageLayout';
 import { NviAdminTableSortSelector } from '../../../../components/nvi/table/NviAdminTableSortSelector';
 import { NviAdminReportingStatusRow } from '../../../../components/nvi/table/rows/NviAdminReportingStatusRow';
@@ -17,25 +16,11 @@ export const NviAdminReportingStatusPage = () => {
   const { t } = useTranslation();
   const { year } = useNviCandidatesParams();
   const { sortedAndFilteredData, isPending, isError } = useInstitutionReportsFilteredAndSortedByUrl(year);
-  const {
-    numCandidatesForReporting,
-    percentageCandidatesComparedToPreviousYear,
-    isPending: periodReportIsPending,
-    isError: periodReportIsError,
-  } = useNviPeriodReportNumbers(year);
 
   return (
     <NviPageLayout
       headline={t('basic_data.nvi.reporting_status')}
-      topView={
-        <NviAdminReportingStatusTexts
-          previousYear={year - 1}
-          isPending={periodReportIsPending}
-          isError={periodReportIsError}
-          totalResults={numCandidatesForReporting}
-          percentage={percentageCandidatesComparedToPreviousYear}
-        />
-      }
+      topView={<NviAdminReportingStatusTexts />}
       yearSelector
       sectorSelector
       institutionSearch>


### PR DESCRIPTION
# Description

Moved fetching of numbers into the display component, as discussed after similar change in admin publication point component. Since the Nvi curator pages are built differently and both the page-component and the text-component uses the data from the same hook, I am not making the change there.

Affected part of the application: http://localhost:3000/basic-data/nvi/status?year=2025

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal architecture for the NVI administrative reporting status display by optimising component data flow and reducing unnecessary property dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->