### PR TITLE
NP-51249: Added "Percentage controlled" to the NVI admin reporting periods

### DIFF
--- a/src/pages/basic-data/_components/NviAdminNavigationAccordion.tsx
+++ b/src/pages/basic-data/_components/NviAdminNavigationAccordion.tsx
@@ -8,12 +8,13 @@ import { NavigationListAccordion } from '../../../components/NavigationListAccor
 import { NviReportProgressBar } from '../../../components/NviReportProgressBar';
 import { LinkCreateButton, NavigationList } from '../../../components/PageWithSideMenu';
 import { SelectableButton } from '../../../components/SelectableButton';
-import { NviAdminOrderBy } from '../nvi/_utils/nvi-admin-sort-helpers';
 import { StyledNviStatusBox } from '../../../components/styled/Wrappers';
 import { RootState } from '../../../redux/store';
 import { dataTestId } from '../../../utils/dataTestIds';
 import { getDefaultNviYear } from '../../../utils/hooks/useNviCandidatesParams';
 import { UrlPathTemplate } from '../../../utils/urlPaths';
+import { getPercentageControlledReportingPeriod } from '../nvi/_utils/nvi-admin-aggregations-helpers';
+import { NviAdminOrderBy } from '../nvi/_utils/nvi-admin-sort-helpers';
 
 export const NviAdminNavigationAccordion = () => {
   const { t } = useTranslation();
@@ -38,11 +39,7 @@ export const NviAdminNavigationAccordion = () => {
         <StyledNviStatusBox>
           {reportQuery.isError || !periodTotals ? undefined : (
             <NviReportProgressBar
-              completedPercentage={
-                periodTotals.undisputedTotalCount > 0
-                  ? Math.floor((periodTotals.undisputedProcessedCount / periodTotals.undisputedTotalCount) * 100)
-                  : 0
-              }
+              completedPercentage={getPercentageControlledReportingPeriod(periodTotals)}
               completedCount={periodTotals.undisputedProcessedCount}
               totalCount={periodTotals.undisputedTotalCount}
               isPending={reportQuery.isPending}

--- a/src/pages/basic-data/nvi/_utils/nvi-admin-aggregations-helpers.test.ts
+++ b/src/pages/basic-data/nvi/_utils/nvi-admin-aggregations-helpers.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'vitest';
+import { NviPeriodTotals } from '../../../../types/nvi.types';
+import { getPercentageControlledReportingPeriod } from './nvi-admin-aggregations-helpers';
+
+const makeTotals = (undisputedProcessedCount: number, undisputedTotalCount: number): NviPeriodTotals => ({
+  type: 'PeriodTotals',
+  validPoints: 0,
+  disputedCount: 0,
+  undisputedProcessedCount,
+  undisputedTotalCount,
+});
+
+describe('getPercentageControlledReportingPeriods()', () => {
+  test('Returns 0 when totals is undefined', () => {
+    expect(getPercentageControlledReportingPeriod(undefined)).toBe(0);
+  });
+
+  test('Returns 0 when undisputedTotalCount is 0', () => {
+    expect(getPercentageControlledReportingPeriod(makeTotals(0, 0))).toBe(0);
+  });
+
+  test('Returns correct integer percentage', () => {
+    expect(getPercentageControlledReportingPeriod(makeTotals(75, 100))).toBe(75);
+  });
+
+  test('Floors the result — does not round up', () => {
+    expect(getPercentageControlledReportingPeriod(makeTotals(1, 3))).toBe(33);
+  });
+
+  test('Returns 100 when all candidates are processed', () => {
+    expect(getPercentageControlledReportingPeriod(makeTotals(100, 100))).toBe(100);
+  });
+});

--- a/src/pages/basic-data/nvi/_utils/nvi-admin-aggregations-helpers.test.ts
+++ b/src/pages/basic-data/nvi/_utils/nvi-admin-aggregations-helpers.test.ts
@@ -10,7 +10,7 @@ const makeTotals = (undisputedProcessedCount: number, undisputedTotalCount: numb
   undisputedTotalCount,
 });
 
-describe('getPercentageControlledReportingPeriods()', () => {
+describe('getPercentageControlledReportingPeriod()', () => {
   test('Returns 0 when totals is undefined', () => {
     expect(getPercentageControlledReportingPeriod(undefined)).toBe(0);
   });

--- a/src/pages/basic-data/nvi/_utils/nvi-admin-aggregations-helpers.ts
+++ b/src/pages/basic-data/nvi/_utils/nvi-admin-aggregations-helpers.ts
@@ -1,6 +1,6 @@
 import { TFunction } from 'i18next';
 import i18n from '../../../../translations/i18n';
-import { InstitutionReport } from '../../../../types/nvi.types';
+import { InstitutionReport, NviPeriodTotals } from '../../../../types/nvi.types';
 import { getLanguageString } from '../../../../utils/translation-helpers';
 
 export const getNviInstitutionName = (report: InstitutionReport) => getLanguageString(report.institution.labels).trim();
@@ -41,4 +41,10 @@ export const getPercentageControlledPublicationPoints = (report: InstitutionRepo
   const rejected = getNviRejectedCount(report);
   const allExceptRejected = all - rejected;
   return allExceptRejected > 0 ? approvedByEverybody / allExceptRejected : 0;
+};
+
+export const getPercentageControlledReportingPeriod = (totals?: NviPeriodTotals) => {
+  return totals && totals.undisputedTotalCount > 0
+    ? Math.floor((totals.undisputedProcessedCount / totals.undisputedTotalCount) * 100)
+    : 0;
 };

--- a/src/pages/basic-data/nvi/reporting-periods/NviPeriodsPage.tsx
+++ b/src/pages/basic-data/nvi/reporting-periods/NviPeriodsPage.tsx
@@ -8,6 +8,7 @@ import { ListSkeleton } from '../../../../components/ListSkeleton';
 import { MainContentLayout } from '../../../../components/page-layouts/MainContentLayout';
 import { NviPeriod, NviPeriodReport } from '../../../../types/nvi.types';
 import { UpsertNviPeriodDialog } from '../../../basic_data/app_admin/UpsertNviPeriodDialog';
+import { CenteredPercentageControlledCell } from '../_styles/nvi-admin-table-styles';
 import { NviAdminReportingPeriodsRow } from './_components/NviAdminReportingPeriodsRow';
 import { useFilteredNviPeriods } from './_hooks/useFilteredNviPeriods';
 
@@ -15,7 +16,7 @@ export const NviPeriodsPage = () => {
   const { t } = useTranslation();
   const [nviPeriodToEdit, setNviPeriodToEdit] = useState<NviPeriod | null>(null);
 
-  const { data, isPending, refetch } = useFetchAllNviPeriodReports();
+  const { data, isPending, isError, refetch } = useFetchAllNviPeriodReports();
   const sortedPeriods = [...(data?.periods ?? [])].sort(
     (a: NviPeriodReport, b: NviPeriodReport) => +b.period.publishingYear - +a.period.publishingYear
   );
@@ -29,6 +30,8 @@ export const NviPeriodsPage = () => {
       <NviStatusMultiSelect />
       {isPending ? (
         <ListSkeleton height={100} minWidth={100} />
+      ) : isError ? (
+        <Typography>{t('feedback.error.get_nvi_periods')}</Typography>
       ) : filteredPeriods.length === 0 ? (
         <Typography>{t('common.no_hits')}</Typography>
       ) : (
@@ -38,6 +41,7 @@ export const NviPeriodsPage = () => {
               <TableCell>{t('nvi_year')}</TableCell>
               <TableCell>{t('common.start_date')}</TableCell>
               <TableCell>{t('common.end_date')}</TableCell>
+              <CenteredPercentageControlledCell>{t('percentage_controlled')}</CenteredPercentageControlledCell>
               <TableCell>{t('status_for_period')}</TableCell>
             </TableRow>
           </TableHead>

--- a/src/pages/basic-data/nvi/reporting-periods/_components/NviAdminReportingPeriodsRow.tsx
+++ b/src/pages/basic-data/nvi/reporting-periods/_components/NviAdminReportingPeriodsRow.tsx
@@ -1,9 +1,12 @@
 import { TableCell, TableRow } from '@mui/material';
 import { DateAndTimeDisplay } from '../../../../../components/_molecules/DateAndTimeDisplay';
+import { PercentageWithIcon } from '../../../../../components/_molecules/PercentageWithIcon';
 import { HorizontalBox } from '../../../../../components/styled/Wrappers';
 import { NviPeriod, NviPeriodReport } from '../../../../../types/nvi.types';
 import { dataTestId } from '../../../../../utils/dataTestIds';
 import { EditIconButton } from '../../../../messages/components/EditIconButton';
+import { CenteredPercentageControlledCell } from '../../_styles/nvi-admin-table-styles';
+import { getPercentageControlledReportingPeriod } from '../../_utils/nvi-admin-aggregations-helpers';
 import { NviPeriodStatusChip } from './NviPeriodStatusChip';
 
 interface NviAdminReportingPeriodsRowProps {
@@ -15,7 +18,7 @@ export const NviAdminReportingPeriodsRow = ({
   nviPeriodReport,
   setNviPeriodToEdit,
 }: NviAdminReportingPeriodsRowProps) => {
-  const { period } = nviPeriodReport;
+  const { period, totals } = nviPeriodReport;
 
   return (
     <TableRow sx={{ height: '4rem' }}>
@@ -32,6 +35,14 @@ export const NviAdminReportingPeriodsRow = ({
           />
         </HorizontalBox>
       </TableCell>
+      <CenteredPercentageControlledCell>
+        <HorizontalBox sx={{ justifyContent: 'center' }}>
+          <PercentageWithIcon
+            displayPercentage={getPercentageControlledReportingPeriod(totals)}
+            alternativeIfZero={'-'}
+          />
+        </HorizontalBox>
+      </CenteredPercentageControlledCell>
       <TableCell>
         <NviPeriodStatusChip period={period} />
       </TableCell>


### PR DESCRIPTION
# Description

Link to Jira issue: [Legg til "Andel kontrollert" i tabellen](https://sikt.atlassian.net/browse/NP-51249)

Dette er tredje del av en omfattende endring av rapporteringsperioder-siden. I del 3 legger jeg til en ny kolonne for "andel kontrollert" i tabellen.

# How to test

Affected part of the application: http://localhost:3000/basic-data/nvi

Verifiser spesielt formelen for prosenten - jeg brukte samme formel som i sidepanelet.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added controlled reporting period percentage metrics to the NVI admin interface, displaying the percentage of reports processed
  * New column in reporting periods table showing percentage controlled for each period

* **Tests**
  * Added comprehensive test coverage for percentage calculation logic

* **Bug Fixes**
  * Improved error handling when retrieving reporting periods data

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BIBSYSDEV/NVA-Frontend/pull/8497)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->