### PR TITLE
NP-51328 Reduce page size for bibtex export

### DIFF
--- a/src/utils/bibtex/useBibtexExport.ts
+++ b/src/utils/bibtex/useBibtexExport.ts
@@ -9,7 +9,7 @@ import { setNotification } from '../../redux/notificationSlice';
 import { formatDateStringToISO } from '../date-helpers';
 import { triggerFileDownload } from '../downloadFileHelpers';
 
-const pageSize = 200;
+const pageSize = 100;
 const hardCap = 10_000;
 
 const nextLinkRegex = /<([^>]+)>;\s*rel="next"/;


### PR DESCRIPTION
# Description

Link to Jira issue: [NP-51328](https://sikt.atlassian.net/browse/NP-51328)

Reducing page size for bibtex export to reduce the risk of certain results causing too large response bodies.

# How to test

Affected part of the application: 
- /filter
- /research-profile/{identifier}


[NP-51328]: https://sikt.atlassian.net/browse/NP-51328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ