### PR TITLE
Add export button for NVI control data and update texts

### DIFF
--- a/src/components/nvi/top-texts/NviAdminPublicationPointsTexts.tsx
+++ b/src/components/nvi/top-texts/NviAdminPublicationPointsTexts.tsx
@@ -43,7 +43,9 @@ export const NviAdminPublicationPointsTexts = () => {
               }}
             />
             <HelperTextModal modalTitle={t('export_dataset_for_nvi_report')}>
-              <Trans i18nKey="export_dataset_for_nvi_report_description" components={{ p: <Typography /> }} />
+              <VerticalBox sx={{ gap: '1rem' }}>
+                <Trans i18nKey="export_dataset_for_nvi_report_description" components={{ p: <Typography /> }} />
+              </VerticalBox>
             </HelperTextModal>
           </HorizontalBox>
         )}

--- a/src/components/nvi/top-texts/NviAdminReportingStatusTexts.tsx
+++ b/src/components/nvi/top-texts/NviAdminReportingStatusTexts.tsx
@@ -1,8 +1,10 @@
 import { Skeleton, Typography } from '@mui/material';
 import { Trans, useTranslation } from 'react-i18next';
+import { ExportNviStatusLink } from '../../../pages/messages/components/ExportNviStatusLink';
+import { HelperTextModal } from '../../../pages/registration/HelperTextModal';
 import { formatLocaleNumber } from '../../../utils/general-helpers';
 import { useNviCandidatesParams } from '../../../utils/hooks/useNviCandidatesParams';
-import { VerticalBox } from '../../styled/Wrappers';
+import { HorizontalBox, VerticalBox } from '../../styled/Wrappers';
 import { useNviPeriodReportNumbers } from '../hooks/useNviPeriodReportNumbers';
 
 export const NviAdminReportingStatusTexts = () => {
@@ -35,6 +37,14 @@ export const NviAdminReportingStatusTexts = () => {
           }}
         />
       )}
+      <HorizontalBox sx={{ mt: '1rem', alignItems: 'center' }}>
+        <ExportNviStatusLink exportAllInstitutions text={t('export_data_for_nvi_control')} sx={{ pl: 0 }} />
+        <HelperTextModal modalTitle={t('export_data_for_nvi_control')}>
+          <VerticalBox sx={{ gap: '1rem' }}>
+            <Trans i18nKey="export_data_for_nvi_control_description" components={{ p: <Typography /> }} />
+          </VerticalBox>
+        </HelperTextModal>
+      </HorizontalBox>
     </VerticalBox>
   );
 };

--- a/src/pages/messages/components/ExportNviStatusLink.tsx
+++ b/src/pages/messages/components/ExportNviStatusLink.tsx
@@ -1,5 +1,5 @@
 import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined';
-import { CircularProgress, Link } from '@mui/material';
+import { CircularProgress, Link, SxProps, Theme } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useExportNviAuthorSharesMutation } from '../../../api/hooks/useExportNviAuthorSharesMutation';
@@ -12,9 +12,11 @@ import { useNviCandidatesParams } from '../../../utils/hooks/useNviCandidatesPar
 interface ExportNviStatusLinkProps {
   acronym?: string;
   exportAllInstitutions?: boolean;
+  text?: string;
+  sx?: SxProps<Theme>;
 }
 
-export const ExportNviStatusLink = ({ acronym, exportAllInstitutions }: ExportNviStatusLinkProps) => {
+export const ExportNviStatusLink = ({ acronym, exportAllInstitutions, text, sx = {} }: ExportNviStatusLinkProps) => {
   const { t } = useTranslation();
   const { year } = useNviCandidatesParams();
   const dispatch = useDispatch();
@@ -68,9 +70,11 @@ export const ExportNviStatusLink = ({ acronym, exportAllInstitutions }: ExportNv
         display: 'inline-flex',
         alignItems: 'center',
         cursor: isPending ? 'default' : 'pointer',
+        gap: '0.25rem',
+        ...sx,
       }}>
-      {isPending ? <CircularProgress size={15} /> : <FileDownloadOutlinedIcon fontSize="small" />}
-      {t('export_dataset_for_nvi_report')}
+      {isPending ? <CircularProgress size={15} sx={{ mr: '0.3rem' }} /> : <FileDownloadOutlinedIcon fontSize="small" />}
+      {text ? text : t('export_dataset_for_nvi_report')}
     </Link>
   );
 };

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -542,8 +542,8 @@
       "disabled_description": "$t(editor.vocabulary_status.Disabled): Er ikke tilgjengelig"
     }
   },
-  "export_dataset_for_nvi_report": "Eksporter datagrunnlag for NVI-rapport",
-  "export_dataset_for_nvi_report_description": "<p>Filen inneholder NVI-kandidater som er godkjent eller fortsatt under kontroll. </p><p>Kandidater som er avvist av en eller flere institusjoner er ikke med i oversikten.</p>",
+  "export_dataset_for_nvi_report": "Eksporter rapporterte publiseringspoeng",
+  "export_dataset_for_nvi_report_description": "<p>Filen inneholder NVI-kandidater som er godkjent og vil bli, eller er, rapportert når perioden er lukket.</p><p>Filen vil ikke endres etter at perioden er lukket.</p><p>Om du kun vil ha statusfilen så ligger de tilgjengelig på \"Vis rapporteringsstatus\".</p>",
   "export_nvi_status_button_tooltip_text": "Knapp for nedlasting av forfatterandel er flyttet til side for publiseringspoeng. Denne knappen er midlertidig deaktivert — nedlasting av tall fra tabellen kommer snart.",
   "feedback": {
     "error": {
@@ -2089,5 +2089,7 @@
   "nvi_admin_publication_points_numbers": "<p><b>{{approvals}} resultat</b> er godkjent av alle, og de gir <b>{{publication_points}} publiseringspoeng.</b><link></p>",
   "you_cannot_upload_files_to_this_result": "Du har ikke tilgang til å laste opp filer for dette resultatet.",
   "you_do_not_have_permission_to_edit_this_registration": "Du har ikke tilgang til å endre denne registreringen.",
-  "nvi_admin_reporting_status_numbers": "<p><b>{{num_results}} resultat</b> er kandidater for rapportering. Det er <b>{{percentage}}%</b> av antall resultat rapportert i {{previous_year}}.</p>"
+  "nvi_admin_reporting_status_numbers": "<p><b>{{num_results}} resultat</b> er kandidater for rapportering. Det er <b>{{percentage}}%</b> av antall resultat rapportert i {{previous_year}}.</p>",
+  "export_data_for_nvi_control": "Eksporter datagrunnlag for NVI-kontroll",
+  "export_data_for_nvi_control_description": "<p>Denne filen viser forfatterandeler som krever endring for å bli rapportert. Det vanligste manglende for å kunne bli rapportert er at forfatter må identifiseres (knyttes til en forfatterprofil i NVA).</p><p>Filen inneholder alle NVI-kandidater, både de som er godkjent, avvist og de som er under kontroll. Om du kun vil ha godkjente / rapporterte så ligger de tilgjengelig på \"Vis status for publiseringspoeng\".</p>"
 }


### PR DESCRIPTION
# Description

Link to Jira issue: S[plitte opp filen for datagrunnlag for NVI-rapport](https://sikt.atlassian.net/browse/NP-51054)

Changed text in NVI Admin download-links for reporting status and publication points, and changed the text in the information modal.

# How to test

Affected part of the application: http://localhost:3000/basic-data/nvi/status?year=2025 and http://localhost:3000/basic-data/nvi/publication-points?year=2025&orderBy=institution&sort=asc

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
