### PR TITLE
NP-51250 Rename nvi year facet

### DIFF
--- a/src/pages/search/registration_search/filters/RegistrationFacetsFilter.tsx
+++ b/src/pages/search/registration_search/filters/RegistrationFacetsFilter.tsx
@@ -320,7 +320,7 @@ export const RegistrationFacetsFilter = ({ registrationQuery }: Pick<SearchPropT
 
       {(registrationQuery.isPending || scientificIndexFacet.length > 0) && (
         <FacetItem
-          title={t('basic_data.nvi.nvi_publication_year')}
+          title={t('basic_data.nvi.nvi_reporting_year')}
           dataTestId={dataTestId.aggregations.scientificIndexFacet}
           isPending={registrationQuery.isPending}>
           {scientificIndexFacet

--- a/src/pages/search/selected_facets/SelectedResultFacetsList.tsx
+++ b/src/pages/search/selected_facets/SelectedResultFacetsList.tsx
@@ -83,7 +83,7 @@ const getParamContent = (t: TFunction, param: string) => {
     case ResultParam.FundingSource:
       return t('common.financier');
     case ResultParam.ScientificReportPeriodSinceParam:
-      return t('basic_data.nvi.nvi_publication_year');
+      return t('basic_data.nvi.nvi_reporting_year');
     case ResultParam.Series:
       return t('registration.resource_type.series');
     case ResultParam.TopLevelOrganization:

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -127,7 +127,6 @@
     },
     "nvi": {
       "add_reporting_period": "Legg til rapporteringsperiode",
-      "nvi_publication_year": "NVI publiseringsår",
       "nvi_reporting_year": "NVI-rapporteringsår",
       "period_year": "Publiseringsår",
       "publication_points_status": "Status for publiseringspoeng",


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-51250](https://sikt.atlassian.net/browse/NP-51250)

Omdøper "NVI publiseringsår" til "NVI-rapporteringsår" i fasetten på forsiden.

NB: Av en eller annen grunn så får vi ikke data til denne fasetten i dev fra backend, så dataen for fasetten må manipuleres om den skal testes (fasetten vises ikke dersom det ikke er data).

# How to test

Affected part of the application: http://localhost:3000/filter

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


[NP-51250]: https://sikt.atlassian.net/browse/NP-51250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ