### PR TITLE
Refactor: Tasks page: Moved user dialog-code to its own components

### DIFF
--- a/src/pages/tasks/TasksPage.tsx
+++ b/src/pages/tasks/TasksPage.tsx
@@ -1,24 +1,17 @@
 import AssignmentIcon from '@mui/icons-material/AssignmentOutlined';
-import { Badge } from '@mui/material';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import { Navigate, Outlet, Route, Routes, useLocation, useNavigate } from 'react-router';
+import { Navigate, Outlet, Route, Routes, useLocation } from 'react-router';
 import { useFetchTickets } from '../../api/hooks/useFetchTickets';
-import { useFetchUserQuery } from '../../api/hooks/useFetchUserQuery';
-import { NviCandidateGlobalStatusEnum, NviCandidateStatusEnum, TicketSearchParam } from '../../api/searchApi';
+import { NviCandidateGlobalStatusEnum, NviCandidateStatusEnum } from '../../api/searchApi';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
-import { NavigationListAccordion } from '../../components/NavigationListAccordion';
 import { SideNavHeader, StyledPageWithSideMenu } from '../../components/PageWithSideMenu';
-import { MinimizedMenuIconButton, SideMenu } from '../../components/SideMenu';
-import { StyledTicketSearchFormGroup } from '../../components/styled/Wrappers';
+import { SideMenu } from '../../components/SideMenu';
 import { TicketListDefaultValuesWrapper } from '../../components/TicketListDefaultValuesWrapper';
-import { TicketTypeFilterButton } from '../../components/TicketTypeFilterButton';
 import { RootState } from '../../redux/store';
-import { TicketTypeEnum, TicketTypeSelection } from '../../types/publication_types/ticket.types';
-import { dataTestId } from '../../utils/dataTestIds';
+import { TicketTypeSelection } from '../../types/publication_types/ticket.types';
 import { PrivateRoute } from '../../utils/routes/Routes';
-import { resetPaginationAndNavigate } from '../../utils/searchHelpers';
 import { getNviCandidatesSearchPath, getSubUrl, UrlPathTemplate } from '../../utils/urlPaths';
 import { checkUserRoles } from '../../utils/user-helpers';
 import { PortfolioSearchPage } from '../editor/PortfolioSearchPage';
@@ -28,11 +21,11 @@ import { NviCorrectionListNavigationAccordion } from '../messages/components/Nvi
 import { NviDisputePage } from '../messages/components/NviDisputePage';
 import { ResultRegistrationsNavigationListAccordion } from '../messages/components/ResultRegistrationsNavigationListAccordion';
 import { TicketList } from '../messages/components/TicketList';
-import { TicketTypeTag } from '../messages/components/TicketTypeTag';
 import { checkPages } from '../messages/tasks-helpers';
-import { useGetNotificationCounts, useGetTicketsCounts } from '../messages/user-dialog-helpers';
 import { RegistrationLandingPage } from '../public_registration/RegistrationLandingPage';
 import { NviCandidatesNavigationAccordion } from './_components/NviCandidatesNavigationAccordion';
+import { TasksPageMinimizedIconButton } from './_components/TasksPageMinimizedIconButton';
+import { UserDialogueNavigationAccordion } from './_components/UserDialogueNavigationAccordion';
 import { NviCandidatePage } from './nvi/nvi-candidate-page/NviCandidatePage';
 import { NviCandidatesListPage } from './nvi/NviCandidatesListPage';
 import { NviPublicationPointsPage } from './nvi/publication-points/NviPublicationPointsPage';
@@ -41,152 +34,42 @@ import { NviReportingStatusPage } from './nvi/status/NviReportingStatusPage';
 const TasksPage = () => {
   const { t } = useTranslation();
   const location = useLocation();
-  const locationState = location.state;
-  const navigate = useNavigate();
-
   const user = useSelector((store: RootState) => store.user);
   const { isNviCurator, isPublishingCurator, isThesisCurator, isDoiCurator, isSupportCurator } = checkUserRoles(user);
   const isTicketCurator = isSupportCurator || isDoiCurator || isPublishingCurator || isThesisCurator;
   const isAnyCurator = isTicketCurator || isNviCurator;
 
   const { isOnTicketsPage, isOnTicketPage, isOnNviCandidatePage } = checkPages(location.pathname);
-
-  const institutionUserQuery = useFetchUserQuery(user?.nvaUsername ?? '');
+  const isOnADetailsPage = isOnTicketPage || isOnNviCandidatePage;
 
   const searchParams = new URLSearchParams(location.search);
 
-  const [ticketTypes, setTicketTypes] = useState<TicketTypeSelection>({
-    doiRequest: isDoiCurator,
-    generalSupportCase: isSupportCurator,
-    publishingRequest: isPublishingCurator,
-    filesApprovalThesis: isThesisCurator,
+  const [ticketTypeToggles, setTicketTypeToggles] = useState<TicketTypeSelection>({
+    doiRequest: true,
+    generalSupportCase: true,
+    publishingRequest: true,
+    filesApprovalThesis: true,
   });
 
-  const selectedTicketTypes = Object.entries(ticketTypes)
+  const selectedTicketTypes = Object.entries(ticketTypeToggles)
     .filter(([, selected]) => selected)
     .map(([key]) => key);
 
   const ticketsQuery = useFetchTickets({
-    enabled: isOnTicketsPage && !institutionUserQuery.isPending,
+    enabled: isOnTicketsPage,
     searchParams,
     selectedTicketTypes,
   });
 
-  const {
-    doiNotificationsCount,
-    publishingNotificationsCount,
-    thesisPublishingNotificationsCount,
-    supportNotificationsCount,
-  } = useGetNotificationCounts({
-    notificationsQueryEnabled: isOnTicketsPage && !institutionUserQuery.isPending,
-    user,
-  });
-
-  const { doiRequestCount, publishingRequestCount, thesisPublishingRequestCount, generalSupportCaseCount } =
-    useGetTicketsCounts({ ticketsAggregations: ticketsQuery.data?.aggregations });
-
   return (
     <StyledPageWithSideMenu>
-      <SideMenu
-        expanded={!isOnTicketPage && !isOnNviCandidatePage}
-        minimizedMenu={
-          <MinimizedMenuIconButton
-            title={t('common.tasks')}
-            to={{
-              pathname: isOnTicketPage
-                ? UrlPathTemplate.TasksDialogue
-                : locationState?.isOnDisputePage
-                  ? UrlPathTemplate.TasksNviDisputes
-                  : UrlPathTemplate.TasksNvi,
-              search: locationState?.previousSearch,
-            }}>
-            <AssignmentIcon />
-          </MinimizedMenuIconButton>
-        }>
+      <SideMenu expanded={!isOnADetailsPage} minimizedMenu={<TasksPageMinimizedIconButton />}>
         <SideNavHeader icon={AssignmentIcon} text={t('common.tasks')} />
         {isTicketCurator && (
-          <NavigationListAccordion
-            title={t('tasks.user_dialog')}
-            startIcon={<AssignmentIcon />}
-            accordionPath={UrlPathTemplate.TasksDialogue}
-            onClick={() => {
-              if (!isOnTicketsPage) {
-                searchParams.delete(TicketSearchParam.From);
-              }
-            }}
-            dataTestId={dataTestId.tasksPage.userDialogAccordion}>
-            <StyledTicketSearchFormGroup sx={{ gap: '0.5rem', mt: 0 }}>
-              {isPublishingCurator && (
-                <TicketTypeFilterButton
-                  data-testid={dataTestId.tasksPage.typeSearch.publishingButton}
-                  endIcon={<Badge badgeContent={publishingNotificationsCount} />}
-                  isSelected={!!ticketTypes.publishingRequest}
-                  onClick={() => {
-                    setTicketTypes({ ...ticketTypes, publishingRequest: !ticketTypes.publishingRequest });
-                    resetPaginationAndNavigate(searchParams, navigate);
-                  }}>
-                  <TicketTypeTag
-                    count={ticketTypes.publishingRequest && publishingRequestCount ? publishingRequestCount : undefined}
-                    type={TicketTypeEnum.PublishingRequest}
-                  />
-                </TicketTypeFilterButton>
-              )}
-
-              {isThesisCurator && (
-                <TicketTypeFilterButton
-                  data-testid={dataTestId.tasksPage.typeSearch.thesisPublishingRequestsButton}
-                  endIcon={<Badge badgeContent={thesisPublishingNotificationsCount} />}
-                  isSelected={!!ticketTypes.filesApprovalThesis}
-                  onClick={() => {
-                    setTicketTypes({ ...ticketTypes, filesApprovalThesis: !ticketTypes.filesApprovalThesis });
-                    resetPaginationAndNavigate(searchParams, navigate);
-                  }}>
-                  <TicketTypeTag
-                    count={
-                      ticketTypes.filesApprovalThesis && thesisPublishingRequestCount
-                        ? thesisPublishingRequestCount
-                        : undefined
-                    }
-                    type={TicketTypeEnum.FilesApprovalThesis}
-                  />
-                </TicketTypeFilterButton>
-              )}
-
-              {isDoiCurator && (
-                <TicketTypeFilterButton
-                  data-testid={dataTestId.tasksPage.typeSearch.doiButton}
-                  endIcon={<Badge badgeContent={doiNotificationsCount} />}
-                  isSelected={!!ticketTypes.doiRequest}
-                  onClick={() => {
-                    setTicketTypes({ ...ticketTypes, doiRequest: !ticketTypes.doiRequest });
-                    resetPaginationAndNavigate(searchParams, navigate);
-                  }}>
-                  <TicketTypeTag
-                    count={ticketTypes.doiRequest && doiRequestCount ? doiRequestCount : undefined}
-                    type={TicketTypeEnum.DoiRequest}
-                  />
-                </TicketTypeFilterButton>
-              )}
-
-              {isSupportCurator && (
-                <TicketTypeFilterButton
-                  data-testid={dataTestId.tasksPage.typeSearch.supportButton}
-                  endIcon={<Badge badgeContent={supportNotificationsCount} />}
-                  isSelected={!!ticketTypes.generalSupportCase}
-                  onClick={() => {
-                    setTicketTypes({ ...ticketTypes, generalSupportCase: !ticketTypes.generalSupportCase });
-                    resetPaginationAndNavigate(searchParams, navigate);
-                  }}>
-                  <TicketTypeTag
-                    count={
-                      ticketTypes.generalSupportCase && generalSupportCaseCount ? generalSupportCaseCount : undefined
-                    }
-                    type={TicketTypeEnum.GeneralSupportCase}
-                  />
-                </TicketTypeFilterButton>
-              )}
-            </StyledTicketSearchFormGroup>
-          </NavigationListAccordion>
+          <UserDialogueNavigationAccordion
+            ticketTypeToggles={ticketTypeToggles}
+            setTicketTypeToggles={setTicketTypeToggles}
+          />
         )}
         {isAnyCurator && <ResultRegistrationsNavigationListAccordion />}
         {isNviCurator && (

--- a/src/pages/tasks/TasksPage.tsx
+++ b/src/pages/tasks/TasksPage.tsx
@@ -45,10 +45,10 @@ const TasksPage = () => {
   const searchParams = new URLSearchParams(location.search);
 
   const [ticketTypeToggles, setTicketTypeToggles] = useState<TicketTypeSelection>({
-    doiRequest: true,
-    generalSupportCase: true,
-    publishingRequest: true,
-    filesApprovalThesis: true,
+    doiRequest: isDoiCurator,
+    generalSupportCase: isSupportCurator,
+    publishingRequest: isPublishingCurator,
+    filesApprovalThesis: isThesisCurator,
   });
 
   const selectedTicketTypes = Object.entries(ticketTypeToggles)
@@ -69,6 +69,7 @@ const TasksPage = () => {
           <UserDialogueNavigationAccordion
             ticketTypeToggles={ticketTypeToggles}
             setTicketTypeToggles={setTicketTypeToggles}
+            ticketsAggregations={ticketsQuery.data?.aggregations}
           />
         )}
         {isAnyCurator && <ResultRegistrationsNavigationListAccordion />}

--- a/src/pages/tasks/_components/TasksPageMinimizedIconButton.tsx
+++ b/src/pages/tasks/_components/TasksPageMinimizedIconButton.tsx
@@ -1,0 +1,25 @@
+import AssignmentIcon from '@mui/icons-material/AssignmentOutlined';
+import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router';
+import { MinimizedMenuIconButton } from '../../../components/SideMenu';
+import { checkPages } from '../../messages/tasks-helpers';
+import { selectTasksBackPath } from '../_utils/select-tasks-back-path';
+
+export const TasksPageMinimizedIconButton = () => {
+  const { t } = useTranslation();
+  const location = useLocation();
+  const locationState = location.state;
+  const { isOnTicketPage } = checkPages(location.pathname);
+
+  return (
+    <MinimizedMenuIconButton
+      title={t('common.tasks')}
+      to={selectTasksBackPath({
+        isOnTicketPage,
+        isOnDisputePage: locationState?.isOnDisputePage,
+        previousSearch: locationState?.previousSearch,
+      })}>
+      <AssignmentIcon />
+    </MinimizedMenuIconButton>
+  );
+};

--- a/src/pages/tasks/_components/TasksPageMinimizedIconButton.tsx
+++ b/src/pages/tasks/_components/TasksPageMinimizedIconButton.tsx
@@ -2,6 +2,7 @@ import AssignmentIcon from '@mui/icons-material/AssignmentOutlined';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
 import { MinimizedMenuIconButton } from '../../../components/SideMenu';
+import { dataTestId } from '../../../utils/dataTestIds';
 import { checkPages } from '../../messages/tasks-helpers';
 import { selectTasksBackPath } from '../_utils/select-tasks-back-path';
 
@@ -13,6 +14,7 @@ export const TasksPageMinimizedIconButton = () => {
 
   return (
     <MinimizedMenuIconButton
+      data-testid={dataTestId.tasksPage.minimizedMenuButton}
       title={t('common.tasks')}
       to={selectTasksBackPath({
         isOnTicketPage,

--- a/src/pages/tasks/_components/UserDialogueNavigationAccordion.tsx
+++ b/src/pages/tasks/_components/UserDialogueNavigationAccordion.tsx
@@ -1,0 +1,61 @@
+import AssignmentIcon from '@mui/icons-material/AssignmentOutlined';
+import { Badge } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { useLocation, useNavigate } from 'react-router';
+import { TicketSearchParam } from '../../../api/searchApi';
+import { NavigationListAccordion } from '../../../components/NavigationListAccordion';
+import { StyledTicketSearchFormGroup } from '../../../components/styled/Wrappers';
+import { TicketTypeFilterButton } from '../../../components/TicketTypeFilterButton';
+import { CustomerTicketAggregations, TicketTypeSelection } from '../../../types/publication_types/ticket.types';
+import { dataTestId } from '../../../utils/dataTestIds';
+import { resetPaginationAndNavigate } from '../../../utils/searchHelpers';
+import { UrlPathTemplate } from '../../../utils/urlPaths';
+import { TicketTypeTag } from '../../messages/components/TicketTypeTag';
+import { checkPages } from '../../messages/tasks-helpers';
+import { useTicketTypeButtonConfigs } from '../_hooks/useTicketTypeButtonConfigs';
+
+interface UserDialogueNavigationAccordionProps {
+  ticketTypeToggles: TicketTypeSelection;
+  setTicketTypeToggles: (ticketTypeToggles: TicketTypeSelection) => void;
+  ticketsAggregations?: CustomerTicketAggregations;
+}
+
+export const UserDialogueNavigationAccordion = ({
+  ticketTypeToggles,
+  setTicketTypeToggles,
+  ticketsAggregations,
+}: UserDialogueNavigationAccordionProps) => {
+  const { t } = useTranslation();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const searchParams = new URLSearchParams(location.search);
+  const { isOnTicketsPage } = checkPages(location.pathname);
+  const buttonConfigs = useTicketTypeButtonConfigs(ticketsAggregations);
+
+  const toggleTicketType = (key: keyof TicketTypeSelection) => {
+    setTicketTypeToggles({ ...ticketTypeToggles, [key]: !ticketTypeToggles[key] });
+    resetPaginationAndNavigate(searchParams, navigate);
+  };
+
+  return (
+    <NavigationListAccordion
+      title={t('tasks.user_dialog')}
+      startIcon={<AssignmentIcon />}
+      accordionPath={UrlPathTemplate.TasksDialogue}
+      onClick={() => !isOnTicketsPage && searchParams.delete(TicketSearchParam.From)}
+      dataTestId={dataTestId.tasksPage.userDialogAccordion}>
+      <StyledTicketSearchFormGroup sx={{ gap: '0.5rem', mt: 0 }}>
+        {buttonConfigs.map(({ ticketType, testId, badgeCount, ticketTypeKey, count }) => (
+          <TicketTypeFilterButton
+            key={ticketType}
+            data-testid={testId}
+            endIcon={<Badge badgeContent={badgeCount} />}
+            isSelected={!!ticketTypeToggles[ticketTypeKey]}
+            onClick={() => toggleTicketType(ticketTypeKey)}>
+            <TicketTypeTag count={ticketTypeToggles[ticketTypeKey] && count ? count : undefined} type={ticketType} />
+          </TicketTypeFilterButton>
+        ))}
+      </StyledTicketSearchFormGroup>
+    </NavigationListAccordion>
+  );
+};

--- a/src/pages/tasks/_hooks/useTicketTypeButtonConfigs.ts
+++ b/src/pages/tasks/_hooks/useTicketTypeButtonConfigs.ts
@@ -1,0 +1,68 @@
+import { useSelector } from 'react-redux';
+import { useLocation } from 'react-router';
+import { RootState } from '../../../redux/store';
+import {
+  CustomerTicketAggregations,
+  TicketTypeEnum,
+  TicketTypeSelection,
+} from '../../../types/publication_types/ticket.types';
+import { dataTestId } from '../../../utils/dataTestIds';
+import { checkUserRoles } from '../../../utils/user-helpers';
+import { checkPages } from '../../messages/tasks-helpers';
+import { useGetNotificationCounts, useGetTicketsCounts } from '../../messages/user-dialog-helpers';
+
+interface TicketTypeButtonConfig {
+  testId: string;
+  badgeCount: number | undefined;
+  ticketTypeKey: keyof TicketTypeSelection;
+  count: number | undefined;
+  ticketType: TicketTypeEnum;
+}
+
+export const useTicketTypeButtonConfigs = (
+  ticketsAggregations?: CustomerTicketAggregations
+): TicketTypeButtonConfig[] => {
+  const location = useLocation();
+  const user = useSelector((store: RootState) => store.user);
+  const { isPublishingCurator, isThesisCurator, isDoiCurator, isSupportCurator } = checkUserRoles(user);
+  const { isOnTicketsPage } = checkPages(location.pathname);
+  const {
+    doiNotificationsCount,
+    publishingNotificationsCount,
+    thesisPublishingNotificationsCount,
+    supportNotificationsCount,
+  } = useGetNotificationCounts({ notificationsQueryEnabled: isOnTicketsPage, user });
+  const { doiRequestCount, publishingRequestCount, thesisPublishingRequestCount, generalSupportCaseCount } =
+    useGetTicketsCounts({ ticketsAggregations });
+
+  return [
+    isPublishingCurator && {
+      testId: dataTestId.tasksPage.typeSearch.publishingButton,
+      badgeCount: publishingNotificationsCount,
+      ticketTypeKey: 'publishingRequest' as const,
+      count: publishingRequestCount,
+      ticketType: TicketTypeEnum.PublishingRequest,
+    },
+    isThesisCurator && {
+      testId: dataTestId.tasksPage.typeSearch.thesisPublishingRequestsButton,
+      badgeCount: thesisPublishingNotificationsCount,
+      ticketTypeKey: 'filesApprovalThesis' as const,
+      count: thesisPublishingRequestCount,
+      ticketType: TicketTypeEnum.FilesApprovalThesis,
+    },
+    isDoiCurator && {
+      testId: dataTestId.tasksPage.typeSearch.doiButton,
+      badgeCount: doiNotificationsCount,
+      ticketTypeKey: 'doiRequest' as const,
+      count: doiRequestCount,
+      ticketType: TicketTypeEnum.DoiRequest,
+    },
+    isSupportCurator && {
+      testId: dataTestId.tasksPage.typeSearch.supportButton,
+      badgeCount: supportNotificationsCount,
+      ticketTypeKey: 'generalSupportCase' as const,
+      count: generalSupportCaseCount,
+      ticketType: TicketTypeEnum.GeneralSupportCase,
+    },
+  ].filter(Boolean) as TicketTypeButtonConfig[];
+};

--- a/src/pages/tasks/_utils/select-tasks-back-path.ts
+++ b/src/pages/tasks/_utils/select-tasks-back-path.ts
@@ -1,16 +1,23 @@
 import { UrlPathTemplate } from '../../../utils/urlPaths';
 
-interface selectTasksBackButtonPathParams {
+interface SelectTasksBackPathParams {
   isOnTicketPage?: boolean;
   isOnDisputePage?: boolean;
   previousSearch?: string;
 }
 
+/**
+ * Returns the navigation target for the minimized side-menu back button.
+ * @param isOnTicketPage - Whether the user is currently on a ticket detail page.
+ * @param isOnDisputePage - Whether the user is currently on the NVI disputes page.
+ * @param previousSearch - The previous search query string to restore.
+ * @returns A navigation object with pathname and search.
+ */
 export const selectTasksBackPath = ({
   isOnTicketPage = false,
   isOnDisputePage = false,
   previousSearch,
-}: selectTasksBackButtonPathParams) => {
+}: SelectTasksBackPathParams) => {
   return {
     pathname: isOnTicketPage
       ? UrlPathTemplate.TasksDialogue

--- a/src/pages/tasks/_utils/select-tasks-back-path.ts
+++ b/src/pages/tasks/_utils/select-tasks-back-path.ts
@@ -1,0 +1,22 @@
+import { UrlPathTemplate } from '../../../utils/urlPaths';
+
+interface selectTasksBackButtonPathParams {
+  isOnTicketPage?: boolean;
+  isOnDisputePage?: boolean;
+  previousSearch?: string;
+}
+
+export const selectTasksBackPath = ({
+  isOnTicketPage = false,
+  isOnDisputePage = false,
+  previousSearch,
+}: selectTasksBackButtonPathParams) => {
+  return {
+    pathname: isOnTicketPage
+      ? UrlPathTemplate.TasksDialogue
+      : isOnDisputePage
+        ? UrlPathTemplate.TasksNviDisputes
+        : UrlPathTemplate.TasksNvi,
+    search: previousSearch,
+  };
+};

--- a/src/utils/dataTestIds.ts
+++ b/src/utils/dataTestIds.ts
@@ -844,6 +844,7 @@ export const dataTestId = {
     },
     unreadSearchSelect: 'unread-search-select',
     userDialogAccordion: 'user-dialog-accordion',
+    minimizedMenuButton: 'tasks-minimized-menu-button',
   },
   unpublishActions: {
     confirmUnpublishCheckbox: 'confirm-unpublish-checkbox',


### PR DESCRIPTION
# How to test

Affected part of the application: [http://localhost:3000/tasks/dialogue](http://localhost:3000/tasks/dialogue)

Just a basic refactoring without (much) change of logic, but a lot of code was moved to make smaller, more focused components.

One logic change:
* Removed a call to institutionUserQuery that was never used (only isPending was checked)

The code has been checked thoroughly by me especially but also by AI with instructions to lookout for changes in logic.

Reviewer should do that as well.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced ticket page navigation with streamlined back-button functionality across different task views.
  * Refined ticket-type filtering interface for improved user experience.
  * Optimised page state management to reduce unnecessary data fetches and improve performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BIBSYSDEV/NVA-Frontend/pull/8516?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->