### PR TITLE
NP-51315: Fixed bug where some registrations could not be viewed by users who weren't logged in

### DIFF
--- a/src/api/hooks/useFetchBookRegistration.tsx
+++ b/src/api/hooks/useFetchBookRegistration.tsx
@@ -1,7 +1,7 @@
-import { fetchProtectedResource } from '../commonApi';
-import { BookRegistration } from '../../types/publication_types/bookRegistration.types';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
+import { BookRegistration } from '../../types/publication_types/bookRegistration.types';
+import { fetchResource } from '../commonApi';
 
 export const useFetchBookRegistration = (containerId: string) => {
   const { t } = useTranslation();
@@ -9,7 +9,7 @@ export const useFetchBookRegistration = (containerId: string) => {
   return useQuery({
     queryKey: ['registration', containerId],
     enabled: !!containerId,
-    queryFn: () => fetchProtectedResource<BookRegistration>(containerId),
+    queryFn: () => fetchResource<BookRegistration>(containerId),
     meta: { errorMessage: t('feedback.error.get_registration') },
   });
 };


### PR DESCRIPTION
# Description

Link to Jira issue: [Resultater i NVA (med åpen fil) er kun tilgjengelig ved pålogging (#536804)](https://sikt.atlassian.net/browse/NP-51315)

# How to test

Affected part of the application: http://localhost:3000/filter?category=AcademicChapter

Registrations that is a "Vitenskapelig kapittel" cannot be accessed when logged out. Verify that they can after this fix.

# Checklist

Ensure that the changes are aligned with the expectations of PO/designer before marking the PR as ready for review.

Also ensure that the following criterias are met:

- [x] The changes are working as expected
- [x] The changes are tested OK for different screen sizes
- [x] The changes are tested OK for a11y
- [x] Interactive elements have data-testids
- [x] I have done a QA of my own changes

_Note: some of these criterias may not always be relevant, and can simply be marked as completed._
