### PR TITLE
NP-51031 Decrease BibTex export

### DIFF
--- a/src/utils/bibtex/useBibtexExport.ts
+++ b/src/utils/bibtex/useBibtexExport.ts
@@ -6,7 +6,7 @@ import { exportToBibTex } from './BibTexFactory';
 
 export const useBibtexExport = () => {
   const [searchParams] = useSearchParams();
-  const maxNumberOfCitations = 500;
+  const maxNumberOfCitations = 100;
 
   const registrationsQueryConfig: FetchResultsParams = {
     query: searchParams.get(ResultParam.Query),


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-51031](https://sikt.atlassian.net/browse/NP-51031)

Setter ned antall entries for BibTex-eksporten fordi monsterposter kan ødelegge eksporten. 

# How to test

Affected part of the application: [Søk](https://dev.nva.sikt.no/filter)

1. Gå til søk
2. Trykk dropdown for "Eksporter" oppe i høyre hjørnet
3. Trykk på "BibTex"
4. Se at nedlastet fil har 100 entries

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-51031]: https://sikt.atlassian.net/browse/NP-51031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ