### PR TITLE
NP-51268: Changed design of change date dialog

### DIFF
--- a/src/pages/basic_data/app_admin/UpsertNviPeriodDialog.tsx
+++ b/src/pages/basic_data/app_admin/UpsertNviPeriodDialog.tsx
@@ -66,7 +66,7 @@ export const UpsertNviPeriodDialog = ({
       open={location.pathname === UrlPathTemplate.BasicDataNviNew || !!nviPeriod}
       onClose={closeDialog}
       data-testid={dataTestId.basicData.nviPeriod.nviPeriodDialog}>
-      <DialogTitle>{nviPeriod ? t('edit_control_period') : t('add_control_period')}</DialogTitle>
+      <DialogTitle>{nviPeriod ? t('edit_reporting_period') : t('basic_data.nvi.add_reporting_period')}</DialogTitle>
       <Formik
         initialValues={nviPeriod ?? emptyNviPeriod}
         onSubmit={async (values) => {
@@ -77,7 +77,7 @@ export const UpsertNviPeriodDialog = ({
         {({ values, setFieldValue, isSubmitting }) => (
           <Form>
             <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-              <Trans t={t} i18nKey="edit_control_period_text" components={{ p: <Typography /> }} />
+              <Trans t={t} i18nKey="edit_reporting_period_text" components={{ p: <Typography /> }} />
               <VerticalBox sx={{ mt: '1rem', gap: '2rem' }}>
                 <Field name="publishingYear">
                   {({ field }: FieldProps<string>) => (

--- a/src/pages/basic_data/app_admin/UpsertNviPeriodDialog.tsx
+++ b/src/pages/basic_data/app_admin/UpsertNviPeriodDialog.tsx
@@ -77,7 +77,7 @@ export const UpsertNviPeriodDialog = ({
         {({ values, setFieldValue, isSubmitting }) => (
           <Form>
             <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-              <Trans t={t} i18nKey="edit_reporting_period_text" components={{ p: <Typography /> }} />
+              <Trans t={t} i18nKey="reporting_period_text" components={{ p: <Typography /> }} />
               <VerticalBox sx={{ mt: '1rem', gap: '2rem' }}>
                 <Field name="publishingYear">
                   {({ field }: FieldProps<string>) => (

--- a/src/pages/basic_data/app_admin/UpsertNviPeriodDialog.tsx
+++ b/src/pages/basic_data/app_admin/UpsertNviPeriodDialog.tsx
@@ -1,11 +1,12 @@
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material';
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Typography } from '@mui/material';
 import { DatePicker, DateTimePicker } from '@mui/x-date-pickers';
 import { useMutation } from '@tanstack/react-query';
 import { Field, FieldProps, Form, Formik } from 'formik';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router';
 import { createNviPeriod, updateNviPeriod } from '../../../api/scientificIndexApi';
+import { HorizontalBox, VerticalBox } from '../../../components/styled/Wrappers';
 import { setNotification } from '../../../redux/notificationSlice';
 import { NviPeriod } from '../../../types/nvi.types';
 import { dataTestId } from '../../../utils/dataTestIds';
@@ -65,9 +66,7 @@ export const UpsertNviPeriodDialog = ({
       open={location.pathname === UrlPathTemplate.BasicDataNviNew || !!nviPeriod}
       onClose={closeDialog}
       data-testid={dataTestId.basicData.nviPeriod.nviPeriodDialog}>
-      <DialogTitle>
-        {nviPeriod ? t('basic_data.nvi.update_reporting_period') : t('basic_data.nvi.add_reporting_period')}
-      </DialogTitle>
+      <DialogTitle>{nviPeriod ? t('edit_control_period') : t('add_control_period')}</DialogTitle>
       <Formik
         initialValues={nviPeriod ?? emptyNviPeriod}
         onSubmit={async (values) => {
@@ -77,85 +76,91 @@ export const UpsertNviPeriodDialog = ({
         }}>
         {({ values, setFieldValue, isSubmitting }) => (
           <Form>
-            <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-              <Field name="publishingYear">
-                {({ field }: FieldProps<string>) => (
-                  <DatePicker
-                    label={t('basic_data.nvi.period_year')}
-                    slotProps={{
-                      textField: {
-                        required: true,
-                        inputProps: { 'data-testid': dataTestId.basicData.nviPeriod.nviPeriodYear },
-                      },
-                    }}
-                    disabled={!!nviPeriod}
-                    views={['year']}
-                    value={field.value ? new Date(field.value) : null}
-                    onChange={(newDate) => {
-                      const year = newDate ? newDate.getFullYear().toString() : '';
-                      setFieldValue(field.name, year);
-                      if (year) {
-                        setFieldValue('startDate', new Date(+year, 3, 1).toISOString());
-                        setFieldValue('reportingDate', new Date(+year + 1, 3, 1).toISOString());
-                      }
-                    }}
-                    shouldDisableYear={(date) => {
-                      const thisYear = date.getFullYear();
-                      return nviPeriod?.publishingYear !== thisYear.toString() && yearsWithPeriod.includes(thisYear);
-                    }}
-                    minDate={nviPeriod ? undefined : minNewNviDate}
-                    maxDate={nviPeriod ? undefined : maxNewNviDate}
-                  />
-                )}
-              </Field>
+            <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+              <Trans t={t} i18nKey="edit_control_period_text" components={{ p: <Typography /> }} />
+              <VerticalBox sx={{ mt: '1rem', gap: '2rem' }}>
+                <Field name="publishingYear">
+                  {({ field }: FieldProps<string>) => (
+                    <DatePicker
+                      label={t('basic_data.nvi.period_year')}
+                      slotProps={{
+                        textField: {
+                          required: true,
+                          inputProps: { 'data-testid': dataTestId.basicData.nviPeriod.nviPeriodYear },
+                        },
+                      }}
+                      disabled={!!nviPeriod}
+                      views={['year']}
+                      value={field.value ? new Date(field.value) : null}
+                      onChange={(newDate) => {
+                        const year = newDate ? newDate.getFullYear().toString() : '';
+                        setFieldValue(field.name, year);
+                        if (year) {
+                          setFieldValue('startDate', new Date(+year, 3, 1).toISOString());
+                          setFieldValue('reportingDate', new Date(+year + 1, 3, 1).toISOString());
+                        }
+                      }}
+                      shouldDisableYear={(date) => {
+                        const thisYear = date.getFullYear();
+                        return nviPeriod?.publishingYear !== thisYear.toString() && yearsWithPeriod.includes(thisYear);
+                      }}
+                      minDate={nviPeriod ? undefined : minNewNviDate}
+                      maxDate={nviPeriod ? undefined : maxNewNviDate}
+                    />
+                  )}
+                </Field>
+                <HorizontalBox sx={{ gap: '1.5rem' }}>
+                  <Field name="startDate">
+                    {({ field }: FieldProps<string>) => (
+                      <DateTimePicker
+                        sx={{ flex: 1 }}
+                        label={t('common.start_date')}
+                        slotProps={{
+                          textField: {
+                            required: true,
+                            inputProps: { 'data-testid': dataTestId.basicData.nviPeriod.nviPeriodStartDate },
+                          },
+                        }}
+                        disabled={!values.publishingYear}
+                        value={field.value ? new Date(field.value) : null}
+                        minDate={values.publishingYear ? new Date(+values.publishingYear, 0, 1) : undefined}
+                        maxDate={values.publishingYear ? new Date(+values.publishingYear + 1, 0, 1) : undefined}
+                        onChange={(newDate, context) => {
+                          if (context.validationError !== 'invalidDate') {
+                            const dateString = newDate ? newDate.toISOString() : '';
+                            setFieldValue(field.name, dateString);
+                          }
+                        }}
+                      />
+                    )}
+                  </Field>
 
-              <Field name="startDate">
-                {({ field }: FieldProps<string>) => (
-                  <DateTimePicker
-                    label={t('common.start_date')}
-                    slotProps={{
-                      textField: {
-                        required: true,
-                        inputProps: { 'data-testid': dataTestId.basicData.nviPeriod.nviPeriodStartDate },
-                      },
-                    }}
-                    disabled={!values.publishingYear}
-                    value={field.value ? new Date(field.value) : null}
-                    minDate={values.publishingYear ? new Date(+values.publishingYear, 0, 1) : undefined}
-                    maxDate={values.publishingYear ? new Date(+values.publishingYear + 1, 0, 1) : undefined}
-                    onChange={(newDate, context) => {
-                      if (context.validationError !== 'invalidDate') {
-                        const dateString = newDate ? newDate.toISOString() : '';
-                        setFieldValue(field.name, dateString);
-                      }
-                    }}
-                  />
-                )}
-              </Field>
-
-              <Field name="reportingDate">
-                {({ field }: FieldProps<string>) => (
-                  <DateTimePicker
-                    label={t('common.end_date')}
-                    slotProps={{
-                      textField: {
-                        required: true,
-                        inputProps: { 'data-testid': dataTestId.basicData.nviPeriod.nviPeriodEndDate },
-                      },
-                    }}
-                    disabled={!values.publishingYear}
-                    value={field.value ? new Date(field.value) : null}
-                    minDate={values.publishingYear ? new Date(+values.publishingYear + 1, 0, 1) : undefined}
-                    maxDate={values.publishingYear ? new Date(+values.publishingYear + 1, 6, 31) : undefined}
-                    onChange={(newDate, context) => {
-                      if (context.validationError !== 'invalidDate') {
-                        const dateString = newDate ? newDate.toISOString() : '';
-                        setFieldValue(field.name, dateString);
-                      }
-                    }}
-                  />
-                )}
-              </Field>
+                  <Field name="reportingDate">
+                    {({ field }: FieldProps<string>) => (
+                      <DateTimePicker
+                        sx={{ flex: 1 }}
+                        label={t('common.end_date')}
+                        slotProps={{
+                          textField: {
+                            required: true,
+                            inputProps: { 'data-testid': dataTestId.basicData.nviPeriod.nviPeriodEndDate },
+                          },
+                        }}
+                        disabled={!values.publishingYear}
+                        value={field.value ? new Date(field.value) : null}
+                        minDate={values.publishingYear ? new Date(+values.publishingYear + 1, 0, 1) : undefined}
+                        maxDate={values.publishingYear ? new Date(+values.publishingYear + 1, 6, 31) : undefined}
+                        onChange={(newDate, context) => {
+                          if (context.validationError !== 'invalidDate') {
+                            const dateString = newDate ? newDate.toISOString() : '';
+                            setFieldValue(field.name, dateString);
+                          }
+                        }}
+                      />
+                    )}
+                  </Field>
+                </HorizontalBox>
+              </VerticalBox>
             </DialogContent>
             <DialogActions sx={{ gap: '0.5rem' }}>
               <Button onClick={closeDialog}>{t('common.cancel')}</Button>

--- a/src/translations/enTranslations.json
+++ b/src/translations/enTranslations.json
@@ -135,8 +135,7 @@
       "reporting_status": "",
       "reporting_status_description": "",
       "show_publication_points_status": "",
-      "show_reporting_status": "",
-      "update_reporting_period": "Update reporting period"
+      "show_reporting_status": ""
     },
     "person_register": {
       "current_employments": "Current employments",

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -2124,5 +2124,5 @@
   "status_for_period": "Status for periode",
   "export_limit_reached": "Bare de første {{limit}} resultatene ble eksportert. Avgrens søket for å eksportere de resterende resultatene.",
   "edit_reporting_period": "Rediger rapporteringsperiode",
-  "edit_reporting_period_text": "<p>Start- og sluttdato styrer når perioden åpnes og lukkes.</p><p>Når sluttdato er passert, lukkes perioden, og NVI-kuratorer kan ikke lenger kontrollere kandidater.</p><p>Endre sluttdato for å gjenåpne perioden. Når sluttdato er passert, kan perioden rapporteres.</p>"
+  "reporting_period_text": "<p>Start- og sluttdato styrer når perioden åpnes og lukkes.</p><p>Når sluttdato er passert, lukkes perioden, og NVI-kuratorer kan ikke lenger kontrollere kandidater.</p><p>Endre sluttdato for å gjenåpne perioden. Når sluttdato er passert, kan perioden rapporteres.</p>"
 }

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -2123,5 +2123,8 @@
   "nvi_period_status_closed": "Lukket",
   "nvi_period_status_reported": "Rapportert",
   "status_for_period": "Status for periode",
-  "export_limit_reached": "Bare de første {{limit}} resultatene ble eksportert. Avgrens søket for å eksportere de resterende resultatene."
+  "export_limit_reached": "Bare de første {{limit}} resultatene ble eksportert. Avgrens søket for å eksportere de resterende resultatene.",
+  "add_control_period": "Legg til kontrollperiode",
+  "edit_control_period": "Rediger kontrollperiode",
+  "edit_control_period_text": "<p>Start- og sluttdato styrer når perioden åpnes og lukkes.</p><p>Når sluttdato er passert, lukkes perioden, og NVI-kuratorer kan ikke lenger kontrollere kandudater.</p><p>Endre sluttdato for å gjenåpne perioden. Når sluttdato er passert, kan perioden rapporteres.</p>"
 }

--- a/src/translations/nbTranslations.json
+++ b/src/translations/nbTranslations.json
@@ -135,8 +135,7 @@
       "reporting_status": "Rapporteringsstatus",
       "reporting_status_description": "<p>Tabellen viser antall kandidater hos alle institusjoner og hvor mange som er ferdig kontrollert i forhold til antall kandidater.</p><p>Forfatteradresseringen styrer den eller de institusjon de telles for. Kandidater som har endt i en tvist er ikke inkludert i denne oversikten.</p>",
       "show_publication_points_status": "Vis status for publiseringspoeng",
-      "show_reporting_status": "Vis rapporteringsstatus",
-      "update_reporting_period": "Oppdater rapporteringsperiode"
+      "show_reporting_status": "Vis rapporteringsstatus"
     },
     "person_register": {
       "current_employments": "Nåværende ansettelser",
@@ -2124,7 +2123,6 @@
   "nvi_period_status_reported": "Rapportert",
   "status_for_period": "Status for periode",
   "export_limit_reached": "Bare de første {{limit}} resultatene ble eksportert. Avgrens søket for å eksportere de resterende resultatene.",
-  "add_control_period": "Legg til kontrollperiode",
-  "edit_control_period": "Rediger kontrollperiode",
-  "edit_control_period_text": "<p>Start- og sluttdato styrer når perioden åpnes og lukkes.</p><p>Når sluttdato er passert, lukkes perioden, og NVI-kuratorer kan ikke lenger kontrollere kandudater.</p><p>Endre sluttdato for å gjenåpne perioden. Når sluttdato er passert, kan perioden rapporteres.</p>"
+  "edit_reporting_period": "Rediger rapporteringsperiode",
+  "edit_reporting_period_text": "<p>Start- og sluttdato styrer når perioden åpnes og lukkes.</p><p>Når sluttdato er passert, lukkes perioden, og NVI-kuratorer kan ikke lenger kontrollere kandidater.</p><p>Endre sluttdato for å gjenåpne perioden. Når sluttdato er passert, kan perioden rapporteres.</p>"
 }

--- a/src/translations/nnTranslations.json
+++ b/src/translations/nnTranslations.json
@@ -135,8 +135,7 @@
       "reporting_status": "",
       "reporting_status_description": "",
       "show_publication_points_status": "",
-      "show_reporting_status": "",
-      "update_reporting_period": "Oppdater rapporteringsperiode"
+      "show_reporting_status": ""
     },
     "person_register": {
       "current_employments": "Noverande tilsetjingar",


### PR DESCRIPTION
# Description

Link to Jira issue: [https://sikt.atlassian.net/browse/NP-51268](Endre design på datoendringsboks)

# How to test

Affected part of the application: http://localhost:3000/basic-data/nvi -> edit-button on end date

Only design-change:

Before:

<img width="343" height="366" alt="image" src="https://github.com/user-attachments/assets/b305251c-a383-41df-88bb-8687a78e5204" />

After:

<img width="614" height="456" alt="image" src="https://github.com/user-attachments/assets/875b5c67-8efd-4064-943d-6240afc290fc" />



# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Redesigned the NVI reporting period editor dialog with improved layout and visual presentation.
  * Updated terminology for clearer user messaging.
  * Enhanced translations with additional explanatory text describing date field functionality and reporting period lifecycle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BIBSYSDEV/NVA-Frontend/pull/8548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->