### PR TITLE
New StatusChip-component with reusable base statuses

### DIFF
--- a/src/components/_molecules/status-chip/BaseStatusChip.tsx
+++ b/src/components/_molecules/status-chip/BaseStatusChip.tsx
@@ -1,0 +1,27 @@
+import { Box } from '@mui/material';
+import { ReactNode } from 'react';
+
+interface StatusChipProps {
+  children: ReactNode;
+  bgcolor?: string;
+  paddingY?: string | number;
+}
+
+export const BaseStatusChip = ({ children, bgcolor = 'info.light', paddingY }: StatusChipProps) => {
+  return (
+    <Box
+      sx={{
+        width: 'fit-content',
+        height: 'fit-content',
+        display: 'flex',
+        gap: '0.2rem',
+        alignItems: 'center',
+        p: '0.25rem 0.75rem 0.25rem 0.5rem',
+        borderRadius: '1rem',
+        bgcolor,
+        paddingY,
+      }}>
+      {children}
+    </Box>
+  );
+};

--- a/src/components/_molecules/status-chip/BaseStatusChip.tsx
+++ b/src/components/_molecules/status-chip/BaseStatusChip.tsx
@@ -1,13 +1,12 @@
-import { Box } from '@mui/material';
+import { Box, SxProps, Theme } from '@mui/material';
 import { ReactNode } from 'react';
 
 interface StatusChipProps {
   children: ReactNode;
-  bgcolor?: string;
-  paddingY?: string | number;
+  sx?: SxProps<Theme>;
 }
 
-export const BaseStatusChip = ({ children, bgcolor = 'info.light', paddingY }: StatusChipProps) => {
+export const BaseStatusChip = ({ children, sx }: StatusChipProps) => {
   return (
     <Box
       sx={{
@@ -18,8 +17,8 @@ export const BaseStatusChip = ({ children, bgcolor = 'info.light', paddingY }: S
         alignItems: 'center',
         p: '0.25rem 0.75rem 0.25rem 0.5rem',
         borderRadius: '1rem',
-        bgcolor,
-        paddingY,
+        bgcolor: 'info.light',
+        ...sx,
       }}>
       {children}
     </Box>

--- a/src/components/_molecules/status-chip/StatusChip.tsx
+++ b/src/components/_molecules/status-chip/StatusChip.tsx
@@ -12,46 +12,46 @@ export enum StatusValue {
   Closed = 'CLOSED',
 }
 
-interface BaseStatusChipProps {
+interface StatusChipProps {
   status: StatusValue;
   text: string;
 }
 
 /* Generic component for showing statuses in NVA for an amount of base statuses. Enabling all chips with the same kind of status to use the same icon
 and background color even if the text varies. */
-export const StatusChip = ({ status, text }: BaseStatusChipProps) => {
+export const StatusChip = ({ status, text }: StatusChipProps) => {
   switch (status) {
     case StatusValue.Waiting:
       return (
-        <BaseStatusChip bgcolor={'neutral87.main'}>
+        <BaseStatusChip sx={{ bgcolor: 'neutral87.main' }}>
           <LockClockIcon aria-hidden="true" fontSize={'small'} />
           {text}
         </BaseStatusChip>
       );
     case StatusValue.InProgress:
       return (
-        <BaseStatusChip bgcolor={'info.light'}>
+        <BaseStatusChip>
           <HourglassEmptyIcon aria-hidden="true" fontSize={'small'} />
           {text}
         </BaseStatusChip>
       );
     case StatusValue.Completed:
       return (
-        <BaseStatusChip bgcolor={'neutral87.main'}>
+        <BaseStatusChip sx={{ bgcolor: 'neutral87.main' }}>
           <CheckIcon aria-hidden="true" fontSize={'small'} />
           {text}
         </BaseStatusChip>
       );
     case StatusValue.Success:
       return (
-        <BaseStatusChip bgcolor={'success.light'}>
+        <BaseStatusChip sx={{ bgcolor: 'success.light' }}>
           <CheckIcon aria-hidden="true" fontSize={'small'} />
           {text}
         </BaseStatusChip>
       );
     case StatusValue.Closed:
       return (
-        <BaseStatusChip bgcolor={'warning.light'}>
+        <BaseStatusChip sx={{ bgcolor: 'warning.light' }}>
           <BlockIcon aria-hidden="true" fontSize={'small'} />
           {text}
         </BaseStatusChip>

--- a/src/components/_molecules/status-chip/StatusChip.tsx
+++ b/src/components/_molecules/status-chip/StatusChip.tsx
@@ -17,8 +17,7 @@ interface StatusChipProps {
   text: string;
 }
 
-/* Generic component for showing statuses in NVA for an amount of base statuses. Enabling all chips with the same kind of status to use the same icon
-and background color even if the text varies. */
+/* Generic component for showing statuses in NVA for an amount of base statuses even if the text varies. */
 export const StatusChip = ({ status, text }: StatusChipProps) => {
   switch (status) {
     case StatusValue.Waiting:

--- a/src/components/_molecules/status-chip/StatusChip.tsx
+++ b/src/components/_molecules/status-chip/StatusChip.tsx
@@ -5,7 +5,7 @@ import LockClockIcon from '@mui/icons-material/LockClock';
 import { BaseStatusChip } from './BaseStatusChip';
 
 export enum StatusValue {
-  Waiting = 'WAITING',
+  Pending = 'PENDING',
   InProgress = 'IN_PROGRESS',
   Completed = 'COMPLETED',
   Success = 'SUCCESS',
@@ -20,7 +20,7 @@ interface StatusChipProps {
 /* Generic component for showing statuses in NVA for an amount of base statuses even if the text varies. */
 export const StatusChip = ({ status, text }: StatusChipProps) => {
   switch (status) {
-    case StatusValue.Waiting:
+    case StatusValue.Pending:
       return (
         <BaseStatusChip sx={{ bgcolor: 'neutral87.main' }}>
           <LockClockIcon aria-hidden="true" fontSize={'small'} />

--- a/src/components/_molecules/status-chip/StatusChip.tsx
+++ b/src/components/_molecules/status-chip/StatusChip.tsx
@@ -1,0 +1,62 @@
+import BlockIcon from '@mui/icons-material/Block';
+import CheckIcon from '@mui/icons-material/Check';
+import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
+import LockClockIcon from '@mui/icons-material/LockClock';
+import { BaseStatusChip } from './BaseStatusChip';
+
+export enum StatusValue {
+  Waiting = 'WAITING',
+  InProgress = 'IN_PROGRESS',
+  Completed = 'COMPLETED',
+  Success = 'SUCCESS',
+  Closed = 'CLOSED',
+}
+
+interface BaseStatusChipProps {
+  status: StatusValue;
+  text: string;
+}
+
+/* Generic component for showing statuses in NVA for an amount of base statuses. Enabling all chips with the same kind of status to use the same icon
+and background color even if the text varies. */
+export const StatusChip = ({ status, text }: BaseStatusChipProps) => {
+  switch (status) {
+    case StatusValue.Waiting:
+      return (
+        <BaseStatusChip bgcolor={'neutral87.main'}>
+          <LockClockIcon aria-hidden="true" fontSize={'small'} />
+          {text}
+        </BaseStatusChip>
+      );
+    case StatusValue.InProgress:
+      return (
+        <BaseStatusChip bgcolor={'info.light'}>
+          <HourglassEmptyIcon aria-hidden="true" fontSize={'small'} />
+          {text}
+        </BaseStatusChip>
+      );
+    case StatusValue.Completed:
+      return (
+        <BaseStatusChip bgcolor={'neutral87.main'}>
+          <CheckIcon aria-hidden="true" fontSize={'small'} />
+          {text}
+        </BaseStatusChip>
+      );
+    case StatusValue.Success:
+      return (
+        <BaseStatusChip bgcolor={'success.light'}>
+          <CheckIcon aria-hidden="true" fontSize={'small'} />
+          {text}
+        </BaseStatusChip>
+      );
+    case StatusValue.Closed:
+      return (
+        <BaseStatusChip bgcolor={'warning.light'}>
+          <BlockIcon aria-hidden="true" fontSize={'small'} />
+          {text}
+        </BaseStatusChip>
+      );
+    default:
+      return null;
+  }
+};


### PR DESCRIPTION
# Description

This is a solution to two problems that became evident when I needed to use the existing StatusChip with a new icon. 

1) The existing StatusChip accepts a string representing the icon as a prop, meaning that if I need to use a new icon I have to modify StatusChip to accept a prop for the new icon. This violates the Open / Closed Principe and can cause an unnecessary messy component over time, since every icon that might be used only one places has to be a prop and a new if/else in the component.

2) The component takes props for icon, text, color and padding, meaning that even though we use the same component, they might look very different across the app, losing some of the point of using the same component.

-> To solve the first problem I propose modifying the StatusChip component to accept icon as `children` instead so that new icons can be used without having to modify the component each time. (New name: BaseStatusChip)

-> To solve the second problem I propose adding a new component (new StatusChip) that hard codes a number of base styles, so that the choice of color and icon for similar states is consolidated across the app. Because the use case can be very different across the app, I am leaving the text as a prop still, even though the styling is the same. I.e. in some cases something might be "ongoing" but in other cases it might be "pending" - but they both use a light blue chip with an hourglass.

StatusChip will use BaseStatusChip to ensure the same styling.

BaseStatusChip now adheres to the Open / Closed Principe. StatusChip does not, but BaseStatusChip can be used in the edge cases not covered in StatusChip, ensuring that it will rarely or never need to be modified.

# How to test

Not used in app yet, but can be tested by inserting into any page and verifying that the result looks as expected.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a status chip component with visual indicators for different statuses: Waiting, InProgress, Completed, Success, and Closed
  * Each status displays a unique icon and colour for improved visual distinction

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BIBSYSDEV/NVA-Frontend/pull/8492)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->