### PR TITLE
NP-51144 Added validation check for announcement on OtherArtisticOutput

### DIFF
--- a/src/utils/validation/registration/referenceValidation.ts
+++ b/src/utils/validation/registration/referenceValidation.ts
@@ -415,11 +415,20 @@ const artisticDesignPublicationInstance = Yup.object<YupShape<ArtisticPublicatio
     ),
   }),
   description: Yup.string().nullable(),
-  venues: Yup.array().when('$publicationInstanceType', ([publicationInstanceType], schema) =>
-    publicationInstanceType === ArtisticType.ArtisticDesign || publicationInstanceType === ArtisticType.VisualArts
-      ? schema.min(1, resourceErrorMessage.exhibitionRequired).required(resourceErrorMessage.exhibitionRequired)
-      : schema.nullable()
-  ),
+  venues: Yup.array().when('$publicationInstanceType', ([publicationInstanceType], schema) => {
+    if (
+      publicationInstanceType === ArtisticType.ArtisticDesign ||
+      publicationInstanceType === ArtisticType.VisualArts
+    ) {
+      return schema.min(1, resourceErrorMessage.exhibitionRequired).required(resourceErrorMessage.exhibitionRequired);
+    } else if (publicationInstanceType === ArtisticType.OtherArtisticOutput) {
+      return schema
+        .min(1, resourceErrorMessage.announcementsRequired)
+        .required(resourceErrorMessage.announcementsRequired);
+    } else {
+      return schema.nullable();
+    }
+  }),
   architectureOutput: Yup.array().when('$publicationInstanceType', ([publicationInstanceType], schema) =>
     publicationInstanceType === ArtisticType.ArtisticArchitecture
       ? schema.min(1, resourceErrorMessage.announcementsRequired).required(resourceErrorMessage.announcementsRequired)


### PR DESCRIPTION
# Description

Link to Jira issue: https://sikt.atlassian.net/browse/NP-51143

Registrations with category OtherArtisticOutput ("Annet kunstnerisk resultat") could be published with zero announcements, even though the form exposes an "Announcements" section. Added a min(1) check on the venues field for this category in referenceValidation.ts, matching the existing behavior for ArtisticDesign and VisualArts

# How to test

Affected part of the application: Wizard/Landing page

Create a new registration with category `OtherArtisticOutput` and make sure it can't be published without an announcement.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
