### PR TITLE
NP-51114 Show rejection reason and comments on rejected nvi candidate 

### DIFF
--- a/src/pages/messages/components/NviCandidateActions.tsx
+++ b/src/pages/messages/components/NviCandidateActions.tsx
@@ -316,7 +316,12 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
 
                 if (isFinalizedNote && canResetApproval && note.institutionId === user?.topOrgCristinId) {
                   deleteFunction = () => statusMutation.mutateAsync({ status: 'Pending' });
-                } else if (note.type === 'GeneralNote' && noteIdentifier && note.username === user?.nvaUsername) {
+                } else if (
+                  isOpenPeriod &&
+                  note.type === 'GeneralNote' &&
+                  noteIdentifier &&
+                  note.username === user?.nvaUsername
+                ) {
                   deleteFunction = () => deleteNoteMutation.mutateAsync(noteIdentifier);
                 }
 

--- a/src/pages/messages/components/NviCandidateActions.tsx
+++ b/src/pages/messages/components/NviCandidateActions.tsx
@@ -22,7 +22,7 @@ import { OpenInNewLink } from '../../../components/OpenInNewLink';
 import { setNotification } from '../../../redux/notificationSlice';
 import { RootState } from '../../../redux/store';
 import { PreviousPathLocationState } from '../../../types/locationState.types';
-import { FinalizedApproval, NviCandidate, RejectedApproval } from '../../../types/nvi.types';
+import { FinalizedApproval, NviCandidate, NviPeriodStatusEnum, RejectedApproval } from '../../../types/nvi.types';
 import { RegistrationTab } from '../../../types/registration.types';
 import { RoleName } from '../../../types/user.types';
 import { dataTestId } from '../../../utils/dataTestIds';
@@ -148,7 +148,7 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
     return dateA.getTime() - dateB.getTime();
   });
 
-  const isOpenPeriod = nviCandidate.period.status === 'OpenPeriod';
+  const isOpenPeriod = nviCandidate.period.status === NviPeriodStatusEnum.OpenPeriod;
 
   const canApproveCandidate = nviCandidate.allowedOperations.includes('approval/approve-candidate');
   const canRejectCandidate = nviCandidate.allowedOperations.includes('approval/reject-candidate');

--- a/src/pages/messages/components/NviCandidateActions.tsx
+++ b/src/pages/messages/components/NviCandidateActions.tsx
@@ -148,12 +148,12 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
     return dateA.getTime() - dateB.getTime();
   });
 
-  const isPeriodOpen = nviCandidate.period.status === 'OpenPeriod';
+  const isOpenPeriod = nviCandidate.period.status === 'OpenPeriod';
 
   const canApproveCandidate = nviCandidate.allowedOperations.includes('approval/approve-candidate');
   const canRejectCandidate = nviCandidate.allowedOperations.includes('approval/reject-candidate');
-  const canResetApproval = isPeriodOpen && nviCandidate.allowedOperations.includes('approval/reset-approval');
-  const canCreateNote = isPeriodOpen && nviCandidate.allowedOperations.includes('note/create-note');
+  const canResetApproval = isOpenPeriod && nviCandidate.allowedOperations.includes('approval/reset-approval');
+  const canCreateNote = isOpenPeriod && nviCandidate.allowedOperations.includes('note/create-note');
 
   return (
     <>
@@ -201,7 +201,7 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
 
       <Divider sx={{ gridArea: 'divider1' }} />
 
-      {isPeriodOpen && (
+      {isOpenPeriod && (
         <>
           <Box sx={{ gridArea: 'actions' }}>
             {myApproval && myApproval.status !== 'Approved' && (

--- a/src/pages/messages/components/NviCandidateActions.tsx
+++ b/src/pages/messages/components/NviCandidateActions.tsx
@@ -148,10 +148,12 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
     return dateA.getTime() - dateB.getTime();
   });
 
+  const isPeriodOpen = nviCandidate.period.status === 'OpenPeriod';
+
   const canApproveCandidate = nviCandidate.allowedOperations.includes('approval/approve-candidate');
   const canRejectCandidate = nviCandidate.allowedOperations.includes('approval/reject-candidate');
-  const canResetApproval = nviCandidate.allowedOperations.includes('approval/reset-approval');
-  const canCreateNote = nviCandidate.allowedOperations.includes('note/create-note');
+  const canResetApproval = isPeriodOpen && nviCandidate.allowedOperations.includes('approval/reset-approval');
+  const canCreateNote = isPeriodOpen && nviCandidate.allowedOperations.includes('note/create-note');
 
   return (
     <>
@@ -199,93 +201,101 @@ export const NviCandidateActions = ({ nviCandidate, nviCandidateQueryKey }: NviC
 
       <Divider sx={{ gridArea: 'divider1' }} />
 
-      <Box sx={{ gridArea: 'actions' }}>
-        {myApproval && myApproval.status !== 'Approved' && (
-          <>
-            {myApproval.status === 'Rejected' ? (
-              <Typography sx={{ mb: '1rem' }}>
-                {t('tasks.nvi.approve_rejected_nvi_candidate_description', {
-                  buttonText: t('tasks.nvi.approve_nvi_candidate'),
-                })}
-              </Typography>
-            ) : (
-              <Trans
-                t={t}
-                i18nKey="tasks.nvi.approve_nvi_candidate_description"
-                components={{
-                  p: <Typography sx={{ mb: '1rem' }} />,
-                  hyperlink: (
-                    <OpenInNewLink
-                      href="https://sikt.no/tjenester/nasjonalt-vitenarkiv-nva/hjelpeside-nva/NVI-rapporteringsinstruks"
-                      sx={{ fontStyle: 'italic' }}
-                    />
-                  ),
-                }}
-                values={{ buttonText: t('tasks.nvi.approve_nvi_candidate') }}
-              />
+      {isPeriodOpen && (
+        <>
+          <Box sx={{ gridArea: 'actions' }}>
+            {myApproval && myApproval.status !== 'Approved' && (
+              <>
+                {myApproval.status === 'Rejected' ? (
+                  <Typography sx={{ mb: '1rem' }}>
+                    {t('tasks.nvi.approve_rejected_nvi_candidate_description', {
+                      buttonText: t('tasks.nvi.approve_nvi_candidate'),
+                    })}
+                  </Typography>
+                ) : (
+                  <Trans
+                    t={t}
+                    i18nKey="tasks.nvi.approve_nvi_candidate_description"
+                    components={{
+                      p: <Typography sx={{ mb: '1rem' }} />,
+                      hyperlink: (
+                        <OpenInNewLink
+                          href="https://sikt.no/tjenester/nasjonalt-vitenarkiv-nva/hjelpeside-nva/NVI-rapporteringsinstruks"
+                          sx={{ fontStyle: 'italic' }}
+                        />
+                      ),
+                    }}
+                    values={{ buttonText: t('tasks.nvi.approve_nvi_candidate') }}
+                  />
+                )}
+
+                <Button
+                  data-testid={dataTestId.tasksPage.nvi.approveButton}
+                  color="secondary"
+                  variant="contained"
+                  fullWidth
+                  size="small"
+                  sx={{ mb: '1rem' }}
+                  loading={statusMutation.isPending && statusMutation.variables?.status === 'Approved'}
+                  disabled={!canApproveCandidate || isMutating}
+                  startIcon={<CheckIcon />}
+                  loadingPosition="end"
+                  onClick={() => statusMutation.mutate({ status: 'Approved' })}>
+                  {t('tasks.nvi.approve_nvi_candidate')}
+                </Button>
+              </>
             )}
 
-            <Button
-              data-testid={dataTestId.tasksPage.nvi.approveButton}
-              color="secondary"
-              variant="contained"
-              fullWidth
-              size="small"
-              sx={{ mb: '1rem' }}
-              loading={statusMutation.isPending && statusMutation.variables?.status === 'Approved'}
-              disabled={!canApproveCandidate || isMutating}
-              startIcon={<CheckIcon />}
-              loadingPosition="end"
-              onClick={() => statusMutation.mutate({ status: 'Approved' })}>
-              {t('tasks.nvi.approve_nvi_candidate')}
-            </Button>
-          </>
-        )}
+            {myApproval && myApproval.status !== 'Rejected' && (
+              <>
+                <Typography sx={{ mb: '1rem' }}>
+                  {t('tasks.nvi.reject_nvi_candidate_description', { buttonText: t('tasks.nvi.reject_nvi_candidate') })}
+                </Typography>
+                <Button
+                  data-testid={dataTestId.tasksPage.nvi.rejectButton}
+                  color="tertiary"
+                  variant="contained"
+                  fullWidth
+                  size="small"
+                  disabled={!canRejectCandidate || isMutating || hasSelectedRejectCandidate}
+                  startIcon={<ClearIcon />}
+                  onClick={() => setHasSelectedRejectCandidate(true)}>
+                  {t('tasks.nvi.reject_nvi_candidate')}
+                </Button>
 
-        {myApproval && myApproval.status !== 'Rejected' && (
-          <>
-            <Typography sx={{ mb: '1rem' }}>
-              {t('tasks.nvi.reject_nvi_candidate_description', { buttonText: t('tasks.nvi.reject_nvi_candidate') })}
-            </Typography>
-            <Button
-              data-testid={dataTestId.tasksPage.nvi.rejectButton}
-              color="tertiary"
-              variant="contained"
-              fullWidth
-              size="small"
-              disabled={!canRejectCandidate || isMutating || hasSelectedRejectCandidate}
-              startIcon={<ClearIcon />}
-              onClick={() => setHasSelectedRejectCandidate(true)}>
-              {t('tasks.nvi.reject_nvi_candidate')}
-            </Button>
+                <NviCandidateRejectionDialog
+                  open={hasSelectedRejectCandidate}
+                  onCancel={() => setHasSelectedRejectCandidate(false)}
+                  onAccept={async (reason) => {
+                    await statusMutation.mutateAsync({ status: 'Rejected', reason });
+                    setHasSelectedRejectCandidate(false);
+                  }}
+                  isLoading={statusMutation.isPending}
+                />
+              </>
+            )}
+          </Box>
 
-            <NviCandidateRejectionDialog
-              open={hasSelectedRejectCandidate}
-              onCancel={() => setHasSelectedRejectCandidate(false)}
-              onAccept={async (reason) => {
-                await statusMutation.mutateAsync({ status: 'Rejected', reason });
-                setHasSelectedRejectCandidate(false);
-              }}
-              isLoading={statusMutation.isPending}
-            />
-          </>
-        )}
-      </Box>
+          <Divider sx={{ gridArea: 'divider2' }} />
+        </>
+      )}
 
-      <Divider sx={{ gridArea: 'divider2' }} />
-
-      {canCreateNote && (
+      {(canCreateNote || sortedNotes.length > 0) && (
         <Box sx={{ gridArea: 'comment' }}>
           <Typography variant="h3" gutterBottom>
             {t('tasks.nvi.note')}
           </Typography>
-          <Typography sx={{ mb: '1rem' }}>{t('tasks.nvi.message_description')}</Typography>
-          <MessageForm
-            hideRequiredAsterisk
-            confirmAction={async (text) => await createNoteMutation.mutateAsync({ text })}
-            fieldLabel={t('tasks.nvi.note')}
-            buttonTitle={t('tasks.nvi.save_note')}
-          />
+          {canCreateNote && (
+            <>
+              <Typography sx={{ mb: '1rem' }}>{t('tasks.nvi.message_description')}</Typography>
+              <MessageForm
+                hideRequiredAsterisk
+                confirmAction={async (text) => await createNoteMutation.mutateAsync({ text })}
+                fieldLabel={t('tasks.nvi.note')}
+                buttonTitle={t('tasks.nvi.save_note')}
+              />
+            </>
+          )}
 
           {sortedNotes.length > 0 && (
             <Box

--- a/src/pages/messages/components/NviDialoguePanel.tsx
+++ b/src/pages/messages/components/NviDialoguePanel.tsx
@@ -26,10 +26,17 @@ export const NviDialoguePanel = ({
   const candidateStatus = nviCandidate.approvals.find(
     (approval) => approval.institutionId === user?.topOrgCristinId
   )?.status;
-  const periodStatus = nviCandidate?.period.status;
+  const periodStatus = nviCandidate.period.status;
 
   const isPendingCandidate = candidateStatus === 'New' || candidateStatus === 'Pending';
   const hasProblem = hasUnidentifiedContributorProblem(nviCandidate.problems);
+
+  const periodBannerKey =
+    periodStatus === 'ClosedPeriod'
+      ? 'tasks.nvi.reporting_period_closed'
+      : periodStatus === 'NoPeriod'
+        ? 'tasks.nvi.reporting_period_missing'
+        : null;
 
   return (
     <>
@@ -52,28 +59,29 @@ export const NviDialoguePanel = ({
         )}
       </Box>
       {!isUpdatingNviCandidateInfo ? (
-        <Box
-          sx={{
-            mx: '1rem',
-            display: 'grid',
-            gap: '1rem',
-            gridTemplateAreas: isPendingCandidate
-              ? hasProblem
-                ? "'curator' 'approvals' 'divider0' 'problem' 'divider1' 'actions' 'divider2' 'comment'"
-                : "'curator' 'approvals' 'divider1' 'actions' 'divider2' 'comment'"
-              : hasProblem
-                ? "'curator' 'approvals' 'divider0' 'problem' 'divider1' 'comment' 'divider2' 'actions'"
-                : "'curator' 'approvals' 'divider1' 'comment' 'divider2' 'actions'",
-          }}>
-          {periodStatus === 'OpenPeriod' ? (
+        <>
+          {periodBannerKey && (
+            <Typography sx={{ mx: '1rem', mb: '1rem', p: '1rem', bgcolor: 'nvi.main' }}>
+              {t(periodBannerKey)}
+            </Typography>
+          )}
+          <Box
+            sx={{
+              mx: '1rem',
+              display: 'grid',
+              gap: '1rem',
+              gridTemplateAreas: isPendingCandidate
+                ? hasProblem
+                  ? "'curator' 'approvals' 'divider0' 'problem' 'divider1' 'actions' 'divider2' 'comment'"
+                  : "'curator' 'approvals' 'divider1' 'actions' 'divider2' 'comment'"
+                : hasProblem
+                  ? "'curator' 'approvals' 'divider0' 'problem' 'divider1' 'comment' 'divider2' 'actions'"
+                  : "'curator' 'approvals' 'divider1' 'comment' 'divider2' 'actions'",
+            }}>
             <NviCandidateActions nviCandidate={nviCandidate} nviCandidateQueryKey={nviCandidateQueryKey} />
-          ) : periodStatus === 'ClosedPeriod' ? (
-            <Typography sx={{ p: '1rem', bgcolor: 'nvi.main' }}>{t('tasks.nvi.reporting_period_closed')}</Typography>
-          ) : periodStatus === 'NoPeriod' ? (
-            <Typography sx={{ p: '1rem', bgcolor: 'nvi.main' }}>{t('tasks.nvi.reporting_period_missing')}</Typography>
-          ) : null}
-          <NviApprovals approvals={nviCandidate?.approvals ?? []} />
-        </Box>
+            <NviApprovals approvals={nviCandidate?.approvals ?? []} />
+          </Box>
+        </>
       ) : (
         <NviDialoguePanelSkeleton />
       )}

--- a/src/pages/messages/components/NviDialoguePanel.tsx
+++ b/src/pages/messages/components/NviDialoguePanel.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { NviStatusChip } from '../../../components/StatusChip';
 import { RootState } from '../../../redux/store';
-import { NviCandidate } from '../../../types/nvi.types';
+import { NviCandidate, NviPeriodStatusEnum } from '../../../types/nvi.types';
 import { hasUnidentifiedContributorProblem } from '../../../utils/nviHelpers';
 import { NviApprovals } from './NviApprovals';
 import { NviCandidateActions } from './NviCandidateActions';
@@ -32,9 +32,9 @@ export const NviDialoguePanel = ({
   const hasProblem = hasUnidentifiedContributorProblem(nviCandidate.problems);
 
   const periodBannerKey =
-    periodStatus === 'ClosedPeriod'
+    periodStatus === NviPeriodStatusEnum.ClosedPeriod
       ? 'tasks.nvi.reporting_period_closed'
-      : periodStatus === 'NoPeriod'
+      : periodStatus === NviPeriodStatusEnum.NoPeriod
         ? 'tasks.nvi.reporting_period_missing'
         : null;
 

--- a/src/types/nvi.types.ts
+++ b/src/types/nvi.types.ts
@@ -22,6 +22,15 @@ export enum NviCandidateApprovalStatusEnum {
 
 export type NviCandidateApprovalStatus = `${NviCandidateApprovalStatusEnum}`;
 
+export enum NviPeriodStatusEnum {
+  OpenPeriod = 'OpenPeriod',
+  ClosedPeriod = 'ClosedPeriod',
+  NoPeriod = 'NoPeriod',
+  UnopenedPeriod = 'UnopenedPeriod',
+}
+
+export type NviPeriodStatus = `${NviPeriodStatusEnum}`;
+
 export interface NviCandidateSearchHitApproval {
   institutionId: string;
   labels: LanguageString;
@@ -136,7 +145,7 @@ export interface NviCandidate {
   approvals: (Approval | FinalizedApproval | RejectedApproval)[];
   notes: Note[];
   period: {
-    status: 'OpenPeriod' | 'ClosedPeriod' | 'NoPeriod' | 'UnopenedPeriod';
+    status: NviPeriodStatus;
     year?: string;
   };
   status?: 'Reported';

--- a/src/utils/testfiles/mockNviCandidate.ts
+++ b/src/utils/testfiles/mockNviCandidate.ts
@@ -1,4 +1,4 @@
-import { NviCandidate } from '../../types/nvi.types';
+import { NviCandidate, NviPeriodStatusEnum } from '../../types/nvi.types';
 
 export const mockNviCandidate: NviCandidate = {
   id: 'https://api.dev.nva.aws.unit.no/scientific-index/candidate/1',
@@ -6,7 +6,7 @@ export const mockNviCandidate: NviCandidate = {
   approvals: [],
   notes: [],
   period: {
-    status: 'OpenPeriod',
+    status: NviPeriodStatusEnum.OpenPeriod,
   },
   allowedOperations: ['approval/approve-candidate', 'approval/reject-candidate', 'approval/reset-approval'],
   problems: [],


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-51114

Previously, the reason for rejection and comments were not shown on a rejected NVI-candidate when the reporting period was closed. Added a check for status for period, and display relevant information accordingly.

# How to test

Affected part of the application: [Tasks NVI](http://localhost:3000/tasks/nvi?status=rejected&globalStatus=rejected%2Cpending)

1. Open the reporting period for 2025 in dev.
2. Find a rejected candidate, and add a comment to it
3. Close the period again
4. Make sure that any action that can be taken on the candidate has been disabled, but that the reason for rejection and the notes are still shown, The menu for deleting a message should also be disabled.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Period status now controls the availability of approval, rejection, note creation, and note deletion actions
  * Added a banner displaying the current period status to provide users with clear visibility of the system state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->